### PR TITLE
Improve products page loading and layout

### DIFF
--- a/pages/products.js
+++ b/pages/products.js
@@ -31,45 +31,46 @@ export default function Products() {
   });
 
   return (
-    <div className="p-4 max-w-screen-xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">Products</h1>
-      <div className="mb-4 flex gap-4">
-        <div>
-          <label htmlFor="minPrice" className="block text-sm font-medium mb-1">Min Price</label>
-          <input
-            type="number"
-            id="minPrice"
-            className="input input-bordered w-full"
-            value={minPrice}
-            onChange={e => setMinPrice(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="maxPrice" className="block text-sm font-medium mb-1">Max Price</label>
-          <input
-            type="number"
-            id="maxPrice"
-            className="input input-bordered w-full"
-            value={maxPrice}
-            onChange={e => setMaxPrice(e.target.value)}
-          />
-        </div>
-      </div>
-      {loading && (
+    <div className="p-4 max-w-screen-2xl mx-auto">
+      {loading ? (
         <div className="flex justify-center my-4">
           <span className="loading loading-spinner"></span>
         </div>
-      )}
-      {!loading && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {filteredProducts.map(p => (
-            <div key={p.ID} className="border rounded p-4 flex flex-col">
-              <h2 className="font-semibold mb-2">{p.TITLE}</h2>
-              <p className="mb-2">{p.VENDOR}</p>
-              <button className="btn btn-sm btn-primary mt-auto" onClick={() => addToCart(p)}>Add to Cart</button>
+      ) : (
+        <>
+          <h1 className="text-3xl font-bold mb-4">Products</h1>
+          <div className="mb-4 flex gap-4">
+            <div>
+              <label htmlFor="minPrice" className="block text-sm font-medium mb-1">Min Price</label>
+              <input
+                type="number"
+                id="minPrice"
+                className="input input-bordered w-full"
+                value={minPrice}
+                onChange={e => setMinPrice(e.target.value)}
+              />
             </div>
-          ))}
-        </div>
+            <div>
+              <label htmlFor="maxPrice" className="block text-sm font-medium mb-1">Max Price</label>
+              <input
+                type="number"
+                id="maxPrice"
+                className="input input-bordered w-full"
+                value={maxPrice}
+                onChange={e => setMaxPrice(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {filteredProducts.map(p => (
+              <div key={p.ID} className="border rounded p-4 flex flex-col">
+                <h2 className="font-semibold mb-2">{p.TITLE}</h2>
+                <p className="mb-2">{p.VENDOR}</p>
+                <button className="btn btn-sm btn-primary mt-auto" onClick={() => addToCart(p)}>Add to Cart</button>
+              </div>
+            ))}
+          </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- hide entire products page content while loading
- enlarge products page width

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842a2bdc1e8832f910df78a8288152d