### PR TITLE
Add NextAuth credentials roles

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,11 +1,15 @@
 import Link from 'next/link';
 import { useContext, useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { useSession, signOut } from 'next-auth/react';
 import { AppContext } from '../contexts/AppContext';
 
 export default function Header() {
   const router = useRouter();
-  const { user, cart, logout } = useContext(AppContext);
+  const { data: session } = useSession();
+  const { cart } = useContext(AppContext);
+  const user = session?.user;
+  const logout = () => signOut({ redirect: false });
   const [categories, setCategories] = useState([]);
   const [search, setSearch] = useState('');
   const [suggestions, setSuggestions] = useState([]);

--- a/lib/db.js
+++ b/lib/db.js
@@ -39,7 +39,7 @@ export function getDb() {
       password TEXT,
       brand_name TEXT,
       gender TEXT,
-      role TEXT DEFAULT 'user',
+      role TEXT DEFAULT 'customer',
       verified INTEGER DEFAULT 0,
       verification_token TEXT,
       reset_token TEXT,

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,6 +1,6 @@
 import { getDb } from './db.js';
 
-export function addUser({ email, password, first_name, last_name, brand_name, gender, role = 'user', verification_token }) {
+export function addUser({ email, password, first_name, last_name, brand_name, gender, role = 'customer', verification_token }) {
   const db = getDb();
   const stmt = db.prepare(`INSERT INTO users (email, first_name, last_name, password, brand_name, gender, role, verification_token)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);

--- a/pages/api/admin/users.js
+++ b/pages/api/admin/users.js
@@ -21,7 +21,7 @@ export default function handler(req, res) {
     if (!email || !password || !firstName || !lastName || !gender) {
       return res.status(400).json({ message: 'missing required fields' });
     }
-    addUser({ email, password, first_name: firstName, last_name: lastName, brand_name: brandName, gender, role: role || 'user' });
+    addUser({ email, password, first_name: firstName, last_name: lastName, brand_name: brandName, gender, role: role || 'customer' });
     return res.status(201).json({ message: 'user created' });
   }
   return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -50,16 +50,24 @@ export const authOptions = {
             last_name: profile?.family_name || nameParts.slice(1).join(' ') || '',
             brand_name: null,
             gender: profile?.gender || '',
-            role: 'user'
+            role: 'customer'
           });
         }
       }
       return true;
     },
-    session({ session }) {
-      const dbUser = findUser(session.user.email);
-      if (dbUser) {
-        session.user.role = dbUser.role;
+    jwt({ token, user }) {
+      if (user) {
+        token.role = user.role;
+      } else if (!token.role) {
+        const dbUser = findUser(token.email);
+        if (dbUser) token.role = dbUser.role;
+      }
+      return token;
+    },
+    session({ session, token }) {
+      if (token && session.user) {
+        session.user.role = token.role;
       }
       return session;
     }

--- a/pages/api/signup.js
+++ b/pages/api/signup.js
@@ -21,12 +21,12 @@ export default function handler(req, res) {
       last_name: lastName,
       brand_name: brandName,
       gender,
-      role: role || 'user',
+      role: role || 'customer',
       verification_token: token
     });
     return res.status(201).json({
       message: 'User created',
-      user: { email, firstName, lastName, brandName, gender, role: role || 'user' },
+      user: { email, firstName, lastName, brandName, gender, role: role || 'customer' },
       token
     });
   } catch (e) {

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -18,7 +18,7 @@ export default function Signup() {
   const [showConfirm, setShowConfirm] = useState(false);
   const [brand, setBrand] = useState('');
   const [gender, setGender] = useState('');
-  const [role, setRole] = useState('user');
+  const [role, setRole] = useState('customer');
   const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
 
@@ -73,7 +73,7 @@ export default function Signup() {
     if (!password) newErrors.password = 'Password is required';
     if (!confirm) newErrors.confirm = 'Confirm password is required';
     if (!gender) newErrors.gender = 'Gender is required';
-    if (role === 'brand' && !brand) newErrors.brand = 'Brand name is required';
+    if (role === 'vendor' && !brand) newErrors.brand = 'Brand name is required';
     if (password && confirm && password !== confirm) {
       newErrors.confirm = 'Passwords do not match';
     }
@@ -88,7 +88,7 @@ export default function Signup() {
         password,
         brandName: brand,
         gender,
-        role: role === 'brand' ? 'admin' : 'user'
+        role
       });
       router.push(`/confirm/${data.token}`);
     } catch (e) {
@@ -223,11 +223,11 @@ export default function Signup() {
             value={role}
             onChange={e => setRole(e.target.value)}
           >
-            <option value="user">User</option>
-            <option value="brand">Brand</option>
+            <option value="customer">Customer</option>
+            <option value="vendor">Vendor</option>
           </select>
         </div>
-        {role === 'brand' && (
+        {role === 'vendor' && (
           <div>
             <input
               className={`input input-bordered w-full ${errors.brand ? 'border-red-500' : ''}`}

--- a/pages/vendor/index.js
+++ b/pages/vendor/index.js
@@ -74,7 +74,7 @@ export default function VendorDashboard() {
   if (!user) {
     return <div className="p-4">Please log in to manage products.</div>;
   }
-  if (user.role !== 'admin') {
+  if (user.role !== 'vendor') {
     return <div className="p-4">Vendor access required.</div>;
   }
 

--- a/pages/vendor/orders.js
+++ b/pages/vendor/orders.js
@@ -15,7 +15,7 @@ export default function VendorOrders() {
   if (!user) {
     return <div className="p-4">Please log in to view orders.</div>;
   }
-  if (user.role !== 'admin') {
+  if (user.role !== 'vendor') {
     return <div className="p-4">Vendor access required.</div>;
   }
 


### PR DESCRIPTION
## Summary
- update default role to `customer`
- store authentication role in JWT via NextAuth callbacks
- sync AppContext with NextAuth session
- adjust signup flow for `customer` and `vendor` roles
- gate vendor pages by `vendor` role

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684282f3b0e4832f98f9a1d9335412c3