### PR TITLE
Implement brand management pages and APIs

### DIFF
--- a/lib/orders.js
+++ b/lib/orders.js
@@ -33,3 +33,20 @@ export function getOrdersForVendor(vendor) {
     .map((row) => ({ ...row, items: JSON.parse(row.items) }))
     .filter((order) => order.items.some((item) => item.VENDOR === vendor));
 }
+
+export function hasOrdersForProduct(productId) {
+  const db = getDb();
+  const stmt = db.prepare('SELECT items FROM orders');
+  const rows = stmt.all();
+  for (const row of rows) {
+    try {
+      const items = JSON.parse(row.items);
+      if (items.some((item) => String(item.ID) === String(productId))) {
+        return true;
+      }
+    } catch (_) {
+      // ignore parse errors
+    }
+  }
+  return false;
+}

--- a/pages/api/brand/categories.js
+++ b/pages/api/brand/categories.js
@@ -1,0 +1,16 @@
+import { getCategories, createCategory } from '../../../lib/products';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const { name } = req.body || {};
+  if (!name) return res.status(400).json({ message: 'name required' });
+  const exists = getCategories().find(
+    (c) => c.name.toLowerCase() === name.toLowerCase()
+  );
+  if (!exists) {
+    createCategory(name);
+  }
+  return res.status(201).json({ message: 'ok' });
+}

--- a/pages/api/brand/orders.js
+++ b/pages/api/brand/orders.js
@@ -1,0 +1,13 @@
+import { getOrdersForVendor } from '../../../lib/orders';
+
+export default function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const { vendor } = req.query;
+  if (!vendor) {
+    return res.status(400).json({ message: 'vendor required' });
+  }
+  const orders = getOrdersForVendor(vendor);
+  return res.status(200).json(orders);
+}

--- a/pages/api/brand/products/[id].js
+++ b/pages/api/brand/products/[id].js
@@ -1,0 +1,56 @@
+import { updateProduct, deleteProduct, loadAndIndexProducts } from '../../../../lib/products';
+import { getProductById } from '../../../../lib/db.js';
+import { hasOrdersForProduct } from '../../../../lib/orders';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  if (!id) return res.status(400).json({ message: 'id required' });
+
+  if (req.method === 'PUT') {
+    const existing = getProductById(String(id));
+    if (!existing) return res.status(404).json({ message: 'Not found' });
+    const {
+      title,
+      vendor,
+      description,
+      product_type,
+      tags,
+      category,
+      quantity,
+      min_price,
+      max_price,
+      currency,
+    } = req.body || {};
+    updateProduct({
+      id: String(id),
+      title: title ?? existing.title,
+      vendor: vendor ?? existing.vendor,
+      description: description ?? existing.description,
+      product_type: product_type ?? existing.product_type,
+      tags: tags ?? existing.tags,
+      category: category ?? existing.category,
+      quantity:
+        typeof quantity !== 'undefined' ? parseInt(quantity, 10) : existing.quantity,
+      min_price: typeof min_price !== 'undefined' ? parseFloat(min_price) : existing.min_price,
+      max_price: typeof max_price !== 'undefined' ? parseFloat(max_price) : existing.max_price,
+      currency: currency ?? existing.currency,
+      status: existing.status,
+      images: existing.images,
+    });
+    await loadAndIndexProducts();
+    return res.status(200).json({ message: 'product updated' });
+  }
+
+  if (req.method === 'DELETE') {
+    const existing = getProductById(String(id));
+    if (!existing) return res.status(404).json({ message: 'Not found' });
+    if (existing.quantity > 0 || hasOrdersForProduct(String(id))) {
+      return res.status(400).json({ message: 'cannot delete product with stock or orders' });
+    }
+    deleteProduct(String(id));
+    await loadAndIndexProducts();
+    return res.status(200).json({ message: 'product deleted' });
+  }
+
+  return res.status(405).json({ message: 'Method Not Allowed' });
+}

--- a/pages/api/brand/products/index.js
+++ b/pages/api/brand/products/index.js
@@ -1,0 +1,49 @@
+import { addProduct, loadAndIndexProducts } from '../../../../lib/products';
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    const { vendor } = req.query;
+    if (!vendor) return res.status(400).json({ message: 'vendor required' });
+    const { products } = await loadAndIndexProducts();
+    const filtered = products.filter((p) => p.VENDOR === vendor);
+    return res.status(200).json(filtered);
+  }
+
+  if (req.method === 'POST') {
+    const {
+      id,
+      title,
+      vendor,
+      description,
+      product_type,
+      tags,
+      category,
+      quantity,
+      min_price,
+      max_price,
+      currency,
+    } = req.body || {};
+    if (!id || !title || !vendor) {
+      return res.status(400).json({ message: 'id, title, vendor required' });
+    }
+    addProduct({
+      id: String(id),
+      title,
+      vendor,
+      description,
+      product_type,
+      tags,
+      category,
+      quantity: quantity ? parseInt(quantity, 10) : 0,
+      min_price: parseFloat(min_price || 0),
+      max_price: parseFloat(max_price || 0),
+      currency: currency || 'USD',
+      status: 'approved',
+      images: JSON.stringify([]),
+    });
+    await loadAndIndexProducts();
+    return res.status(201).json({ message: 'product created' });
+  }
+
+  return res.status(405).json({ message: 'Method Not Allowed' });
+}

--- a/pages/brand/dashboard.js
+++ b/pages/brand/dashboard.js
@@ -1,0 +1,172 @@
+import { useState, useEffect, useContext } from 'react';
+import { AppContext } from '../../contexts/AppContext';
+
+export default function BrandDashboard() {
+  const { user } = useContext(AppContext);
+  const emptyForm = {
+    id: '',
+    title: '',
+    vendor: '',
+    description: '',
+    product_type: '',
+    tags: '',
+    category: '',
+    quantity: 0,
+    min_price: 0,
+    max_price: 0,
+    currency: 'USD',
+  };
+  const [form, setForm] = useState(emptyForm);
+  const [products, setProducts] = useState([]);
+  const [message, setMessage] = useState('');
+  const [editingId, setEditingId] = useState(null);
+
+  const fetchProducts = async () => {
+    if (!user) return;
+    const res = await fetch(
+      `/api/brand/products?vendor=${encodeURIComponent(user.brandName || '')}`
+    );
+    if (res.ok) {
+      setProducts(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    fetchProducts();
+  }, [user]);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const payload = editingId ? { ...form, id: editingId } : form;
+    const url = editingId ? `/api/brand/products/${editingId}` : '/api/brand/products';
+    const method = editingId ? 'PUT' : 'POST';
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (res.ok) {
+      setMessage(editingId ? 'Product updated' : 'Product added');
+      setForm(emptyForm);
+      setEditingId(null);
+      fetchProducts();
+    } else {
+      const data = await res.json();
+      setMessage(data.message || 'Error');
+    }
+  };
+
+  const handleEdit = (p) => {
+    setForm({
+      id: p.ID,
+      title: p.TITLE || '',
+      vendor: p.VENDOR || '',
+      description: p.DESCRIPTION || '',
+      product_type: p.PRODUCT_TYPE || '',
+      tags: p.TAGS || '',
+      category: p.CATEGORY || '',
+      quantity: p.TOTAL_INVENTORY || 0,
+      min_price: p.MIN_PRICE || 0,
+      max_price: p.MAX_PRICE || 0,
+      currency: p.CURRENCY || 'USD',
+    });
+    setEditingId(p.ID);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setForm(emptyForm);
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm('Delete this product?')) return;
+    const res = await fetch(`/api/brand/products/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
+    if (res.ok) {
+      fetchProducts();
+    }
+  };
+
+  if (!user) {
+    return <div className="p-4">Please log in to manage products.</div>;
+  }
+  if (user.role !== 'brand') {
+    return <div className="p-4">Brand access required.</div>;
+  }
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Brand Dashboard</h1>
+      {message && <div className="mb-4 text-green-600">{message}</div>}
+      <form onSubmit={submit} className="space-y-2 mb-6">
+        {[
+          'id',
+          'title',
+          'vendor',
+          'description',
+          'product_type',
+          'tags',
+          'category',
+          'quantity',
+          'min_price',
+          'max_price',
+          'currency',
+        ].map((field) => (
+          <div key={field}>
+            <label className="label capitalize">
+              <span className="label-text">{field.replace('_', ' ')}</span>
+            </label>
+            <input
+              name={field}
+              value={form[field]}
+              onChange={handleChange}
+              placeholder={field}
+              className="input input-bordered w-full"
+            />
+          </div>
+        ))}
+        <div className="flex gap-2">
+          {editingId && (
+            <button type="button" onClick={cancelEdit} className="btn">
+              Cancel
+            </button>
+          )}
+          <button type="submit" className="btn btn-primary">
+            {editingId ? 'Update Product' : 'Add Product'}
+          </button>
+        </div>
+      </form>
+      <h2 className="text-xl font-semibold mb-2">Existing Products</h2>
+      <ul className="space-y-1">
+        {products.map((p) => (
+          <li key={p.ID} className="flex justify-between items-center gap-2">
+            <span>
+              {p.TITLE} - {p.CATEGORY || p.PRODUCT_TYPE}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="btn btn-sm"
+                onClick={() => handleEdit(p)}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                className="btn btn-sm btn-error"
+                onClick={() => handleDelete(p.ID)}
+              >
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/brand/orders.js
+++ b/pages/brand/orders.js
@@ -1,0 +1,38 @@
+import { useContext, useEffect, useState } from 'react';
+import { AppContext } from '../contexts/AppContext';
+
+export default function BrandOrders() {
+  const { user } = useContext(AppContext);
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+    fetch(`/api/brand/orders?vendor=${encodeURIComponent(user.brandName || '')}`)
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setOrders(data));
+  }, [user]);
+
+  if (!user) {
+    return <div className="p-4">Please log in to view orders.</div>;
+  }
+  if (user.role !== 'brand') {
+    return <div className="p-4">Brand access required.</div>;
+  }
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Order History</h1>
+      <ul className="space-y-2">
+        {orders.map((o) => (
+          <li key={o.id} className="border p-2">
+            <p>
+              Order #{o.id} - {o.status}
+            </p>
+            <p>Total: £{o.total}</p>
+          </li>
+        ))}
+        {orders.length === 0 && <li>No orders found.</li>}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support checking orders by product id
- add brand product management endpoints
- expose brand orders API
- add brand dashboard and orders pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685291562890832fabb3805614570f45