### PR TITLE
Add header with login & signup links

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import { useContext } from 'react';
+import { AppContext } from '../contexts/AppContext';
+
+export default function Header() {
+  const { user } = useContext(AppContext);
+  return (
+    <header className="navbar bg-base-300 mb-6">
+      <div className="flex-1">
+        <Link href="/" className="btn btn-ghost normal-case text-xl">Home</Link>
+      </div>
+      <div className="flex-none">
+        {user ? (
+          <span className="px-4">Hello, {user.firstName || user.email}</span>
+        ) : (
+          <>
+            <Link href="/login" className="btn btn-ghost">Login</Link>
+            <Link href="/signup" className="btn btn-primary ml-2">Signup</Link>
+          </>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/contexts/AppContext.js
+++ b/contexts/AppContext.js
@@ -41,6 +41,10 @@ export function AppProvider({ children }) {
     setUser(data.user);
   };
 
+  const logout = () => {
+    setUser(null);
+  };
+
   const addToCart = (product) => {
     setCart(prev => {
       const existing = prev.find(p => p.ID === product.ID);
@@ -66,7 +70,7 @@ export function AppProvider({ children }) {
   };
 
   return (
-    <AppContext.Provider value={{ user, cart, login, signup, addToCart, changeQty, removeFromCart }}>
+    <AppContext.Provider value={{ user, cart, login, signup, logout, addToCart, changeQty, removeFromCart }}>
       {children}
     </AppContext.Provider>
   );

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import '../styles/globals.css';
 import { AppProvider } from '../contexts/AppContext';
+import Header from '../components/Header';
 
 export default function App({ Component, pageProps }) {
   const [theme, setTheme] = useState('light');
@@ -21,6 +22,7 @@ export default function App({ Component, pageProps }) {
 
   return (
     <AppProvider>
+      <Header />
       <Component {...pageProps} theme={theme} setTheme={setTheme} />
     </AppProvider>
   );


### PR DESCRIPTION
## Summary
- add a reusable Header component showing Login/Signup links
- expose logout function from AppContext
- mount the Header on all pages via `_app.js`

## Testing
- `npm run lint` *(fails: asks how to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9cb2158832f8ddf5b4b9694ab63