### PR TITLE
Update cart badge position

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -133,7 +133,7 @@ export default function Header() {
             Cart
           </Link>
           {itemCount > 0 && (
-            <span className="badge badge-sm badge-primary absolute -top-2 -right-2">
+            <span className="badge badge-sm badge-secondary absolute top-0 -right-2">
               {itemCount}
             </span>
           )}
@@ -195,7 +195,7 @@ export default function Header() {
                   Cart
                 </Link>
                 {itemCount > 0 && (
-                  <span className="badge badge-sm badge-primary absolute -top-2 -right-2">
+                  <span className="badge badge-sm badge-secondary absolute top-0 -right-2">
                     {itemCount}
                   </span>
                 )}


### PR DESCRIPTION
## Summary
- reposition cart badge to prevent clipping
- use `badge-secondary` for new color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842b3ba5a14832fbd6083bff0ec82a9