### PR TITLE
Add cart actions in header and product grid

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -3,13 +3,18 @@ import { useContext } from 'react';
 import { AppContext } from '../contexts/AppContext';
 
 export default function Header() {
-  const { user } = useContext(AppContext);
+  const { user, cart } = useContext(AppContext);
+  const itemCount = cart.reduce((sum, item) => sum + item.qty, 0);
   return (
     <header className="navbar bg-base-300 mb-6">
       <div className="flex-1">
         <Link href="/" className="btn btn-ghost normal-case text-xl">Home</Link>
       </div>
       <div className="flex-none">
+        <Link href="/cart" className="btn btn-ghost mr-2">
+          Cart
+          <span className="badge badge-sm badge-primary ml-2">{itemCount}</span>
+        </Link>
         {user ? (
           <span className="px-4">Hello, {user.firstName || user.email}</span>
         ) : (

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,9 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useContext } from 'react';
 import Head from 'next/head';
+import { AppContext } from '../contexts/AppContext';
 
 export default function Home({ theme, setTheme }) {
+    const { addToCart } = useContext(AppContext);
     const [searchTerm, setSearchTerm] = useState('');
     const [products, setProducts] = useState([]);
     const [loading, setLoading] = useState(false);
@@ -285,6 +287,12 @@ export default function Home({ theme, setTheme }) {
                                         <span>Reviews: {product.REVIEW_COUNT} ({product.AVERAGE_RATING.toFixed(1)} avg)</span>
                                     )}
                                 </div>
+                                <button
+                                    className="btn btn-sm btn-primary mt-2"
+                                    onClick={() => addToCart(product)}
+                                >
+                                    Add to Cart
+                                </button>
                             </div>
                         </div>
                     ))}


### PR DESCRIPTION
## Summary
- show cart link and item count in the header
- allow adding products to the cart from the search results

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841b1758dc0832f923d0c19a49632fe