### PR TITLE
Improve cart badge styling

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -132,8 +132,8 @@ export default function Header() {
             </svg>
             Cart
           </Link>
-          {itemCount > 0 && (
-            <span className="badge badge-sm badge-secondary absolute top-0 -right-2">
+            {itemCount > 0 && (
+            <span className="badge badge-primary absolute top-0 -right-2 w-5 h-5 flex items-center justify-center rounded-full text-white text-xs">
               {itemCount}
             </span>
           )}
@@ -195,7 +195,7 @@ export default function Header() {
                   Cart
                 </Link>
                 {itemCount > 0 && (
-                  <span className="badge badge-sm badge-secondary absolute top-0 -right-2">
+                  <span className="badge badge-primary absolute top-0 -right-2 w-5 h-5 flex items-center justify-center rounded-full text-white text-xs">
                     {itemCount}
                   </span>
                 )}


### PR DESCRIPTION
## Summary
- center cart badge text and make it circular
- switch the badge color to primary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842c5cf3bc4832f83a7a9cb3cacb15d