### PR TITLE
Add initial unit tests setup

### DIFF
--- a/__tests__/Header.test.js
+++ b/__tests__/Header.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Header from '../components/Header';
+import { AppContext } from '../contexts/AppContext';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: jest.fn() })
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null }),
+  signOut: jest.fn()
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }) => <a href={href}>{children}</a>
+}));
+
+const renderWithContext = (ui, { cart = [], user = null } = {}) => {
+  const value = { cart, user };
+  return render(
+    <AppContext.Provider value={value}>{ui}</AppContext.Provider>
+  );
+};
+
+test('shows login and signup when unauthenticated', () => {
+  renderWithContext(<Header />);
+  expect(screen.getByText('Login')).toBeInTheDocument();
+  expect(screen.getByText('Signup')).toBeInTheDocument();
+});
+
+test('shows admin and cart count when authenticated as admin', () => {
+  const user = { role: 'admin', firstName: 'Alice', email: 'a@a.com' };
+  const cart = [{ ID: 1, qty: 2 }];
+  renderWithContext(<Header />, { user, cart });
+  expect(screen.getByText('Admin')).toBeInTheDocument();
+  expect(screen.getByText('2')).toBeInTheDocument();
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+export default {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '^next/link$': '<rootDir>/test-utils/NextLink.js'
+  }
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "next lint",
     "migrate": "node scripts/migrate.mjs",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "jest"
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",
@@ -33,6 +34,9 @@
     "postcss": "^8.4.38",
     "prettier": "^3.5.3",
     "prisma": "^6.9.0",
-    "tailwindcss": "^3.4.1"
+    "tailwindcss": "^3.4.1",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/jest-dom": "^6.4.2"
   }
 }

--- a/test-utils/NextLink.js
+++ b/test-utils/NextLink.js
@@ -1,0 +1,3 @@
+export default function Link({ href, children }) {
+  return <a href={href}>{children}</a>;
+}


### PR DESCRIPTION
## Summary
- add Jest config and DOM setup
- add tests for `Header` component
- mock Next.js modules for tests
- include Next.js `Link` helper for Jest
- add `test` script and devDependencies

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a2d2b64c832fa65961587327ae8f