### PR TITLE
Add header search suggestions and product details

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,10 +1,14 @@
 import Link from 'next/link';
 import { useContext, useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { AppContext } from '../contexts/AppContext';
 
 export default function Header() {
+  const router = useRouter();
   const { user, cart } = useContext(AppContext);
   const [categories, setCategories] = useState([]);
+  const [search, setSearch] = useState('');
+  const [suggestions, setSuggestions] = useState([]);
 
   useEffect(() => {
     async function loadCategories() {
@@ -20,14 +24,49 @@ export default function Header() {
     }
     loadCategories();
   }, []);
+
+  useEffect(() => {
+    if (!search.trim()) {
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(search)}&pageSize=5`, { signal: controller.signal });
+        if (res.ok) {
+          const data = await res.json();
+          setSuggestions(data.results || []);
+        }
+      } catch (_) {
+        // ignore
+      }
+    }, 300);
+    return () => {
+      clearTimeout(t);
+      controller.abort();
+    };
+  }, [search]);
   const itemCount = cart.reduce((sum, item) => sum + item.qty, 0);
+  const submitSearch = e => {
+    e.preventDefault();
+    if (!search.trim()) return;
+    router.push(`/?q=${encodeURIComponent(search)}`);
+    setSuggestions([]);
+  };
+
+  const selectSuggestion = (p) => {
+    router.push(`/products/${p.ID}`);
+    setSuggestions([]);
+    setSearch('');
+  };
   return (
     <header className="navbar bg-base-300 mb-6">
       <div className="flex-1">
         <Link href="/" className="btn btn-ghost normal-case text-xl">Home</Link>
       </div>
-      <div className="flex-none">
-        <div className="dropdown dropdown-hover mr-2">
+      <div className="flex-none gap-2">
+        <div className="dropdown dropdown-hover">
           <label tabIndex={0} className="btn btn-outline">Categories</label>
           <ul tabIndex={0} className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
             {categories.map(cat => (
@@ -37,6 +76,25 @@ export default function Header() {
             ))}
           </ul>
         </div>
+        <form onSubmit={submitSearch} className="relative">
+          <input
+            className="input input-bordered w-40 md:w-64"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search"
+          />
+          {suggestions.length > 0 && (
+            <ul className="absolute z-10 bg-base-100 border rounded-box mt-1 w-full max-h-60 overflow-auto">
+              {suggestions.map(s => (
+                <li key={s.ID}>
+                  <button type="button" className="block w-full text-left px-2 py-1 hover:bg-base-200" onClick={() => selectSuggestion(s)}>
+                    {s.TITLE}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </form>
         <Link href="/cart" className="btn btn-ghost mr-2">
           Cart
           {itemCount > 0 && (

--- a/pages/api/products/[id].js
+++ b/pages/api/products/[id].js
@@ -1,0 +1,18 @@
+import { loadAndIndexProducts } from '../../../lib/products';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  if (!id) {
+    return res.status(400).json({ message: 'id required' });
+  }
+  try {
+    const { products } = await loadAndIndexProducts();
+    const product = products.find(p => p.ID === String(id));
+    if (!product) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+    res.status(200).json(product);
+  } catch (e) {
+    res.status(500).json({ message: 'Failed to load product' });
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useContext } from 'react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 import Head from 'next/head';
 import { AppContext } from '../contexts/AppContext';
 
@@ -27,6 +28,15 @@ export default function Home({ theme, setTheme }) {
 
     // useRef to store the AbortController instance
     const abortControllerRef = useRef(null);
+
+    useEffect(() => {
+        if (router.query.q) {
+            const q = Array.isArray(router.query.q) ? router.query.q[0] : router.query.q;
+            setSearchTerm(q);
+        } else {
+            setSearchTerm('');
+        }
+    }, [router.query.q]);
 
     // Sync filter with query parameter
     useEffect(() => {
@@ -170,25 +180,6 @@ export default function Home({ theme, setTheme }) {
                         </button>
                     ))}
                 </div>
-
-                <form onSubmit={handleSearch} className="mb-8 flex gap-2">
-                    <input
-                        type="text"
-                        id="search"
-                        className="input input-bordered flex-grow"
-                        placeholder="Search by title, vendor, description..."
-                        value={searchTerm}
-                        onChange={(e) => setSearchTerm(e.target.value)}
-                    />
-                    <button
-                        type="submit"
-                        className="btn btn-primary"
-                        disabled={loading}
-                    >
-                        {loading ? 'Searching...' : 'Search'}
-                    </button>
-                </form>
-
                 <div className="md:flex">
                     <form onSubmit={handleSearch} className="md:w-60 md:mr-8 mb-8 flex flex-col gap-4">
 
@@ -323,27 +314,31 @@ export default function Home({ theme, setTheme }) {
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                     {products.map((product) => (
                         <div key={product.ID} className="card bg-base-100 border border-gray-200 shadow-md transform hover:shadow-xl hover:scale-105 transition duration-200 ease-in-out">
-                            <div className="w-full h-40 bg-gray-200 flex items-center justify-center overflow-hidden">
-                                {product.FEATURED_IMAGE?.url ? (
-                                    <img
-                                        src={product.FEATURED_IMAGE.url}
-                                        alt={product.TITLE || 'Product Image'}
-                                        className="object-cover w-full h-full"
-                                        onError={(e) => { e.target.onerror = null; e.target.src = `https://placehold.co/400x300/e0e0e0/555555?text=No+Image`; }}
-                                    />
-                                ) : (
-                                    <img
-                                        src={`https://placehold.co/400x300/e0e0e0/555555?text=No+Image`}
-                                        alt="No Image Available"
-                                        className="object-cover w-full h-full"
-                                    />
-                                )}
-                            </div>
+                            <Link href={`/products/${product.ID}`}> 
+                                <div className="w-full h-40 bg-gray-200 flex items-center justify-center overflow-hidden">
+                                    {product.FEATURED_IMAGE?.url ? (
+                                        <img
+                                            src={product.FEATURED_IMAGE.url}
+                                            alt={product.TITLE || 'Product Image'}
+                                            className="object-cover w-full h-full"
+                                            onError={(e) => { e.target.onerror = null; e.target.src = `https://placehold.co/400x300/e0e0e0/555555?text=No+Image`; }}
+                                        />
+                                    ) : (
+                                        <img
+                                            src={`https://placehold.co/400x300/e0e0e0/555555?text=No+Image`}
+                                            alt="No Image Available"
+                                            className="object-cover w-full h-full"
+                                        />
+                                    )}
+                                </div>
+                            </Link>
 
                             <div className="card-body flex flex-col gap-1">
-                                <h2 className="text-lg font-semibold text-base-content line-clamp-2" title={product.TITLE}>
-                                    {product.TITLE || 'Untitled Product'}
-                                </h2>
+                                <Link href={`/products/${product.ID}`} className="hover:underline">
+                                    <h2 className="text-lg font-semibold text-base-content line-clamp-2" title={product.TITLE}>
+                                        {product.TITLE || 'Untitled Product'}
+                                    </h2>
+                                </Link>
                                 <div className="flex flex-wrap gap-1 text-xs text-base-content">
                                     {product.VENDOR && <span className="badge badge-ghost">{product.VENDOR}</span>}
                                     {product.PRODUCT_TYPE && <span className="badge badge-ghost">{product.PRODUCT_TYPE}</span>}

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -1,0 +1,51 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState, useContext } from 'react';
+import { AppContext } from '../../contexts/AppContext';
+import Link from 'next/link';
+
+export default function ProductDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { addToCart } = useContext(AppContext);
+  const [product, setProduct] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    async function load() {
+      try {
+        const res = await fetch(`/api/products/${id}`);
+        if (!res.ok) throw new Error('Failed');
+        const data = await res.json();
+        setProduct(data);
+      } catch (e) {
+        setError('Failed to load product');
+      }
+    }
+    load();
+  }, [id]);
+
+  if (error) return <div className="p-4">{error}</div>;
+  if (!product) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">{product.TITLE}</h1>
+      <div className="mb-4 w-full flex justify-center">
+        {product.FEATURED_IMAGE?.url ? (
+          <img src={product.FEATURED_IMAGE.url} alt={product.TITLE} className="object-cover max-h-96" />
+        ) : (
+          <img src="https://placehold.co/600x400?text=No+Image" alt="No image" className="object-cover max-h-96" />
+        )}
+      </div>
+      <p className="mb-2">Vendor: {product.VENDOR}</p>
+      <p className="mb-2">Type: {product.PRODUCT_TYPE}</p>
+      <p className="mb-4">{product.DESCRIPTION_TEXT || product.BODY_HTML_TEXT || 'No description available.'}</p>
+      <p className="text-lg font-bold mb-4">{product.CURRENCY} {parseFloat(product.MIN_PRICE).toFixed(2)}</p>
+      <button className="btn btn-primary" onClick={() => addToCart(product)}>Add to Cart</button>
+      <div className="mt-4">
+        <Link href="/">&larr; Back to products</Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a product search box with suggestions to header
- hook up search term from query in index page
- link products to a new detail page
- expose an API to fetch single product details

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c41256b0832f829a3015ce6f2934