### PR TITLE
Implement role-based auth with initial super-admin

### DIFF
--- a/__tests__/Header.test.js
+++ b/__tests__/Header.test.js
@@ -38,7 +38,7 @@ test('shows login and signup when unauthenticated', () => {
 });
 
 test('shows admin and cart count when authenticated as admin', () => {
-  const user = { role: 'admin', firstName: 'Alice', email: 'a@a.com' };
+  const user = { role: 'super-admin', firstName: 'Alice', email: 'a@a.com' };
   const cart = [{ ID: 1, qty: 2 }];
   mockUseSession.mockReturnValue({ data: { user } });
   renderWithContext(<Header />, { cart });

--- a/components/Header.js
+++ b/components/Header.js
@@ -140,7 +140,7 @@ export default function Header() {
         </div>
         {user ? (
           <>
-            {user.role === 'admin' ? (
+            {user.role === 'super-admin' ? (
               <Link href="/admin" className="btn btn-ghost mr-2">
                 Admin
               </Link>
@@ -217,7 +217,7 @@ export default function Header() {
             )}
             {user ? (
               <>
-                {user.role === 'admin' ? (
+                {user.role === 'super-admin' ? (
                   <li><Link href="/admin">Admin</Link></li>
                 ) : (
                   <li><Link href="/orders">Orders</Link></li>

--- a/lib/db.js
+++ b/lib/db.js
@@ -46,7 +46,7 @@ export function getDb() {
       password TEXT,
       brand_name TEXT,
       gender TEXT,
-      role TEXT DEFAULT 'customer',
+      role TEXT DEFAULT 'user',
       verified INTEGER DEFAULT 0,
       verification_token TEXT,
       reset_token TEXT,

--- a/lib/users.js
+++ b/lib/users.js
@@ -7,7 +7,7 @@ export function addUser({
   last_name,
   brand_name,
   gender,
-  role = 'customer',
+  role = 'user',
   verification_token,
 }) {
   const db = getDb();

--- a/lib/withRole.js
+++ b/lib/withRole.js
@@ -1,0 +1,14 @@
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../pages/api/auth/[...nextauth]';
+
+export function withRole(roles) {
+  return (handler) => async (req, res) => {
+    const session = await getServerSession(req, res, authOptions);
+    const role = session?.user?.role;
+    if (!session || !role || !roles.includes(role)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    req.user = session.user;
+    return handler(req, res);
+  };
+}

--- a/pages/admin/approvals.js
+++ b/pages/admin/approvals.js
@@ -30,7 +30,7 @@ export default function Approvals() {
 
   if (!user)
     return <div className="p-4">Please log in to view vendor products.</div>;
-  if (user.role !== 'admin')
+  if (user.role !== 'super-admin')
     return <div className="p-4">Admin access required.</div>;
 
   return (

--- a/pages/admin/categories.js
+++ b/pages/admin/categories.js
@@ -59,7 +59,7 @@ export default function Categories() {
 
   if (!user)
     return <div className="p-4">Please log in to view categories.</div>;
-  if (user.role !== 'admin')
+  if (user.role !== 'super-admin')
     return <div className="p-4">Admin access required.</div>;
 
   return (

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -90,7 +90,7 @@ export default function Admin() {
   if (!user) {
     return <div className="p-4">Please log in to view your products.</div>;
   }
-  if (user.role !== 'admin') {
+  if (user.role !== 'super-admin') {
     return <div className="p-4">Admin access required.</div>;
   }
 

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -40,7 +40,7 @@ export default function ManageUsers() {
   };
 
   if (!user) return <div className="p-4">Please log in to view users.</div>;
-  if (user.role !== 'admin')
+  if (user.role !== 'super-admin')
     return <div className="p-4">Admin access required.</div>;
 
   return (
@@ -57,8 +57,8 @@ export default function ManageUsers() {
               onChange={(e) => changeRole(u.email, e.target.value)}
             >
               <option value="user">user</option>
-              <option value="vendor">vendor</option>
-              <option value="admin">admin</option>
+              <option value="brand">brand</option>
+              <option value="super-admin">super-admin</option>
             </select>
             <button onClick={() => remove(u.email)} className="btn btn-sm">
               Delete

--- a/pages/api/admin/categories.js
+++ b/pages/api/admin/categories.js
@@ -4,8 +4,9 @@ import {
   renameCategory,
   removeCategory,
 } from '../../../lib/products';
+import { withRole } from '../../../lib/withRole';
 
-export default function handler(req, res) {
+function handler(req, res) {
   if (req.method === 'GET') {
     return res.status(200).json(getCategories());
   }
@@ -30,3 +31,6 @@ export default function handler(req, res) {
   }
   return res.status(405).json({ message: 'Method Not Allowed' });
 }
+
+
+export default withRole(['super-admin'])(handler);

--- a/pages/api/admin/products.js
+++ b/pages/api/admin/products.js
@@ -8,6 +8,7 @@ import { getProductById } from '../../../lib/db.js';
 import formidable from 'formidable';
 import fs from 'fs';
 import path from 'path';
+import { withRole } from '../../../lib/withRole';
 
 export const config = {
   api: {
@@ -25,7 +26,7 @@ function parseForm(req) {
   });
 }
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (req.method === 'POST' || req.method === 'PUT') {
     const { fields, files } = await parseForm(req);
     const {
@@ -115,3 +116,6 @@ export default async function handler(req, res) {
 
   return res.status(405).json({ message: 'Method Not Allowed' });
 }
+
+
+export default withRole(['brand','super-admin'])(handler);

--- a/pages/api/admin/users.js
+++ b/pages/api/admin/users.js
@@ -4,8 +4,9 @@ import {
   deleteUser,
   addUser,
 } from '../../../lib/users';
+import { withRole } from '../../../lib/withRole';
 
-export default function handler(req, res) {
+function handler(req, res) {
   if (req.method === 'GET') {
     return res.status(200).json(getAllUsers());
   }
@@ -35,9 +36,12 @@ export default function handler(req, res) {
       last_name: lastName,
       brand_name: brandName,
       gender,
-      role: role || 'customer',
+      role: role || 'user',
     });
     return res.status(201).json({ message: 'user created' });
   }
   return res.status(405).json({ message: 'Method Not Allowed' });
 }
+
+
+export default withRole(['super-admin'])(handler);

--- a/pages/api/admin/vendor-products.js
+++ b/pages/api/admin/vendor-products.js
@@ -3,8 +3,9 @@ import {
   approveProduct,
   rejectProduct,
 } from '../../../lib/products';
+import { withRole } from '../../../lib/withRole';
 
-export default function handler(req, res) {
+function handler(req, res) {
   if (req.method === 'GET') {
     return res.status(200).json(getPendingProducts());
   }
@@ -24,3 +25,6 @@ export default function handler(req, res) {
   }
   return res.status(405).json({ message: 'Method Not Allowed' });
 }
+
+
+export default withRole(['super-admin'])(handler);

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -51,7 +51,7 @@ export const authOptions = {
               profile?.family_name || nameParts.slice(1).join(' ') || '',
             brand_name: null,
             gender: profile?.gender || '',
-            role: 'customer',
+            role: 'user',
           });
         }
       }

--- a/pages/api/orders.js
+++ b/pages/api/orders.js
@@ -5,8 +5,9 @@ import {
   getOrdersForVendor,
 } from '../../lib/orders.js';
 import { findUser } from '../../lib/users.js';
+import { withRole } from '../../lib/withRole';
 
-export default function handler(req, res) {
+function handler(req, res) {
   if (req.method === 'POST') {
     const { email, items, total } = req.body;
     if (!email || !items) {
@@ -21,7 +22,7 @@ export default function handler(req, res) {
     if (!email) return res.status(400).json({ message: 'email required' });
     const user = findUser(email);
     if (!user) return res.status(404).json({ message: 'user not found' });
-    if (user.role === 'admin') {
+    if (user.role === 'super-admin') {
       return res.status(200).json(getAllOrders());
     }
     if (user.role === 'brand') {
@@ -32,3 +33,6 @@ export default function handler(req, res) {
 
   return res.status(405).json({ message: 'Method Not Allowed' });
 }
+
+
+export default withRole(['user','brand','super-admin'])(handler);

--- a/pages/api/signup.js
+++ b/pages/api/signup.js
@@ -22,7 +22,7 @@ export default function handler(req, res) {
       last_name: lastName,
       brand_name: brandName,
       gender,
-      role: role || 'customer',
+      role: role || 'user',
       verification_token: token,
     });
     return res.status(201).json({
@@ -33,7 +33,7 @@ export default function handler(req, res) {
         lastName,
         brandName,
         gender,
-        role: role || 'customer',
+        role: role || 'user',
       },
       token,
     });

--- a/pages/api/vendor/orders.js
+++ b/pages/api/vendor/orders.js
@@ -1,6 +1,7 @@
 import { getOrdersForVendor } from '../../../lib/orders';
+import { withRole } from '../../../lib/withRole';
 
-export default function handler(req, res) {
+function handler(req, res) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
@@ -11,3 +12,6 @@ export default function handler(req, res) {
   const orders = getOrdersForVendor(vendor);
   return res.status(200).json(orders);
 }
+
+
+export default withRole(['brand'])(handler);

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -25,7 +25,7 @@ export default function Orders() {
             <p>
               Order #{o.id} - {o.status}
             </p>
-            {(user.role === 'admin' || user.role === 'brand') && (
+            {(user.role === 'super-admin' || user.role === 'brand') && (
               <p className="text-sm text-gray-600">Customer: {o.user_email}</p>
             )}
             <ul className="list-disc pl-4 text-sm mb-1">

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -18,7 +18,7 @@ export default function Signup() {
   const [showConfirm, setShowConfirm] = useState(false);
   const [brand, setBrand] = useState('');
   const [gender, setGender] = useState('');
-  const [role, setRole] = useState('customer');
+  const [role, setRole] = useState('user');
   const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
 
@@ -94,7 +94,7 @@ export default function Signup() {
     if (!password) newErrors.password = 'Password is required';
     if (!confirm) newErrors.confirm = 'Confirm password is required';
     if (!gender) newErrors.gender = 'Gender is required';
-    if (role === 'vendor' && !brand) newErrors.brand = 'Brand name is required';
+    if (role === 'brand' && !brand) newErrors.brand = 'Brand name is required';
     if (password && confirm && password !== confirm) {
       newErrors.confirm = 'Passwords do not match';
     }
@@ -318,11 +318,11 @@ export default function Signup() {
             value={role}
             onChange={(e) => setRole(e.target.value)}
           >
-            <option value="customer">Customer</option>
-            <option value="vendor">Vendor</option>
+            <option value="user">User</option>
+            <option value="brand">Brand</option>
           </select>
         </div>
-        {role === 'vendor' && (
+        {role === 'brand' && (
           <div>
             <input
               className={`input input-bordered w-full ${errors.brand ? 'border-red-500' : ''}`}

--- a/pages/vendor/index.js
+++ b/pages/vendor/index.js
@@ -93,8 +93,8 @@ export default function VendorDashboard() {
   if (!user) {
     return <div className="p-4">Please log in to manage products.</div>;
   }
-  if (user.role !== 'vendor') {
-    return <div className="p-4">Vendor access required.</div>;
+  if (user.role !== 'brand') {
+    return <div className="p-4">Brand access required.</div>;
   }
 
   return (

--- a/pages/vendor/orders.js
+++ b/pages/vendor/orders.js
@@ -17,8 +17,8 @@ export default function VendorOrders() {
   if (!user) {
     return <div className="p-4">Please log in to view orders.</div>;
   }
-  if (user.role !== 'vendor') {
-    return <div className="p-4">Vendor access required.</div>;
+  if (user.role !== 'brand') {
+    return <div className="p-4">Brand access required.</div>;
   }
 
   return (

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -55,4 +55,23 @@ db.exec(`CREATE TABLE IF NOT EXISTS orders (
   FOREIGN KEY(user_email) REFERENCES users(email)
 )`);
 
+const adminExists = db
+  .prepare("SELECT email FROM users WHERE role = 'super-admin'")
+  .get();
+if (!adminExists) {
+  db.prepare(
+    `INSERT INTO users (email, first_name, last_name, password, brand_name, gender, role)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    'admin@example.com',
+    'Super',
+    'Admin',
+    'password',
+    null,
+    '',
+    'super-admin'
+  );
+  console.log('Seeded super-admin user: admin@example.com / password');
+}
+
 console.log('Database migrated');


### PR DESCRIPTION
## Summary
- add a role-based middleware helper
- seed an initial `super-admin` user during migration
- include roles in NextAuth OAuth flow
- update role names across pages and API routes
- restrict API routes with `withRole`
- adjust header and tests for new roles

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685290dd8d84832f95129e6a85e558df