### PR TITLE
Implement user order history and category browsing

### DIFF
--- a/__tests__/Header.test.js
+++ b/__tests__/Header.test.js
@@ -4,19 +4,19 @@ import Header from '../components/Header';
 import { AppContext } from '../contexts/AppContext';
 
 jest.mock('next/router', () => ({
-  useRouter: () => ({ push: jest.fn() })
+  useRouter: () => ({ push: jest.fn() }),
 }));
 
 const mockUseSession = jest.fn();
 jest.mock('next-auth/react', () => ({
   __esModule: true,
   useSession: (...args) => mockUseSession(...args),
-  signOut: jest.fn()
+  signOut: jest.fn(),
 }));
 
 jest.mock('next/link', () => ({
   __esModule: true,
-  default: ({ href, children }) => <a href={href}>{children}</a>
+  default: ({ href, children }) => <a href={href}>{children}</a>,
 }));
 
 beforeEach(() => {
@@ -25,9 +25,7 @@ beforeEach(() => {
 });
 const renderWithContext = (ui, { cart = [], user = null } = {}) => {
   const value = { cart, user };
-  return render(
-    <AppContext.Provider value={value}>{ui}</AppContext.Provider>
-  );
+  return render(<AppContext.Provider value={value}>{ui}</AppContext.Provider>);
 };
 
 test('shows login and signup when unauthenticated', () => {
@@ -44,4 +42,11 @@ test('shows admin and cart count when authenticated as admin', () => {
   renderWithContext(<Header />, { cart });
   expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
   expect(screen.getAllByText('2').length).toBeGreaterThan(0);
+});
+
+test('shows orders link when authenticated as customer', () => {
+  const user = { role: 'customer', firstName: 'Bob', email: 'b@b.com' };
+  mockUseSession.mockReturnValue({ data: { user } });
+  renderWithContext(<Header />);
+  expect(screen.getAllByText('Orders').length).toBeGreaterThan(0);
 });

--- a/components/Header.js
+++ b/components/Header.js
@@ -17,10 +17,10 @@ export default function Header() {
   useEffect(() => {
     async function loadCategories() {
       try {
-        const res = await fetch('/api/search');
+        const res = await fetch('/api/categories');
         if (res.ok) {
           const data = await res.json();
-          setCategories(data.productTypes || []);
+          setCategories(data || []);
         }
       } catch (err) {
         console.error('Failed to load categories', err);
@@ -108,7 +108,9 @@ export default function Header() {
           >
             {categories.map((cat) => (
               <li key={cat}>
-                <Link href={`/?type=${encodeURIComponent(cat)}`}>{cat}</Link>
+                <Link href={`/categories/${encodeURIComponent(cat)}`}>
+                  {cat}
+                </Link>
               </li>
             ))}
           </ul>
@@ -132,7 +134,7 @@ export default function Header() {
             </svg>
             Cart
           </Link>
-            {itemCount > 0 && (
+          {itemCount > 0 && (
             <span className="badge badge-primary absolute top-0 -right-2 w-5 h-5 flex items-center justify-center rounded-full text-white text-xs">
               {itemCount}
             </span>
@@ -145,7 +147,7 @@ export default function Header() {
                 Admin
               </Link>
             ) : (
-              <Link href="/orders" className="btn btn-ghost mr-2">
+              <Link href="/user/orders" className="btn btn-ghost mr-2">
                 Orders
               </Link>
             )}
@@ -169,11 +171,25 @@ export default function Header() {
       <div className="md:hidden flex-none">
         <div className="dropdown dropdown-end">
           <label tabIndex={0} className="btn btn-square btn-ghost">
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M4 6h16M4 12h16M4 18h16"
+              />
             </svg>
           </label>
-          <ul tabIndex={0} className="menu dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+          <ul
+            tabIndex={0}
+            className="menu dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52"
+          >
             <li>
               <div className="relative flex items-center">
                 <Link href="/cart" className="flex items-center gap-1">
@@ -206,9 +222,11 @@ export default function Header() {
                 <details>
                   <summary>Categories</summary>
                   <ul>
-                    {categories.map(cat => (
+                    {categories.map((cat) => (
                       <li key={cat}>
-                        <Link href={`/?type=${encodeURIComponent(cat)}`}>{cat}</Link>
+                        <Link href={`/categories/${encodeURIComponent(cat)}`}>
+                          {cat}
+                        </Link>
                       </li>
                     ))}
                   </ul>
@@ -218,16 +236,28 @@ export default function Header() {
             {user ? (
               <>
                 {user.role === 'admin' ? (
-                  <li><Link href="/admin">Admin</Link></li>
+                  <li>
+                    <Link href="/admin">Admin</Link>
+                  </li>
                 ) : (
-                  <li><Link href="/orders">Orders</Link></li>
+                  <li>
+                    <Link href="/user/orders">Orders</Link>
+                  </li>
                 )}
-                <li><button type="button" onClick={logout}>Logout</button></li>
+                <li>
+                  <button type="button" onClick={logout}>
+                    Logout
+                  </button>
+                </li>
               </>
             ) : (
               <>
-                <li><Link href="/login">Login</Link></li>
-                <li><Link href="/signup">Signup</Link></li>
+                <li>
+                  <Link href="/login">Login</Link>
+                </li>
+                <li>
+                  <Link href="/signup">Signup</Link>
+                </li>
               </>
             )}
           </ul>

--- a/pages/api/categories.js
+++ b/pages/api/categories.js
@@ -1,0 +1,9 @@
+import { getCategories } from '../../lib/products';
+
+export default function handler(req, res) {
+  if (req.method === 'GET') {
+    const cats = getCategories().map((c) => c.name);
+    return res.status(200).json(cats);
+  }
+  return res.status(405).json({ message: 'Method Not Allowed' });
+}

--- a/pages/api/search.js
+++ b/pages/api/search.js
@@ -30,6 +30,7 @@ export default async function handler(req, res) {
     q,
     filterByVendor,
     filterByType,
+    filterByCategory,
     inStock,
     sortBy,
     page = 1,
@@ -66,6 +67,11 @@ export default async function handler(req, res) {
   if (filterByType && filterByType !== 'All') {
     results = results.filter(
       (product) => product.PRODUCT_TYPE === filterByType
+    );
+  }
+  if (filterByCategory && filterByCategory !== 'All') {
+    results = results.filter(
+      (product) => product.CATEGORY === filterByCategory
     );
   }
   if (inStock === 'true') {
@@ -126,6 +132,9 @@ export default async function handler(req, res) {
   const productTypes = [
     ...new Set(productsCache.map((p) => p.PRODUCT_TYPE).filter(Boolean)),
   ].sort();
+  const categories = [
+    ...new Set(productsCache.map((p) => p.CATEGORY).filter(Boolean)),
+  ].sort();
 
   res.status(200).json({
     results: paginated,
@@ -135,5 +144,6 @@ export default async function handler(req, res) {
     totalPages: Math.ceil(total / pageSizeInt),
     vendors,
     productTypes,
+    categories,
   });
 }

--- a/pages/api/user/orders.js
+++ b/pages/api/user/orders.js
@@ -1,0 +1,15 @@
+import { getOrdersForUser } from '../../../lib/orders.js';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const orders = getOrdersForUser(session.user.email);
+  return res.status(200).json(orders);
+}

--- a/pages/categories/[name].js
+++ b/pages/categories/[name].js
@@ -1,0 +1,61 @@
+import { useRouter } from 'next/router';
+import { useContext, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { AppContext } from '../../contexts/AppContext';
+
+export default function CategoryPage() {
+  const router = useRouter();
+  const { name } = router.query;
+  const { addToCart } = useContext(AppContext);
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!name) return;
+    async function load() {
+      setLoading(true);
+      const res = await fetch(
+        `/api/search?filterByCategory=${encodeURIComponent(name)}`
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setProducts(data.results || []);
+      }
+      setLoading(false);
+    }
+    load();
+  }, [name]);
+
+  if (!name) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 max-w-screen-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Category: {name}</h1>
+      {loading && <div>Loading...</div>}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        {products.map((p) => (
+          <div
+            key={p.ID}
+            className="bg-base-100 rounded-lg shadow-md p-4 flex flex-col"
+          >
+            <Link
+              href={`/products/${p.ID}`}
+              className="font-semibold mb-2 hover:underline"
+            >
+              {p.TITLE}
+            </Link>
+            <button
+              className="btn btn-sm btn-primary mt-auto"
+              onClick={() => addToCart(p)}
+            >
+              Add to Cart
+            </button>
+          </div>
+        ))}
+      </div>
+      {products.length === 0 && !loading && (
+        <p>No products found in this category.</p>
+      )}
+    </div>
+  );
+}

--- a/pages/categories/index.js
+++ b/pages/categories/index.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function Categories() {
+  const [categories, setCategories] = useState([]);
+  useEffect(() => {
+    fetch('/api/categories')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setCategories(data));
+  }, []);
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Categories</h1>
+      <ul className="list-disc pl-4 space-y-1">
+        {categories.map((c) => (
+          <li key={c}>
+            <Link href={`/categories/${encodeURIComponent(c)}`}>{c}</Link>
+          </li>
+        ))}
+        {categories.length === 0 && <li>No categories found.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/pages/user/orders.js
+++ b/pages/user/orders.js
@@ -1,0 +1,42 @@
+import { useContext, useEffect, useState } from 'react';
+import { AppContext } from '../../contexts/AppContext';
+
+export default function UserOrders() {
+  const { user } = useContext(AppContext);
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+    fetch('/api/user/orders')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setOrders(data));
+  }, [user]);
+
+  if (!user) {
+    return <div className="p-4">Please log in to view orders.</div>;
+  }
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">My Orders</h1>
+      <ul className="space-y-2">
+        {orders.map((o) => (
+          <li key={o.id} className="border p-2">
+            <p>
+              Order #{o.id} - {o.status}
+            </p>
+            <ul className="list-disc pl-4 text-sm mb-1">
+              {o.items.map((item) => (
+                <li key={item.ID}>
+                  {item.TITLE} x {item.qty}
+                </li>
+              ))}
+            </ul>
+            <p>Total: £{o.total}</p>
+          </li>
+        ))}
+        {orders.length === 0 && <li>No orders found.</li>}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/api/categories` for listing product categories
- support filtering by category in search API
- fetch categories in header and link to `/categories`
- update orders link to `/user/orders`
- create category list and detail pages
- add user order history page and API
- test header updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68529104f380832fb2a8ee2134ab9df9