### PR TITLE
Improve products page design

### DIFF
--- a/pages/products.js
+++ b/pages/products.js
@@ -31,7 +31,7 @@ export default function Products() {
   });
 
   return (
-    <div className="p-4 max-w-screen-2xl mx-auto">
+    <div className="p-6 w-full bg-gradient-to-br from-base-200 to-base-100 min-h-screen">
       {loading ? (
         <div className="flex justify-center my-4">
           <span className="loading loading-spinner"></span>
@@ -71,13 +71,16 @@ export default function Products() {
               />
             </div>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
             {filteredProducts.map((p) => (
-              <div key={p.ID} className="border rounded p-4 flex flex-col">
-                <h2 className="font-semibold mb-2">{p.TITLE}</h2>
-                <p className="mb-2">{p.VENDOR}</p>
+              <div
+                key={p.ID}
+                className="bg-base-100 rounded-lg shadow-md p-4 flex flex-col hover:shadow-xl transition"
+              >
+                <h2 className="font-semibold text-primary mb-1">{p.TITLE}</h2>
+                <p className="mb-2 text-sm text-base-content/60">{p.VENDOR}</p>
                 <button
-                  className="btn btn-sm btn-primary mt-auto"
+                  className="btn btn-sm btn-secondary mt-auto"
                   onClick={() => addToCart(p)}
                 >
                   Add to Cart

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -29,7 +29,7 @@ export default function ProductDetail() {
   if (!product) return <div className="p-4">Loading...</div>;
 
   return (
-    <div className="p-4 max-w-3xl mx-auto">
+    <div className="p-6 max-w-5xl mx-auto bg-base-100 rounded-box shadow-md">
       <h1 className="text-2xl font-bold mb-4">{product.TITLE}</h1>
       <div className="mb-4 w-full flex justify-center">
         {product.FEATURED_IMAGE?.url ? (


### PR DESCRIPTION
## Summary
- enlarge product listing container and add a gradient background
- restyle product cards with DaisyUI colors
- widen the product detail page and add a subtle card layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842a5be0a08832fb5d9e40f42d29a0d