### PR TITLE
Improve category UX

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,9 +1,25 @@
 import Link from 'next/link';
-import { useContext } from 'react';
+import { useContext, useState, useEffect } from 'react';
 import { AppContext } from '../contexts/AppContext';
 
 export default function Header() {
   const { user, cart } = useContext(AppContext);
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    async function loadCategories() {
+      try {
+        const res = await fetch('/api/search');
+        if (res.ok) {
+          const data = await res.json();
+          setCategories(data.productTypes || []);
+        }
+      } catch (err) {
+        console.error('Failed to load categories', err);
+      }
+    }
+    loadCategories();
+  }, []);
   const itemCount = cart.reduce((sum, item) => sum + item.qty, 0);
   return (
     <header className="navbar bg-base-300 mb-6">
@@ -11,6 +27,16 @@ export default function Header() {
         <Link href="/" className="btn btn-ghost normal-case text-xl">Home</Link>
       </div>
       <div className="flex-none">
+        <div className="dropdown dropdown-hover mr-2">
+          <label tabIndex={0} className="btn btn-outline">Categories</label>
+          <ul tabIndex={0} className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
+            {categories.map(cat => (
+              <li key={cat}>
+                <Link href={`/?type=${encodeURIComponent(cat)}`}>{cat}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
         <Link href="/cart" className="btn btn-ghost mr-2">
           Cart
           <span className="badge badge-sm badge-primary ml-2">{itemCount}</span>


### PR DESCRIPTION
## Summary
- fetch product types in `Header`
- show category dropdown on hover
- sync `filterByType` with URL query in `index`
- update filter buttons to use new handler and use outline style

## Testing
- `npm run lint` *(fails: next executable not found or requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6841b5269984832fb34b6cd542a59b84