### PR TITLE
Add per-field validation

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -5,28 +5,48 @@ export default function Login() {
   const { login } = useContext(AppContext);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+  const [errors, setErrors] = useState({});
+  const [formError, setFormError] = useState('');
 
   const submit = async e => {
     e.preventDefault();
-    if (!email || !password) {
-      setError('Email and password required');
-      return;
-    }
+    const newErrors = {};
+    if (!email) newErrors.email = 'Email is required';
+    if (!password) newErrors.password = 'Password is required';
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) return;
+
     try {
       await login(email, password);
     } catch (e) {
-      setError('Invalid credentials');
+      setFormError('Invalid credentials');
     }
   };
 
   return (
     <div className="p-4 max-w-sm mx-auto">
       <h1 className="text-2xl font-bold mb-4">Login</h1>
-      {error && <div className="text-red-500 mb-2">{error}</div>}
+      {formError && <div className="text-red-500 mb-2">{formError}</div>}
       <form onSubmit={submit} className="space-y-2">
-        <input className="input input-bordered w-full" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
-        <input type="password" className="input input-bordered w-full" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <div>
+          <input
+            className={`input input-bordered w-full ${errors.email ? 'border-red-500' : ''}`}
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder="Email"
+          />
+          {errors.email && <p className="text-red-500 text-sm">{errors.email}</p>}
+        </div>
+        <div>
+          <input
+            type="password"
+            className={`input input-bordered w-full ${errors.password ? 'border-red-500' : ''}`}
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            placeholder="Password"
+          />
+          {errors.password && <p className="text-red-500 text-sm">{errors.password}</p>}
+        </div>
         <button className="btn btn-primary w-full" type="submit">Login</button>
       </form>
     </div>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -10,18 +10,24 @@ export default function Signup() {
   const [confirm, setConfirm] = useState('');
   const [brand, setBrand] = useState('');
   const [gender, setGender] = useState('');
-  const [error, setError] = useState('');
+  const [errors, setErrors] = useState({});
+  const [formError, setFormError] = useState('');
 
   const submit = async e => {
     e.preventDefault();
-    if (!firstName || !lastName || !email || !password || !confirm || !gender) {
-      setError('All fields except brand name are required');
-      return;
+    const newErrors = {};
+    if (!firstName) newErrors.firstName = 'First name is required';
+    if (!lastName) newErrors.lastName = 'Last name is required';
+    if (!email) newErrors.email = 'Email is required';
+    if (!password) newErrors.password = 'Password is required';
+    if (!confirm) newErrors.confirm = 'Confirm password is required';
+    if (!gender) newErrors.gender = 'Gender is required';
+    if (password && confirm && password !== confirm) {
+      newErrors.confirm = 'Passwords do not match';
     }
-    if (password !== confirm) {
-      setError('Passwords do not match');
-      return;
-    }
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) return;
+
     try {
       await signup({
         firstName,
@@ -32,27 +38,83 @@ export default function Signup() {
         gender
       });
     } catch (e) {
-      setError('Signup failed');
+      setFormError('Signup failed');
     }
   };
 
   return (
     <div className="p-4 max-w-sm mx-auto">
       <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
-      {error && <div className="text-red-500 mb-2">{error}</div>}
+      {formError && <div className="text-red-500 mb-2">{formError}</div>}
       <form onSubmit={submit} className="space-y-2">
-        <input className="input input-bordered w-full" value={firstName} onChange={e => setFirstName(e.target.value)} placeholder="First Name" />
-        <input className="input input-bordered w-full" value={lastName} onChange={e => setLastName(e.target.value)} placeholder="Last Name" />
-        <input className="input input-bordered w-full" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
-        <input type="password" className="input input-bordered w-full" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
-        <input type="password" className="input input-bordered w-full" value={confirm} onChange={e => setConfirm(e.target.value)} placeholder="Confirm Password" />
-        <input className="input input-bordered w-full" value={brand} onChange={e => setBrand(e.target.value)} placeholder="Brand Name (optional)" />
-        <select className="select select-bordered w-full" value={gender} onChange={e => setGender(e.target.value)}>
-          <option value="">Select Gender</option>
-          <option value="male">Male</option>
-          <option value="female">Female</option>
-          <option value="other">Other</option>
-        </select>
+        <div>
+          <input
+            className={`input input-bordered w-full ${errors.firstName ? 'border-red-500' : ''}`}
+            value={firstName}
+            onChange={e => setFirstName(e.target.value)}
+            placeholder="First Name"
+          />
+          {errors.firstName && <p className="text-red-500 text-sm">{errors.firstName}</p>}
+        </div>
+        <div>
+          <input
+            className={`input input-bordered w-full ${errors.lastName ? 'border-red-500' : ''}`}
+            value={lastName}
+            onChange={e => setLastName(e.target.value)}
+            placeholder="Last Name"
+          />
+          {errors.lastName && <p className="text-red-500 text-sm">{errors.lastName}</p>}
+        </div>
+        <div>
+          <input
+            className={`input input-bordered w-full ${errors.email ? 'border-red-500' : ''}`}
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder="Email"
+          />
+          {errors.email && <p className="text-red-500 text-sm">{errors.email}</p>}
+        </div>
+        <div>
+          <input
+            type="password"
+            className={`input input-bordered w-full ${errors.password ? 'border-red-500' : ''}`}
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            placeholder="Password"
+          />
+          {errors.password && <p className="text-red-500 text-sm">{errors.password}</p>}
+        </div>
+        <div>
+          <input
+            type="password"
+            className={`input input-bordered w-full ${errors.confirm ? 'border-red-500' : ''}`}
+            value={confirm}
+            onChange={e => setConfirm(e.target.value)}
+            placeholder="Confirm Password"
+          />
+          {errors.confirm && <p className="text-red-500 text-sm">{errors.confirm}</p>}
+        </div>
+        <div>
+          <input
+            className="input input-bordered w-full"
+            value={brand}
+            onChange={e => setBrand(e.target.value)}
+            placeholder="Brand Name (optional)"
+          />
+        </div>
+        <div>
+          <select
+            className={`select select-bordered w-full ${errors.gender ? 'border-red-500' : ''}`}
+            value={gender}
+            onChange={e => setGender(e.target.value)}
+          >
+            <option value="">Select Gender</option>
+            <option value="male">Male</option>
+            <option value="female">Female</option>
+            <option value="other">Other</option>
+          </select>
+          {errors.gender && <p className="text-red-500 text-sm">{errors.gender}</p>}
+        </div>
         <button className="btn btn-primary w-full" type="submit">Sign Up</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add field-level validation for sign up page
- show input errors individually for login page

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6841b24fa2c8832f9e8f8643e5446b38