### PR TITLE
Enhance admin editing and password visibility

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -53,6 +53,22 @@ export function addProduct(product) {
   stmt.run(product);
 }
 
+export function updateProduct(product) {
+  const db = getDb();
+  const stmt = db.prepare(`UPDATE products SET
+      title=@title,
+      vendor=@vendor,
+      description=@description,
+      product_type=@product_type,
+      tags=@tags,
+      quantity=@quantity,
+      min_price=@min_price,
+      max_price=@max_price,
+      currency=@currency
+    WHERE id=@id`);
+  stmt.run(product);
+}
+
 export function getAllFromDb() {
   const db = getDb();
   return db.prepare('SELECT * FROM products').all();

--- a/lib/products.js
+++ b/lib/products.js
@@ -3,7 +3,7 @@ import FlexSearch from 'flexsearch';
 const { Document } = FlexSearch;
 import path from 'path';
 import { put, list } from '@vercel/blob';
-import { getAllFromDb, addProduct as dbAddProduct } from './db.js';
+import { getAllFromDb, addProduct as dbAddProduct, updateProduct as dbUpdateProduct } from './db.js';
 
 let products = [];
 let productIndex = null;
@@ -235,5 +235,10 @@ export function searchProducts(query) {
 
 export function addProduct(product) {
     dbAddProduct(product);
+    isDataLoaded = false;
+}
+
+export function updateProduct(product) {
+    dbUpdateProduct(product);
     isDataLoaded = false;
 }

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -3,9 +3,11 @@ import { AppContext } from '../../contexts/AppContext';
 
 export default function Admin() {
   const { user } = useContext(AppContext);
-  const [form, setForm] = useState({ id: '', title: '', vendor: '', description: '', product_type: '', tags: '', quantity: 0, min_price: 0, max_price: 0, currency: 'USD' });
+  const emptyForm = { id: '', title: '', vendor: '', description: '', product_type: '', tags: '', quantity: 0, min_price: 0, max_price: 0, currency: 'USD' };
+  const [form, setForm] = useState(emptyForm);
   const [products, setProducts] = useState([]);
   const [message, setMessage] = useState('');
+  const [editingId, setEditingId] = useState(null);
 
   const fetchProducts = async () => {
     if (!user) return;
@@ -24,18 +26,40 @@ export default function Admin() {
   const submit = async e => {
     e.preventDefault();
     const res = await fetch('/api/admin/products', {
-      method: 'POST',
+      method: editingId ? 'PUT' : 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(form)
+      body: JSON.stringify(editingId ? { ...form, id: editingId } : form)
     });
     if (res.ok) {
-      setMessage('Product added');
-      setForm({ id: '', title: '', vendor: '', description: '', product_type: '', tags: '', quantity: 0, min_price: 0, max_price: 0, currency: 'USD' });
+      setMessage(editingId ? 'Product updated' : 'Product added');
+      setForm(emptyForm);
+      setEditingId(null);
       fetchProducts();
     } else {
       const data = await res.json();
       setMessage(data.message || 'Error');
     }
+  };
+
+  const handleEdit = (p) => {
+    setForm({
+      id: p.ID,
+      title: p.TITLE || '',
+      vendor: p.VENDOR || '',
+      description: p.DESCRIPTION || '',
+      product_type: p.PRODUCT_TYPE || '',
+      tags: p.TAGS || '',
+      quantity: p.TOTAL_INVENTORY || 0,
+      min_price: p.MIN_PRICE || 0,
+      max_price: p.MAX_PRICE || 0,
+      currency: p.CURRENCY || 'USD'
+    });
+    setEditingId(p.ID);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setForm(emptyForm);
   };
 
   if (!user) {
@@ -51,14 +75,25 @@ export default function Admin() {
       {message && <div className="mb-4 text-green-600">{message}</div>}
       <form onSubmit={submit} className="space-y-2 mb-6">
         {['id','title','vendor','description','product_type','tags','quantity','min_price','max_price','currency'].map(field => (
-          <input key={field} name={field} value={form[field]} onChange={handleChange} placeholder={field} className="input input-bordered w-full" />
+          <div key={field}>
+            <label className="label capitalize">
+              <span className="label-text">{field.replace('_',' ')}</span>
+            </label>
+            <input name={field} value={form[field]} onChange={handleChange} placeholder={field} className="input input-bordered w-full" />
+          </div>
         ))}
-        <button type="submit" className="btn btn-primary">Add Product</button>
+        <div className="flex gap-2">
+          {editingId && <button type="button" onClick={cancelEdit} className="btn">Cancel</button>}
+          <button type="submit" className="btn btn-primary">{editingId ? 'Update Product' : 'Add Product'}</button>
+        </div>
       </form>
       <h2 className="text-xl font-semibold mb-2">Existing Products</h2>
       <ul className="space-y-1">
         {products.map(p => (
-          <li key={p.ID}>{p.TITLE} - {p.PRODUCT_TYPE}</li>
+          <li key={p.ID} className="flex justify-between items-center">
+            <span>{p.TITLE} - {p.PRODUCT_TYPE}</span>
+            <button type="button" className="btn btn-sm" onClick={() => handleEdit(p)}>Edit</button>
+          </li>
         ))}
       </ul>
     </div>

--- a/pages/api/admin/products.js
+++ b/pages/api/admin/products.js
@@ -1,4 +1,4 @@
-import { addProduct, loadAndIndexProducts } from '../../../lib/products';
+import { addProduct, updateProduct, loadAndIndexProducts } from '../../../lib/products';
 
 export default async function handler(req, res) {
   if (req.method === 'POST') {
@@ -20,6 +20,27 @@ export default async function handler(req, res) {
     });
     await loadAndIndexProducts();
     return res.status(201).json({ message: 'Product added' });
+  }
+
+  if (req.method === 'PUT') {
+    const { id, title, vendor, description, product_type, tags, quantity, min_price, max_price, currency } = req.body;
+    if (!id || !title) {
+      return res.status(400).json({ message: 'id and title are required' });
+    }
+    updateProduct({
+      id: String(id),
+      title,
+      vendor,
+      description,
+      product_type,
+      tags,
+      quantity: quantity ? parseInt(quantity, 10) : 0,
+      min_price: parseFloat(min_price || 0),
+      max_price: parseFloat(max_price || 0),
+      currency: currency || 'USD'
+    });
+    await loadAndIndexProducts();
+    return res.status(200).json({ message: 'Product updated' });
   }
 
   if (req.method === 'GET') {

--- a/pages/login.js
+++ b/pages/login.js
@@ -8,6 +8,7 @@ export default function Login() {
   const { login } = useContext(AppContext);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
 
@@ -67,14 +68,31 @@ export default function Login() {
           />
           {errors.email && <p className="text-red-500 text-sm">{errors.email}</p>}
         </div>
-        <div>
+        <div className="relative">
           <input
-            type="password"
-            className={`input input-bordered w-full ${errors.password ? 'border-red-500' : ''}`}
+            type={showPassword ? 'text' : 'password'}
+            className={`input input-bordered w-full pr-10 ${errors.password ? 'border-red-500' : ''}`}
             value={password}
             onChange={e => setPassword(e.target.value)}
             placeholder="Password"
           />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute right-2 top-2"
+          >
+            {showPassword ? (
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="h-5 w-5">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.965 9.965 0 012.652-4.304m3.821-2.338A9.953 9.953 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.952 9.952 0 01-.46 1.08M15 12a3 3 0 11-6 0 3 3 0 016 0zm-1.259 4.75L5.21 5.21" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 3l18 18" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="h-5 w-5">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+            )}
+          </button>
           {errors.password && <p className="text-red-500 text-sm">{errors.password}</p>}
         </div>
         <button className="btn btn-primary w-full" type="submit">Login</button>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -14,6 +14,8 @@ export default function Signup() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
   const [brand, setBrand] = useState('');
   const [gender, setGender] = useState('');
   const [role, setRole] = useState('user');
@@ -141,30 +143,64 @@ export default function Signup() {
           />
           {errors.email && <p className="text-red-500 text-sm">{errors.email}</p>}
         </div>
-        <div>
+        <div className="relative">
           <input
-            type="password"
-            className={`input input-bordered w-full ${errors.password ? 'border-red-500' : ''}`}
+            type={showPassword ? 'text' : 'password'}
+            className={`input input-bordered w-full pr-10 ${errors.password ? 'border-red-500' : ''}`}
             value={password}
             onChange={e => setPassword(e.target.value)}
             onBlur={handlePasswordBlur}
             placeholder="Password"
           />
+          <button
+            type="button"
+            className="absolute right-2 top-2"
+            onClick={() => setShowPassword(!showPassword)}
+          >
+            {showPassword ? (
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="h-5 w-5">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.965 9.965 0 012.652-4.304m3.821-2.338A9.953 9.953 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.952 9.952 0 01-.46 1.08M15 12a3 3 0 11-6 0 3 3 0 016 0zm-1.259 4.75L5.21 5.21" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 3l18 18" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="h-5 w-5">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+            )}
+          </button>
           <p className="text-sm text-gray-500">
             Password must be at least 8 characters and include uppercase,
             lowercase, number and special character
           </p>
           {errors.password && <p className="text-red-500 text-sm">{errors.password}</p>}
         </div>
-        <div>
+        <div className="relative">
           <input
-            type="password"
-            className={`input input-bordered w-full ${errors.confirm ? 'border-red-500' : ''}`}
+            type={showConfirm ? 'text' : 'password'}
+            className={`input input-bordered w-full pr-10 ${errors.confirm ? 'border-red-500' : ''}`}
             value={confirm}
             onChange={e => setConfirm(e.target.value)}
             onBlur={handleConfirmBlur}
             placeholder="Confirm Password"
           />
+          <button
+            type="button"
+            className="absolute right-2 top-2"
+            onClick={() => setShowConfirm(!showConfirm)}
+          >
+            {showConfirm ? (
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="h-5 w-5">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.965 9.965 0 012.652-4.304m3.821-2.338A9.953 9.953 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.952 9.952 0 01-.46 1.08M15 12a3 3 0 11-6 0 3 3 0 016 0zm-1.259 4.75L5.21 5.21" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 3l18 18" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="h-5 w-5">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+            )}
+          </button>
           {errors.confirm && <p className="text-red-500 text-sm">{errors.confirm}</p>}
         </div>
         <div>


### PR DESCRIPTION
## Summary
- allow updating products through API and admin panel
- show labels for product form fields
- add eye icon toggle for password inputs

## Testing
- `npm run lint` *(fails: prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_6841ca84f88c832f8dc04b53b190c9b3