### PR TITLE
UI tweaks for better layout

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -62,20 +62,8 @@ export default function Header() {
   };
   return (
     <header className="navbar bg-base-300 mb-6">
-      <div className="flex-1">
+      <div className="flex-1 flex items-center gap-2">
         <Link href="/" className="btn btn-ghost normal-case text-xl">Home</Link>
-      </div>
-      <div className="flex-none gap-2">
-        <div className="dropdown dropdown-hover">
-          <label tabIndex={0} className="btn btn-outline">Categories</label>
-          <ul tabIndex={0} className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-            {categories.map(cat => (
-              <li key={cat}>
-                <Link href={`/?type=${encodeURIComponent(cat)}`}>{cat}</Link>
-              </li>
-            ))}
-          </ul>
-        </div>
         <form onSubmit={submitSearch} className="relative">
           <input
             className="input input-bordered w-40 md:w-64"
@@ -95,6 +83,18 @@ export default function Header() {
             </ul>
           )}
         </form>
+      </div>
+      <div className="flex-none gap-2">
+        <div className="dropdown dropdown-hover">
+          <label tabIndex={0} className="btn btn-outline">Categories</label>
+          <ul tabIndex={0} className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
+            {categories.map(cat => (
+              <li key={cat}>
+                <Link href={`/?type=${encodeURIComponent(cat)}`}>{cat}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
         <Link href="/cart" className="btn btn-ghost mr-2">
           Cart
           {itemCount > 0 && (

--- a/pages/index.js
+++ b/pages/index.js
@@ -282,7 +282,6 @@ export default function Home({ theme, setTheme }) {
                             </button>
                         </div>
                     </form>
-                </div>
                     <div className="flex-1">
                         {activeFilters.length > 0 && (
                             <div className="mb-4 flex flex-wrap gap-2">
@@ -391,6 +390,7 @@ export default function Home({ theme, setTheme }) {
                     </div>
                 )}
                 </div>
+            </div>
             </main>
         </div>
     );

--- a/pages/login.js
+++ b/pages/login.js
@@ -43,14 +43,14 @@ export default function Login() {
       <h1 className="text-2xl font-bold mb-4">Login</h1>
       <button
         type="button"
-        className="btn w-full mb-2"
+        className="btn w-full mb-2 hover:bg-red-600"
         onClick={() => signIn('google')}
       >
         Login with Google
       </button>
       <button
         type="button"
-        className="btn w-full mb-2"
+        className="btn w-full mb-2 hover:bg-gray-800 hover:text-white"
         onClick={() => signIn('github')}
       >
         Login with GitHub

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -93,14 +93,14 @@ export default function Signup() {
       <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
       <button
         type="button"
-        className="btn w-full mb-2"
+        className="btn w-full mb-2 hover:bg-red-600"
         onClick={() => signIn('google')}
       >
         Sign up with Google
       </button>
       <button
         type="button"
-        className="btn w-full mb-2"
+        className="btn w-full mb-2 hover:bg-gray-800 hover:text-white"
         onClick={() => signIn('github')}
       >
         Sign up with GitHub


### PR DESCRIPTION
## Summary
- move search bar next to Home link
- add hover styles for Google and GitHub auth buttons
- fix product page flex layout so products sit beside filters

## Testing
- `npm install`
- `npm run lint` *(fails: ESLint interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6841c8885cfc832f82db400d4996b74e