### PR TITLE
Add GitHub auth and adjust search UI

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,5 +1,6 @@
 import NextAuth from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
+import GitHubProvider from 'next-auth/providers/github';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { findUser, addUser } from '../../../lib/users.js';
 
@@ -8,6 +9,10 @@ export const authOptions = {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID || '',
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || ''
+    }),
+    GitHubProvider({
+      clientId: process.env.GITHUB_CLIENT_ID || '',
+      clientSecret: process.env.GITHUB_CLIENT_SECRET || ''
     }),
     CredentialsProvider({
       name: 'Credentials',
@@ -34,14 +39,15 @@ export const authOptions = {
   ],
   callbacks: {
     async signIn({ user, account, profile }) {
-      if (account.provider === 'google') {
+      if (account.provider === 'google' || account.provider === 'github') {
         const existing = findUser(user.email);
         if (!existing) {
+          const nameParts = (profile?.name || '').split(' ');
           addUser({
             email: user.email,
             password: '',
-            first_name: profile?.given_name || '',
-            last_name: profile?.family_name || '',
+            first_name: profile?.given_name || nameParts[0] || '',
+            last_name: profile?.family_name || nameParts.slice(1).join(' ') || '',
             brand_name: null,
             gender: profile?.gender || '',
             role: 'user'

--- a/pages/index.js
+++ b/pages/index.js
@@ -171,21 +171,26 @@ export default function Home({ theme, setTheme }) {
                     ))}
                 </div>
 
+                <form onSubmit={handleSearch} className="mb-8 flex gap-2">
+                    <input
+                        type="text"
+                        id="search"
+                        className="input input-bordered flex-grow"
+                        placeholder="Search by title, vendor, description..."
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                    />
+                    <button
+                        type="submit"
+                        className="btn btn-primary"
+                        disabled={loading}
+                    >
+                        {loading ? 'Searching...' : 'Search'}
+                    </button>
+                </form>
+
                 <div className="md:flex">
                     <form onSubmit={handleSearch} className="md:w-60 md:mr-8 mb-8 flex flex-col gap-4">
-                        <div>
-                            <label htmlFor="search" className="block text-sm font-medium text-base-content mb-1">
-                                Search Products
-                            </label>
-                            <input
-                                type="text"
-                                id="search"
-                                className="input input-bordered w-full"
-                                placeholder="Search by title, vendor, description..."
-                                value={searchTerm}
-                                onChange={(e) => setSearchTerm(e.target.value)}
-                            />
-                        </div>
 
                         <div>
                             <label htmlFor="filterVendor" className="block text-sm font-medium text-base-content mb-1">
@@ -282,7 +287,7 @@ export default function Home({ theme, setTheme }) {
                                 className="btn btn-primary w-full"
                                 disabled={loading}
                             >
-                                {loading ? 'Searching...' : 'Search'}
+                                {loading ? 'Applying...' : 'Apply Filters'}
                             </button>
                         </div>
                     </form>

--- a/pages/login.js
+++ b/pages/login.js
@@ -34,6 +34,13 @@ export default function Login() {
       >
         Login with Google
       </button>
+      <button
+        type="button"
+        className="btn w-full mb-2"
+        onClick={() => signIn('github')}
+      >
+        Login with GitHub
+      </button>
       {formError && <div className="text-red-500 mb-2">{formError}</div>}
       <form onSubmit={submit} className="space-y-2">
         <div>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -53,6 +53,13 @@ export default function Signup() {
       >
         Sign up with Google
       </button>
+      <button
+        type="button"
+        className="btn w-full mb-2"
+        onClick={() => signIn('github')}
+      >
+        Sign up with GitHub
+      </button>
       {formError && <div className="text-red-500 mb-2">{formError}</div>}
       <form onSubmit={submit} className="space-y-2">
         <div>


### PR DESCRIPTION
## Summary
- allow logging in with GitHub
- add social sign up/login button for GitHub
- move search box above filters and rename filter submit button

## Testing
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6841c00bc208832f8d8f7ccd2a2f0932