### PR TITLE
Implement vendor dashboard features

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -19,6 +19,7 @@ export function getDb() {
       description TEXT,
       product_type TEXT,
       tags TEXT,
+      category TEXT,
       quantity INTEGER,
       min_price REAL,
       max_price REAL,
@@ -48,8 +49,8 @@ export function getDb() {
 
 export function addProduct(product) {
   const db = getDb();
-  const stmt = db.prepare(`INSERT INTO products (id, title, vendor, description, product_type, tags, quantity, min_price, max_price, currency)
-    VALUES (@id, @title, @vendor, @description, @product_type, @tags, @quantity, @min_price, @max_price, @currency)`);
+  const stmt = db.prepare(`INSERT INTO products (id, title, vendor, description, product_type, tags, category, quantity, min_price, max_price, currency)
+    VALUES (@id, @title, @vendor, @description, @product_type, @tags, @category, @quantity, @min_price, @max_price, @currency)`);
   stmt.run(product);
 }
 
@@ -61,12 +62,19 @@ export function updateProduct(product) {
       description=@description,
       product_type=@product_type,
       tags=@tags,
+      category=@category,
       quantity=@quantity,
       min_price=@min_price,
       max_price=@max_price,
       currency=@currency
     WHERE id=@id`);
   stmt.run(product);
+}
+
+export function deleteProduct(id) {
+  const db = getDb();
+  const stmt = db.prepare('DELETE FROM products WHERE id = ?');
+  stmt.run(id);
 }
 
 export function getAllFromDb() {

--- a/lib/orders.js
+++ b/lib/orders.js
@@ -19,3 +19,12 @@ export function getAllOrders() {
   return stmt.all().map(row => ({ ...row, items: JSON.parse(row.items) }));
 }
 
+export function getOrdersForVendor(vendor) {
+  const db = getDb();
+  const stmt = db.prepare(`SELECT * FROM orders ORDER BY created_at DESC`);
+  return stmt
+    .all()
+    .map(row => ({ ...row, items: JSON.parse(row.items) }))
+    .filter(order => order.items.some(item => item.VENDOR === vendor));
+}
+

--- a/lib/products.js
+++ b/lib/products.js
@@ -3,7 +3,7 @@ import FlexSearch from 'flexsearch';
 const { Document } = FlexSearch;
 import path from 'path';
 import { put, list } from '@vercel/blob';
-import { getAllFromDb, addProduct as dbAddProduct, updateProduct as dbUpdateProduct } from './db.js';
+import { getAllFromDb, addProduct as dbAddProduct, updateProduct as dbUpdateProduct, deleteProduct as dbDeleteProduct } from './db.js';
 
 let products = [];
 let productIndex = null;
@@ -57,6 +57,7 @@ async function loadProductsData() {
         DESCRIPTION: row.description,
         PRODUCT_TYPE: row.product_type,
         TAGS: row.tags,
+        CATEGORY: row.category,
         TOTAL_INVENTORY: row.quantity,
         PRICE_RANGE_V2: {
             min_variant_price: { amount: row.min_price, currency_code: row.currency },
@@ -76,6 +77,7 @@ function createFlexDoc() {
                 'BODY_HTML_TEXT',
                 'TAGS',
                 'PRODUCT_TYPE',
+                'CATEGORY',
                 'METAFIELDS.my_fields_ingredients.value'
             ],
             store: true
@@ -104,6 +106,7 @@ export async function loadAndIndexProducts() {
                 'BODY_HTML_TEXT',
                 'TAGS',
                 'PRODUCT_TYPE',
+                'CATEGORY',
                 'METAFIELDS.my_fields_ingredients.value'
             ],
             store: true
@@ -240,5 +243,10 @@ export function addProduct(product) {
 
 export function updateProduct(product) {
     dbUpdateProduct(product);
+    isDataLoaded = false;
+}
+
+export function deleteProduct(id) {
+    dbDeleteProduct(id);
     isDataLoaded = false;
 }

--- a/pages/api/admin/products.js
+++ b/pages/api/admin/products.js
@@ -1,8 +1,8 @@
-import { addProduct, updateProduct, loadAndIndexProducts } from '../../../lib/products';
+import { addProduct, updateProduct, deleteProduct, loadAndIndexProducts } from '../../../lib/products';
 
 export default async function handler(req, res) {
   if (req.method === 'POST') {
-    const { id, title, vendor, description, product_type, tags, quantity, min_price, max_price, currency } = req.body;
+    const { id, title, vendor, description, product_type, tags, category, quantity, min_price, max_price, currency } = req.body;
     if (!id || !title) {
       return res.status(400).json({ message: 'id and title are required' });
     }
@@ -13,6 +13,7 @@ export default async function handler(req, res) {
       description,
       product_type,
       tags,
+      category,
       quantity: quantity ? parseInt(quantity, 10) : 0,
       min_price: parseFloat(min_price || 0),
       max_price: parseFloat(max_price || 0),
@@ -23,7 +24,7 @@ export default async function handler(req, res) {
   }
 
   if (req.method === 'PUT') {
-    const { id, title, vendor, description, product_type, tags, quantity, min_price, max_price, currency } = req.body;
+    const { id, title, vendor, description, product_type, tags, category, quantity, min_price, max_price, currency } = req.body;
     if (!id || !title) {
       return res.status(400).json({ message: 'id and title are required' });
     }
@@ -34,6 +35,7 @@ export default async function handler(req, res) {
       description,
       product_type,
       tags,
+      category,
       quantity: quantity ? parseInt(quantity, 10) : 0,
       min_price: parseFloat(min_price || 0),
       max_price: parseFloat(max_price || 0),
@@ -41,6 +43,16 @@ export default async function handler(req, res) {
     });
     await loadAndIndexProducts();
     return res.status(200).json({ message: 'Product updated' });
+  }
+
+  if (req.method === 'DELETE') {
+    const { id } = req.query;
+    if (!id) {
+      return res.status(400).json({ message: 'id required' });
+    }
+    deleteProduct(String(id));
+    await loadAndIndexProducts();
+    return res.status(200).json({ message: 'Product deleted' });
   }
 
   if (req.method === 'GET') {

--- a/pages/api/vendor/orders.js
+++ b/pages/api/vendor/orders.js
@@ -1,0 +1,13 @@
+import { getOrdersForVendor } from '../../../lib/orders';
+
+export default function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const { vendor } = req.query;
+  if (!vendor) {
+    return res.status(400).json({ message: 'vendor required' });
+  }
+  const orders = getOrdersForVendor(vendor);
+  return res.status(200).json(orders);
+}

--- a/pages/vendor/index.js
+++ b/pages/vendor/index.js
@@ -1,0 +1,113 @@
+import { useState, useEffect, useContext } from 'react';
+import { AppContext } from '../../contexts/AppContext';
+
+export default function VendorDashboard() {
+  const { user } = useContext(AppContext);
+  const emptyForm = { id: '', title: '', vendor: '', description: '', product_type: '', tags: '', category: '', quantity: 0, min_price: 0, max_price: 0, currency: 'USD' };
+  const [form, setForm] = useState(emptyForm);
+  const [products, setProducts] = useState([]);
+  const [message, setMessage] = useState('');
+  const [editingId, setEditingId] = useState(null);
+
+  const fetchProducts = async () => {
+    if (!user) return;
+    const res = await fetch(`/api/admin/products?vendor=${encodeURIComponent(user.brandName || '')}`);
+    if (res.ok) {
+      setProducts(await res.json());
+    }
+  };
+
+  useEffect(() => { fetchProducts(); }, [user]);
+
+  const handleChange = e => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const submit = async e => {
+    e.preventDefault();
+    const res = await fetch('/api/admin/products', {
+      method: editingId ? 'PUT' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(editingId ? { ...form, id: editingId } : form)
+    });
+    if (res.ok) {
+      setMessage(editingId ? 'Product updated' : 'Product added');
+      setForm(emptyForm);
+      setEditingId(null);
+      fetchProducts();
+    } else {
+      const data = await res.json();
+      setMessage(data.message || 'Error');
+    }
+  };
+
+  const handleEdit = p => {
+    setForm({
+      id: p.ID,
+      title: p.TITLE || '',
+      vendor: p.VENDOR || '',
+      description: p.DESCRIPTION || '',
+      product_type: p.PRODUCT_TYPE || '',
+      tags: p.TAGS || '',
+      category: p.CATEGORY || '',
+      quantity: p.TOTAL_INVENTORY || 0,
+      min_price: p.MIN_PRICE || 0,
+      max_price: p.MAX_PRICE || 0,
+      currency: p.CURRENCY || 'USD'
+    });
+    setEditingId(p.ID);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setForm(emptyForm);
+  };
+
+  const handleDelete = async id => {
+    if (!confirm('Delete this product?')) return;
+    const res = await fetch(`/api/admin/products?id=${encodeURIComponent(id)}`, { method: 'DELETE' });
+    if (res.ok) {
+      fetchProducts();
+    }
+  };
+
+  if (!user) {
+    return <div className="p-4">Please log in to manage products.</div>;
+  }
+  if (user.role !== 'admin') {
+    return <div className="p-4">Vendor access required.</div>;
+  }
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Vendor Dashboard</h1>
+      {message && <div className="mb-4 text-green-600">{message}</div>}
+      <form onSubmit={submit} className="space-y-2 mb-6">
+        {['id','title','vendor','description','product_type','tags','category','quantity','min_price','max_price','currency'].map(field => (
+          <div key={field}>
+            <label className="label capitalize">
+              <span className="label-text">{field.replace('_',' ')}</span>
+            </label>
+            <input name={field} value={form[field]} onChange={handleChange} placeholder={field} className="input input-bordered w-full" />
+          </div>
+        ))}
+        <div className="flex gap-2">
+          {editingId && <button type="button" onClick={cancelEdit} className="btn">Cancel</button>}
+          <button type="submit" className="btn btn-primary">{editingId ? 'Update Product' : 'Add Product'}</button>
+        </div>
+      </form>
+      <h2 className="text-xl font-semibold mb-2">Existing Products</h2>
+      <ul className="space-y-1">
+        {products.map(p => (
+          <li key={p.ID} className="flex justify-between items-center gap-2">
+            <span>{p.TITLE} - {p.CATEGORY || p.PRODUCT_TYPE}</span>
+            <div className="flex gap-2">
+              <button type="button" className="btn btn-sm" onClick={() => handleEdit(p)}>Edit</button>
+              <button type="button" className="btn btn-sm btn-error" onClick={() => handleDelete(p.ID)}>Delete</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/vendor/orders.js
+++ b/pages/vendor/orders.js
@@ -1,0 +1,36 @@
+import { useContext, useEffect, useState } from 'react';
+import { AppContext } from '../../contexts/AppContext';
+
+export default function VendorOrders() {
+  const { user } = useContext(AppContext);
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+    fetch(`/api/vendor/orders?vendor=${encodeURIComponent(user.brandName || '')}`)
+      .then(res => res.ok ? res.json() : [])
+      .then(data => setOrders(data));
+  }, [user]);
+
+  if (!user) {
+    return <div className="p-4">Please log in to view orders.</div>;
+  }
+  if (user.role !== 'admin') {
+    return <div className="p-4">Vendor access required.</div>;
+  }
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Order History</h1>
+      <ul className="space-y-2">
+        {orders.map(o => (
+          <li key={o.id} className="border p-2">
+            <p>Order #{o.id} - {o.status}</p>
+            <p>Total: £{o.total}</p>
+          </li>
+        ))}
+        {orders.length === 0 && <li>No orders found.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -27,10 +27,17 @@ db.exec(`CREATE TABLE IF NOT EXISTS products (
   description TEXT,
   product_type TEXT,
   tags TEXT,
+  category TEXT,
   quantity INTEGER,
   min_price REAL,
   max_price REAL,
   currency TEXT
+)`);
+
+// Categories table for grouping products
+db.exec(`CREATE TABLE IF NOT EXISTS categories (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT UNIQUE
 )`);
 
 // Orders table


### PR DESCRIPTION
## Summary
- support product `category` column and categories table
- allow vendors to manage products including deletion
- add API to retrieve vendor orders
- create vendor dashboard and orders pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails during install)*

------
https://chatgpt.com/codex/tasks/task_e_68427018c3e4832f9cbbda63d22a3a59