### PR TITLE
Add responsive mobile menu

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -88,7 +88,7 @@ export default function Header() {
           )}
         </form>
       </div>
-      <div className="flex-none gap-2">
+      <div className="hidden md:flex flex-none gap-2">
         <div className="dropdown dropdown-hover">
           <label tabIndex={0} className="btn btn-outline">Categories</label>
           <ul tabIndex={0} className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
@@ -121,6 +121,55 @@ export default function Header() {
             <Link href="/signup" className="btn btn-primary ml-2">Signup</Link>
           </>
         )}
+      </div>
+
+      <div className="md:hidden flex-none">
+        <div className="dropdown dropdown-end">
+          <label tabIndex={0} className="btn btn-square btn-ghost">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </label>
+          <ul tabIndex={0} className="menu dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+            <li>
+              <Link href="/cart" className="justify-between">
+                Cart
+                {itemCount > 0 && (
+                  <span className="badge badge-sm badge-primary ml-2">{itemCount}</span>
+                )}
+              </Link>
+            </li>
+            {categories.length > 0 && (
+              <li>
+                <details>
+                  <summary>Categories</summary>
+                  <ul>
+                    {categories.map(cat => (
+                      <li key={cat}>
+                        <Link href={`/?type=${encodeURIComponent(cat)}`}>{cat}</Link>
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              </li>
+            )}
+            {user ? (
+              <>
+                {user.role === 'admin' ? (
+                  <li><Link href="/admin">Admin</Link></li>
+                ) : (
+                  <li><Link href="/orders">Orders</Link></li>
+                )}
+                <li><button type="button" onClick={logout}>Logout</button></li>
+              </>
+            ) : (
+              <>
+                <li><Link href="/login">Login</Link></li>
+                <li><Link href="/signup">Signup</Link></li>
+              </>
+            )}
+          </ul>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- add a hamburger dropdown for small screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842a2c68854832f93a76ab3c8a3fd32