### PR TITLE
Implement improved signup, login, and cart management

### DIFF
--- a/contexts/AppContext.js
+++ b/contexts/AppContext.js
@@ -20,15 +20,25 @@ export function AppProvider({ children }) {
   }, [user, cart]);
 
   const login = async (email, password) => {
-    const res = await fetch('/api/login', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email, password }) });
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
     if (!res.ok) throw new Error('Login failed');
-    setUser({ email });
+    const data = await res.json();
+    setUser(data.user);
   };
 
-  const signup = async (email, password) => {
-    const res = await fetch('/api/signup', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email, password }) });
+  const signup = async (payload) => {
+    const res = await fetch('/api/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
     if (!res.ok) throw new Error('Signup failed');
-    setUser({ email });
+    const data = await res.json();
+    setUser(data.user);
   };
 
   const addToCart = (product) => {
@@ -41,8 +51,22 @@ export function AppProvider({ children }) {
     });
   };
 
+  const changeQty = (id, delta) => {
+    setCart(prev => {
+      return prev
+        .map(item =>
+          item.ID === id ? { ...item, qty: item.qty + delta } : item
+        )
+        .filter(item => item.qty > 0);
+    });
+  };
+
+  const removeFromCart = (id) => {
+    setCart(prev => prev.filter(item => item.ID !== id));
+  };
+
   return (
-    <AppContext.Provider value={{ user, cart, login, signup, addToCart }}>
+    <AppContext.Provider value={{ user, cart, login, signup, addToCart, changeQty, removeFromCart }}>
       {children}
     </AppContext.Provider>
   );

--- a/lib/db.js
+++ b/lib/db.js
@@ -24,6 +24,14 @@ export function getDb() {
       max_price REAL,
       currency TEXT
     )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS users (
+      email TEXT PRIMARY KEY,
+      first_name TEXT,
+      last_name TEXT,
+      password TEXT,
+      brand_name TEXT,
+      gender TEXT
+    )`);
   }
   return db;
 }

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,35 +1,14 @@
-import fs from 'fs';
-import path from 'path';
+import { getDb } from './db.js';
 
-const usersFile = path.join(process.cwd(), 'data', 'users.json');
-
-function loadUsers() {
-  if (!fs.existsSync(usersFile)) {
-    return [];
-  }
-  const raw = fs.readFileSync(usersFile, 'utf-8');
-  try {
-    return JSON.parse(raw);
-  } catch (e) {
-    return [];
-  }
-}
-
-function saveUsers(users) {
-  fs.mkdirSync(path.dirname(usersFile), { recursive: true });
-  fs.writeFileSync(usersFile, JSON.stringify(users, null, 2));
-}
-
-export function addUser({ email, password }) {
-  const users = loadUsers();
-  if (users.find(u => u.email === email)) {
-    throw new Error('User exists');
-  }
-  users.push({ email, password });
-  saveUsers(users);
+export function addUser({ email, password, first_name, last_name, brand_name, gender }) {
+  const db = getDb();
+  const stmt = db.prepare(`INSERT INTO users (email, first_name, last_name, password, brand_name, gender)
+    VALUES (?, ?, ?, ?, ?, ?)`);
+  stmt.run(email, first_name, last_name, password, brand_name || null, gender);
 }
 
 export function findUser(email) {
-  const users = loadUsers();
-  return users.find(u => u.email === email);
+  const db = getDb();
+  const stmt = db.prepare('SELECT email, first_name, last_name, password, brand_name, gender FROM users WHERE email = ?');
+  return stmt.get(email);
 }

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -1,18 +1,21 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
+import { AppContext } from '../../contexts/AppContext';
 
 export default function Admin() {
+  const { user } = useContext(AppContext);
   const [form, setForm] = useState({ id: '', title: '', vendor: '', description: '', product_type: '', tags: '', quantity: 0, min_price: 0, max_price: 0, currency: 'USD' });
   const [products, setProducts] = useState([]);
   const [message, setMessage] = useState('');
 
   const fetchProducts = async () => {
-    const res = await fetch('/api/admin/products');
+    if (!user) return;
+    const res = await fetch(`/api/admin/products?vendor=${encodeURIComponent(user.brandName || '')}`);
     if (res.ok) {
       setProducts(await res.json());
     }
   };
 
-  useEffect(() => { fetchProducts(); }, []);
+  useEffect(() => { fetchProducts(); }, [user]);
 
   const handleChange = e => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -34,6 +37,10 @@ export default function Admin() {
       setMessage(data.message || 'Error');
     }
   };
+
+  if (!user) {
+    return <div className="p-4">Please log in to view your products.</div>;
+  }
 
   return (
     <div className="p-4 max-w-2xl mx-auto">

--- a/pages/api/admin/products.js
+++ b/pages/api/admin/products.js
@@ -24,7 +24,11 @@ export default async function handler(req, res) {
 
   if (req.method === 'GET') {
     const { products } = await loadAndIndexProducts();
-    return res.status(200).json(products);
+    let filtered = products;
+    if (req.query.vendor) {
+      filtered = products.filter(p => p.VENDOR === req.query.vendor);
+    }
+    return res.status(200).json(filtered);
   }
 
   return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -12,5 +12,15 @@ export default function handler(req, res) {
   if (!user || user.password !== password) {
     return res.status(401).json({ message: 'Invalid credentials' });
   }
-  return res.status(200).json({ message: 'Login successful', email });
+  const { first_name, last_name, brand_name, gender } = user;
+  return res.status(200).json({
+    message: 'Login successful',
+    user: {
+      email,
+      firstName: first_name,
+      lastName: last_name,
+      brandName: brand_name,
+      gender
+    }
+  });
 }

--- a/pages/api/signup.js
+++ b/pages/api/signup.js
@@ -4,16 +4,26 @@ export default function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
-  const { email, password } = req.body;
-  if (!email || !password) {
-    return res.status(400).json({ message: 'email and password required' });
+  const { email, password, firstName, lastName, brandName, gender } = req.body;
+  if (!email || !password || !firstName || !lastName || !gender) {
+    return res.status(400).json({ message: 'missing required fields' });
   }
   try {
     if (findUser(email)) {
       return res.status(409).json({ message: 'User exists' });
     }
-    addUser({ email, password });
-    return res.status(201).json({ message: 'User created' });
+    addUser({
+      email,
+      password,
+      first_name: firstName,
+      last_name: lastName,
+      brand_name: brandName,
+      gender
+    });
+    return res.status(201).json({
+      message: 'User created',
+      user: { email, firstName, lastName, brandName, gender }
+    });
   } catch (e) {
     return res.status(500).json({ message: 'Error creating user' });
   }

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import { AppContext } from '../contexts/AppContext';
 
 export default function Cart() {
-  const { cart } = useContext(AppContext);
+  const { cart, changeQty, removeFromCart } = useContext(AppContext);
 
   return (
     <div className="p-4 max-w-3xl mx-auto">
@@ -10,9 +10,14 @@ export default function Cart() {
       {cart.length === 0 && <p>Your cart is empty.</p>}
       <ul className="space-y-2">
         {cart.map(item => (
-          <li key={item.ID} className="border p-2 flex justify-between">
+          <li key={item.ID} className="border p-2 flex justify-between items-center">
             <span>{item.TITLE}</span>
-            <span>Qty: {item.qty}</span>
+            <div className="flex items-center space-x-2">
+              <button className="btn btn-xs" onClick={() => changeQty(item.ID, -1)}>-</button>
+              <span>{item.qty}</span>
+              <button className="btn btn-xs" onClick={() => changeQty(item.ID, 1)}>+</button>
+              <button className="btn btn-xs btn-error" onClick={() => removeFromCart(item.ID)}>Remove</button>
+            </div>
           </li>
         ))}
       </ul>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -3,18 +3,34 @@ import { AppContext } from '../contexts/AppContext';
 
 export default function Signup() {
   const { signup } = useContext(AppContext);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [brand, setBrand] = useState('');
+  const [gender, setGender] = useState('');
   const [error, setError] = useState('');
 
   const submit = async e => {
     e.preventDefault();
-    if (!email || !password) {
-      setError('Email and password required');
+    if (!firstName || !lastName || !email || !password || !confirm || !gender) {
+      setError('All fields except brand name are required');
+      return;
+    }
+    if (password !== confirm) {
+      setError('Passwords do not match');
       return;
     }
     try {
-      await signup(email, password);
+      await signup({
+        firstName,
+        lastName,
+        email,
+        password,
+        brandName: brand,
+        gender
+      });
     } catch (e) {
       setError('Signup failed');
     }
@@ -25,8 +41,18 @@ export default function Signup() {
       <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
       {error && <div className="text-red-500 mb-2">{error}</div>}
       <form onSubmit={submit} className="space-y-2">
+        <input className="input input-bordered w-full" value={firstName} onChange={e => setFirstName(e.target.value)} placeholder="First Name" />
+        <input className="input input-bordered w-full" value={lastName} onChange={e => setLastName(e.target.value)} placeholder="Last Name" />
         <input className="input input-bordered w-full" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
         <input type="password" className="input input-bordered w-full" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <input type="password" className="input input-bordered w-full" value={confirm} onChange={e => setConfirm(e.target.value)} placeholder="Confirm Password" />
+        <input className="input input-bordered w-full" value={brand} onChange={e => setBrand(e.target.value)} placeholder="Brand Name (optional)" />
+        <select className="select select-bordered w-full" value={gender} onChange={e => setGender(e.target.value)}>
+          <option value="">Select Gender</option>
+          <option value="male">Male</option>
+          <option value="female">Female</option>
+          <option value="other">Other</option>
+        </select>
         <button className="btn btn-primary w-full" type="submit">Sign Up</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- expand DB to include a `users` table
- store and retrieve users via SQLite
- extend signup API to capture user details
- adjust login API to return full user object
- show admin products only for current logged-in user
- enhance signup page with extra fields and validation
- update cart page with quantity controls and remove feature
- expose cart helpers via context

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841a67ce8c0832fa6bfe3973be0bc0a