### PR TITLE
Add basic social auth and order system

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,23 @@ This will also install **DaisyUI**, a Tailwind CSS component library used throug
 BLOB_READ_WRITE_TOKEN=your-vercel-blob-token
 BLOB_BASE_URL=https://your-vercel-blob-url
 SKIP_INDEX_BUILD=false
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+NEXTAUTH_SECRET=random-secret
 ```
 
-4. **Place your product data**
+4. **Initialize the database**
+
+```bash
+npm run migrate
+```
+
+5. **Place your product data**
 
 Either put your `products.csv` inside the `/data/` directory **or** specify a
 remote file via the `PRODUCTS_URL` environment variable.
 
-5. **Run the project**
+6. **Run the project**
 
 ```bash
 npm run dev

--- a/contexts/AppContext.js
+++ b/contexts/AppContext.js
@@ -45,6 +45,16 @@ export function AppProvider({ children }) {
     setUser(null);
   };
 
+  const placeOrder = async () => {
+    if (!user || cart.length === 0) return;
+    await fetch('/api/orders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: user.email, items: cart, total: cart.reduce((s,i)=>s+i.qty*parseFloat(i.MIN_PRICE||0),0) })
+    });
+    setCart([]);
+  };
+
   const addToCart = (product) => {
     setCart(prev => {
       const existing = prev.find(p => p.ID === product.ID);
@@ -70,8 +80,9 @@ export function AppProvider({ children }) {
   };
 
   return (
-    <AppContext.Provider value={{ user, cart, login, signup, logout, addToCart, changeQty, removeFromCart }}>
+    <AppContext.Provider value={{ user, cart, login, signup, logout, addToCart, changeQty, removeFromCart, placeOrder }}>
       {children}
     </AppContext.Provider>
   );
 }
+

--- a/lib/db.js
+++ b/lib/db.js
@@ -30,7 +30,17 @@ export function getDb() {
       last_name TEXT,
       password TEXT,
       brand_name TEXT,
-      gender TEXT
+      gender TEXT,
+      role TEXT DEFAULT 'user'
+    )`);
+    db.exec(`CREATE TABLE IF NOT EXISTS orders (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_email TEXT,
+      items TEXT,
+      total REAL,
+      status TEXT DEFAULT 'pending',
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(user_email) REFERENCES users(email)
     )`);
   }
   return db;

--- a/lib/orders.js
+++ b/lib/orders.js
@@ -1,0 +1,21 @@
+import { getDb } from './db.js';
+
+export function addOrder({ user_email, items, total, status = 'pending' }) {
+  const db = getDb();
+  const stmt = db.prepare(`INSERT INTO orders (user_email, items, total, status) VALUES (?, ?, ?, ?)`);
+  const info = stmt.run(user_email, JSON.stringify(items), total, status);
+  return info.lastInsertRowid;
+}
+
+export function getOrdersForUser(email) {
+  const db = getDb();
+  const stmt = db.prepare(`SELECT * FROM orders WHERE user_email = ? ORDER BY created_at DESC`);
+  return stmt.all(email).map(row => ({ ...row, items: JSON.parse(row.items) }));
+}
+
+export function getAllOrders() {
+  const db = getDb();
+  const stmt = db.prepare(`SELECT * FROM orders ORDER BY created_at DESC`);
+  return stmt.all().map(row => ({ ...row, items: JSON.parse(row.items) }));
+}
+

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,14 +1,15 @@
 import { getDb } from './db.js';
 
-export function addUser({ email, password, first_name, last_name, brand_name, gender }) {
+export function addUser({ email, password, first_name, last_name, brand_name, gender, role = 'user' }) {
   const db = getDb();
-  const stmt = db.prepare(`INSERT INTO users (email, first_name, last_name, password, brand_name, gender)
-    VALUES (?, ?, ?, ?, ?, ?)`);
-  stmt.run(email, first_name, last_name, password, brand_name || null, gender);
+  const stmt = db.prepare(`INSERT INTO users (email, first_name, last_name, password, brand_name, gender, role)
+    VALUES (?, ?, ?, ?, ?, ?, ?)`);
+  stmt.run(email, first_name, last_name, password, brand_name || null, gender, role);
 }
 
 export function findUser(email) {
   const db = getDb();
-  const stmt = db.prepare('SELECT email, first_name, last_name, password, brand_name, gender FROM users WHERE email = ?');
+  const stmt = db.prepare('SELECT email, first_name, last_name, password, brand_name, gender, role FROM users WHERE email = ?');
   return stmt.get(email);
 }
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "node scripts/generate-search-index.mjs && next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "migrate": "node scripts/migrate.mjs"
   },
   "dependencies": {
     "@vercel/blob": "^0.23.0",
@@ -17,6 +18,7 @@
     "flexsearch": "^0.7.31",
     "jsdom": "^24.0.0",
     "next": "14.2.3",
+    "next-auth": "^4.24.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,8 +2,9 @@ import { useEffect, useState } from 'react';
 import '../styles/globals.css';
 import { AppProvider } from '../contexts/AppContext';
 import Header from '../components/Header';
+import { SessionProvider } from 'next-auth/react';
 
-export default function App({ Component, pageProps }) {
+export default function App({ Component, pageProps: { session, ...pageProps } }) {
   const [theme, setTheme] = useState('light');
 
   useEffect(() => {
@@ -21,9 +22,11 @@ export default function App({ Component, pageProps }) {
   }, [theme]);
 
   return (
-    <AppProvider>
-      <Header />
-      <Component {...pageProps} theme={theme} setTheme={setTheme} />
-    </AppProvider>
+    <SessionProvider session={session}>
+      <AppProvider>
+        <Header />
+        <Component {...pageProps} theme={theme} setTheme={setTheme} />
+      </AppProvider>
+    </SessionProvider>
   );
 }

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -41,6 +41,9 @@ export default function Admin() {
   if (!user) {
     return <div className="p-4">Please log in to view your products.</div>;
   }
+  if (user.role !== 'admin') {
+    return <div className="p-4">Admin access required.</div>;
+  }
 
   return (
     <div className="p-4 max-w-2xl mx-auto">
@@ -61,3 +64,4 @@ export default function Admin() {
     </div>
   );
 }
+

--- a/pages/admin/login.js
+++ b/pages/admin/login.js
@@ -1,0 +1,3 @@
+import Login from '../login';
+
+export default Login;

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,0 +1,67 @@
+import NextAuth from 'next-auth';
+import GoogleProvider from 'next-auth/providers/google';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import { findUser, addUser } from '../../../lib/users.js';
+
+export const authOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || ''
+    }),
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'text' },
+        password: { label: 'Password', type: 'password' }
+      },
+      authorize(credentials) {
+        const user = findUser(credentials.email);
+        if (user && user.password === credentials.password) {
+          const { first_name, last_name, brand_name, gender, role } = user;
+          return {
+            id: user.email,
+            email: user.email,
+            name: `${first_name} ${last_name}`,
+            brandName: brand_name,
+            gender,
+            role
+          };
+        }
+        return null;
+      }
+    })
+  ],
+  callbacks: {
+    async signIn({ user, account, profile }) {
+      if (account.provider === 'google') {
+        const existing = findUser(user.email);
+        if (!existing) {
+          addUser({
+            email: user.email,
+            password: '',
+            first_name: profile?.given_name || '',
+            last_name: profile?.family_name || '',
+            brand_name: null,
+            gender: profile?.gender || '',
+            role: 'user'
+          });
+        }
+      }
+      return true;
+    },
+    session({ session }) {
+      const dbUser = findUser(session.user.email);
+      if (dbUser) {
+        session.user.role = dbUser.role;
+      }
+      return session;
+    }
+  },
+  session: {
+    strategy: 'jwt'
+  }
+};
+
+export default NextAuth(authOptions);
+

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -12,7 +12,7 @@ export default function handler(req, res) {
   if (!user || user.password !== password) {
     return res.status(401).json({ message: 'Invalid credentials' });
   }
-  const { first_name, last_name, brand_name, gender } = user;
+  const { first_name, last_name, brand_name, gender, role } = user;
   return res.status(200).json({
     message: 'Login successful',
     user: {
@@ -20,7 +20,9 @@ export default function handler(req, res) {
       firstName: first_name,
       lastName: last_name,
       brandName: brand_name,
-      gender
+      gender,
+      role
     }
   });
 }
+

--- a/pages/api/orders.js
+++ b/pages/api/orders.js
@@ -1,0 +1,27 @@
+import { addOrder, getOrdersForUser, getAllOrders } from '../../lib/orders.js';
+import { findUser } from '../../lib/users.js';
+
+export default function handler(req, res) {
+  if (req.method === 'POST') {
+    const { email, items, total } = req.body;
+    if (!email || !items) {
+      return res.status(400).json({ message: 'email and items required' });
+    }
+    addOrder({ user_email: email, items, total: total || 0 });
+    return res.status(201).json({ message: 'order placed' });
+  }
+
+  if (req.method === 'GET') {
+    const { email } = req.query;
+    if (!email) return res.status(400).json({ message: 'email required' });
+    const user = findUser(email);
+    if (!user) return res.status(404).json({ message: 'user not found' });
+    if (user.role === 'admin') {
+      return res.status(200).json(getAllOrders());
+    }
+    return res.status(200).json(getOrdersForUser(email));
+  }
+
+  return res.status(405).json({ message: 'Method Not Allowed' });
+}
+

--- a/pages/api/signup.js
+++ b/pages/api/signup.js
@@ -4,7 +4,7 @@ export default function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
-  const { email, password, firstName, lastName, brandName, gender } = req.body;
+  const { email, password, firstName, lastName, brandName, gender, role } = req.body;
   if (!email || !password || !firstName || !lastName || !gender) {
     return res.status(400).json({ message: 'missing required fields' });
   }
@@ -18,13 +18,15 @@ export default function handler(req, res) {
       first_name: firstName,
       last_name: lastName,
       brand_name: brandName,
-      gender
+      gender,
+      role: role || 'user'
     });
     return res.status(201).json({
       message: 'User created',
-      user: { email, firstName, lastName, brandName, gender }
+      user: { email, firstName, lastName, brandName, gender, role: role || 'user' }
     });
   } catch (e) {
     return res.status(500).json({ message: 'Error creating user' });
   }
 }
+

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import { AppContext } from '../contexts/AppContext';
 
 export default function Cart() {
-  const { cart, changeQty, removeFromCart } = useContext(AppContext);
+  const { cart, changeQty, removeFromCart, placeOrder } = useContext(AppContext);
   const itemCount = cart.reduce((sum, item) => sum + item.qty, 0);
   const totalPrice = cart.reduce(
     (sum, item) => sum + item.qty * parseFloat(item.MIN_PRICE || 0),
@@ -40,7 +40,7 @@ export default function Cart() {
             <p className="font-semibold">Total Items: {itemCount}</p>
             <p className="font-semibold">Total Price: £{totalPrice.toFixed(2)}</p>
           </div>
-          <button className="btn btn-primary">Checkout</button>
+          <button className="btn btn-primary" onClick={placeOrder}>Checkout</button>
         </div>
       )}
     </div>

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,5 +1,6 @@
 import { useState, useContext } from 'react';
 import { AppContext } from '../contexts/AppContext';
+import { signIn } from 'next-auth/react';
 
 export default function Login() {
   const { login } = useContext(AppContext);
@@ -26,6 +27,13 @@ export default function Login() {
   return (
     <div className="p-4 max-w-sm mx-auto">
       <h1 className="text-2xl font-bold mb-4">Login</h1>
+      <button
+        type="button"
+        className="btn w-full mb-2"
+        onClick={() => signIn('google')}
+      >
+        Login with Google
+      </button>
       {formError && <div className="text-red-500 mb-2">{formError}</div>}
       <form onSubmit={submit} className="space-y-2">
         <div>
@@ -52,3 +60,4 @@ export default function Login() {
     </div>
   );
 }
+

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -1,0 +1,34 @@
+import { useContext, useEffect, useState } from 'react';
+import { AppContext } from '../contexts/AppContext';
+
+export default function Orders() {
+  const { user } = useContext(AppContext);
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+    fetch(`/api/orders?email=${encodeURIComponent(user.email)}`)
+      .then(res => res.ok ? res.json() : [])
+      .then(data => setOrders(data));
+  }, [user]);
+
+  if (!user) {
+    return <div className="p-4">Please log in to view orders.</div>;
+  }
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Orders</h1>
+      <ul className="space-y-2">
+        {orders.map(o => (
+          <li key={o.id} className="border p-2">
+            <p>Order #{o.id} - {o.status}</p>
+            <p>Total: £{o.total}</p>
+          </li>
+        ))}
+        {orders.length === 0 && <li>No orders found.</li>}
+      </ul>
+    </div>
+  );
+}
+

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,5 +1,6 @@
 import { useState, useContext } from 'react';
 import { AppContext } from '../contexts/AppContext';
+import { signIn } from 'next-auth/react';
 
 export default function Signup() {
   const { signup } = useContext(AppContext);
@@ -45,6 +46,13 @@ export default function Signup() {
   return (
     <div className="p-4 max-w-sm mx-auto">
       <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
+      <button
+        type="button"
+        className="btn w-full mb-2"
+        onClick={() => signIn('google')}
+      >
+        Sign up with Google
+      </button>
       {formError && <div className="text-red-500 mb-2">{formError}</div>}
       <form onSubmit={submit} className="space-y-2">
         <div>
@@ -120,3 +128,4 @@ export default function Signup() {
     </div>
   );
 }
+

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -1,0 +1,48 @@
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+
+const dbFile = path.join(process.cwd(), 'data', 'products.db');
+if (!fs.existsSync(path.dirname(dbFile))) {
+  fs.mkdirSync(path.dirname(dbFile), { recursive: true });
+}
+const db = new Database(dbFile);
+
+// Users table with role
+db.exec(`CREATE TABLE IF NOT EXISTS users (
+  email TEXT PRIMARY KEY,
+  first_name TEXT,
+  last_name TEXT,
+  password TEXT,
+  brand_name TEXT,
+  gender TEXT,
+  role TEXT DEFAULT 'user'
+)`);
+
+// Products table
+db.exec(`CREATE TABLE IF NOT EXISTS products (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  vendor TEXT,
+  description TEXT,
+  product_type TEXT,
+  tags TEXT,
+  quantity INTEGER,
+  min_price REAL,
+  max_price REAL,
+  currency TEXT
+)`);
+
+// Orders table
+db.exec(`CREATE TABLE IF NOT EXISTS orders (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_email TEXT,
+  items TEXT,
+  total REAL,
+  status TEXT DEFAULT 'pending',
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(user_email) REFERENCES users(email)
+)`);
+
+console.log('Database migrated');
+


### PR DESCRIPTION
## Summary
- add NextAuth setup with Google OAuth and credentials
- support user roles and orders in DB
- enable admin login and order management
- wire up order checkout and pages
- document DB migrations and auth env vars

## Testing
- `npm run lint` *(fails: `next` not found)*
- `node scripts/migrate.mjs` *(fails: cannot find module 'better-sqlite3')*

------
https://chatgpt.com/codex/tasks/task_e_6841bd6987fc832fb6c0bed78abd3746