### PR TITLE
Implement basic auth and cart features

### DIFF
--- a/contexts/AppContext.js
+++ b/contexts/AppContext.js
@@ -1,0 +1,49 @@
+import { createContext, useState, useEffect } from 'react';
+
+export const AppContext = createContext();
+
+export function AppProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [cart, setCart] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('app-state');
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      setUser(parsed.user || null);
+      setCart(parsed.cart || []);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('app-state', JSON.stringify({ user, cart }));
+  }, [user, cart]);
+
+  const login = async (email, password) => {
+    const res = await fetch('/api/login', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email, password }) });
+    if (!res.ok) throw new Error('Login failed');
+    setUser({ email });
+  };
+
+  const signup = async (email, password) => {
+    const res = await fetch('/api/signup', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email, password }) });
+    if (!res.ok) throw new Error('Signup failed');
+    setUser({ email });
+  };
+
+  const addToCart = (product) => {
+    setCart(prev => {
+      const existing = prev.find(p => p.ID === product.ID);
+      if (existing) {
+        return prev.map(p => p.ID === product.ID ? { ...p, qty: p.qty + 1 } : p);
+      }
+      return [...prev, { ...product, qty: 1 }];
+    });
+  };
+
+  return (
+    <AppContext.Provider value={{ user, cart, login, signup, addToCart }}>
+      {children}
+    </AppContext.Provider>
+  );
+}

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+
+const usersFile = path.join(process.cwd(), 'data', 'users.json');
+
+function loadUsers() {
+  if (!fs.existsSync(usersFile)) {
+    return [];
+  }
+  const raw = fs.readFileSync(usersFile, 'utf-8');
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    return [];
+  }
+}
+
+function saveUsers(users) {
+  fs.mkdirSync(path.dirname(usersFile), { recursive: true });
+  fs.writeFileSync(usersFile, JSON.stringify(users, null, 2));
+}
+
+export function addUser({ email, password }) {
+  const users = loadUsers();
+  if (users.find(u => u.email === email)) {
+    throw new Error('User exists');
+  }
+  users.push({ email, password });
+  saveUsers(users);
+}
+
+export function findUser(email) {
+  const users = loadUsers();
+  return users.find(u => u.email === email);
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import '../styles/globals.css';
+import { AppProvider } from '../contexts/AppContext';
 
 export default function App({ Component, pageProps }) {
   const [theme, setTheme] = useState('light');
@@ -18,5 +19,9 @@ export default function App({ Component, pageProps }) {
     }
   }, [theme]);
 
-  return <Component {...pageProps} theme={theme} setTheme={setTheme} />;
+  return (
+    <AppProvider>
+      <Component {...pageProps} theme={theme} setTheme={setTheme} />
+    </AppProvider>
+  );
 }

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,0 +1,16 @@
+import { findUser } from '../../lib/users';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: 'email and password required' });
+  }
+  const user = findUser(email);
+  if (!user || user.password !== password) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+  return res.status(200).json({ message: 'Login successful', email });
+}

--- a/pages/api/signup.js
+++ b/pages/api/signup.js
@@ -1,0 +1,20 @@
+import { addUser, findUser } from '../../lib/users';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: 'email and password required' });
+  }
+  try {
+    if (findUser(email)) {
+      return res.status(409).json({ message: 'User exists' });
+    }
+    addUser({ email, password });
+    return res.status(201).json({ message: 'User created' });
+  } catch (e) {
+    return res.status(500).json({ message: 'Error creating user' });
+  }
+}

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -1,0 +1,21 @@
+import { useContext } from 'react';
+import { AppContext } from '../contexts/AppContext';
+
+export default function Cart() {
+  const { cart } = useContext(AppContext);
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">Cart</h1>
+      {cart.length === 0 && <p>Your cart is empty.</p>}
+      <ul className="space-y-2">
+        {cart.map(item => (
+          <li key={item.ID} className="border p-2 flex justify-between">
+            <span>{item.TITLE}</span>
+            <span>Qty: {item.qty}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,34 @@
+import { useState, useContext } from 'react';
+import { AppContext } from '../contexts/AppContext';
+
+export default function Login() {
+  const { login } = useContext(AppContext);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = async e => {
+    e.preventDefault();
+    if (!email || !password) {
+      setError('Email and password required');
+      return;
+    }
+    try {
+      await login(email, password);
+    } catch (e) {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Login</h1>
+      {error && <div className="text-red-500 mb-2">{error}</div>}
+      <form onSubmit={submit} className="space-y-2">
+        <input className="input input-bordered w-full" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" className="input input-bordered w-full" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button className="btn btn-primary w-full" type="submit">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/products.js
+++ b/pages/products.js
@@ -1,0 +1,33 @@
+import { useState, useEffect, useContext } from 'react';
+import { AppContext } from '../contexts/AppContext';
+
+export default function Products() {
+  const { addToCart } = useContext(AppContext);
+  const [products, setProducts] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch('/api/search');
+      if (res.ok) {
+        const data = await res.json();
+        setProducts(data.results);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div className="p-4 max-w-6xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">Products</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {products.map(p => (
+          <div key={p.ID} className="border rounded p-4 flex flex-col">
+            <h2 className="font-semibold mb-2">{p.TITLE}</h2>
+            <p className="mb-2">{p.VENDOR}</p>
+            <button className="btn btn-sm btn-primary mt-auto" onClick={() => addToCart(p)}>Add to Cart</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,0 +1,34 @@
+import { useState, useContext } from 'react';
+import { AppContext } from '../contexts/AppContext';
+
+export default function Signup() {
+  const { signup } = useContext(AppContext);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = async e => {
+    e.preventDefault();
+    if (!email || !password) {
+      setError('Email and password required');
+      return;
+    }
+    try {
+      await signup(email, password);
+    } catch (e) {
+      setError('Signup failed');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
+      {error && <div className="text-red-500 mb-2">{error}</div>}
+      <form onSubmit={submit} className="space-y-2">
+        <input className="input input-bordered w-full" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" className="input input-bordered w-full" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button className="btn btn-primary w-full" type="submit">Sign Up</button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create AppContext for user and cart state
- add simple user store helper
- add login and signup API routes
- hook AppProvider into `_app.js`
- add login and signup pages
- add products listing page with add to cart
- add cart page

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_68419bf19968832fa02446f877af7993