### PR TITLE
Add email existence check on signup

### DIFF
--- a/pages/api/check-email.js
+++ b/pages/api/check-email.js
@@ -1,0 +1,10 @@
+import { findUser } from '../../lib/users';
+
+export default function handler(req, res) {
+  const { email } = req.query;
+  if (!email) {
+    return res.status(400).json({ message: 'email required' });
+  }
+  const user = findUser(email);
+  return res.status(200).json({ exists: !!user });
+}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -22,16 +22,29 @@ export default function Signup() {
   const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
 
-  const handleEmailBlur = () => {
+  const handleEmailBlur = async () => {
     setErrors(prev => {
       const next = { ...prev };
       if (email && !emailRegex.test(email)) {
         next.email = 'Invalid email format';
-      } else if (next.email === 'Invalid email format') {
+      } else if (next.email === 'Invalid email format' || next.email === 'Email already registered') {
         delete next.email;
       }
       return next;
     });
+    if (email && emailRegex.test(email)) {
+      try {
+        const res = await fetch(`/api/check-email?email=${encodeURIComponent(email)}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.exists) {
+            setErrors(prev => ({ ...prev, email: 'Email already registered' }));
+          }
+        }
+      } catch (_) {
+        // ignore network errors
+      }
+    }
   };
 
   const handlePasswordBlur = () => {


### PR DESCRIPTION
## Summary
- add API endpoint to check if email already exists
- validate email against DB when input loses focus

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842839a8ee4832fb97c86d13d1f18ab