### PR TITLE
Fix cart badge clipping

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -113,12 +113,27 @@ export default function Header() {
             ))}
           </ul>
         </div>
-        <div className="indicator mr-2">
-          <Link href="/cart" className="btn btn-ghost">
+        <div className="relative mr-2">
+          <Link href="/cart" className="btn btn-ghost flex items-center gap-1">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              className="w-5 h-5"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+              />
+            </svg>
             Cart
           </Link>
           {itemCount > 0 && (
-            <span className="indicator-item badge badge-sm badge-primary">
+            <span className="badge badge-sm badge-primary absolute -top-2 -right-2">
               {itemCount}
             </span>
           )}
@@ -160,10 +175,29 @@ export default function Header() {
           </label>
           <ul tabIndex={0} className="menu dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
             <li>
-              <div className="indicator">
-                <Link href="/cart">Cart</Link>
+              <div className="relative flex items-center">
+                <Link href="/cart" className="flex items-center gap-1">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    className="w-5 h-5"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+                    />
+                  </svg>
+                  Cart
+                </Link>
                 {itemCount > 0 && (
-                  <span className="indicator-item badge badge-sm badge-primary">{itemCount}</span>
+                  <span className="badge badge-sm badge-primary absolute -top-2 -right-2">
+                    {itemCount}
+                  </span>
                 )}
               </div>
             </li>


### PR DESCRIPTION
## Summary
- adjust cart badge position so it isn't clipped
- include a shopping cart icon next to the Cart text in desktop and mobile menus

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b20ca7c0832f94e845ede0627752