### PR TITLE
Add deletion checks & category validation

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+
+const logFile = path.join(process.cwd(), 'data', 'audit.log');
+
+export function logAudit(action, details = {}) {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    action,
+    details,
+  };
+  fs.mkdirSync(path.dirname(logFile), { recursive: true });
+  fs.appendFileSync(logFile, JSON.stringify(entry) + '\n');
+}

--- a/lib/db.js
+++ b/lib/db.js
@@ -144,6 +144,29 @@ export function deleteCategory(id) {
   stmt.run(id);
 }
 
+export function getCategoryById(id) {
+  const db = getDb();
+  const stmt = db.prepare('SELECT id, name FROM categories WHERE id = ?');
+  return stmt.get(id);
+}
+
+export function getCategoryByName(name) {
+  const db = getDb();
+  const stmt = db.prepare(
+    'SELECT id, name FROM categories WHERE lower(name) = lower(?)'
+  );
+  return stmt.get(name);
+}
+
+export function countProductsForCategory(name) {
+  const db = getDb();
+  const stmt = db.prepare(
+    'SELECT COUNT(*) as count FROM products WHERE lower(category) = lower(?)'
+  );
+  const row = stmt.get(name);
+  return row ? row.count : 0;
+}
+
 export function getProductById(id) {
   const db = getDb();
   const stmt = db.prepare('SELECT * FROM products WHERE id = ?');

--- a/lib/products.js
+++ b/lib/products.js
@@ -14,6 +14,9 @@ import {
   addCategory as dbAddCategory,
   updateCategory as dbUpdateCategory,
   deleteCategory as dbDeleteCategory,
+  getCategoryByName,
+  getCategoryById,
+  countProductsForCategory,
 } from './db.js';
 
 let products = [];
@@ -322,7 +325,10 @@ export function getCategories() {
 }
 
 export function createCategory(name) {
-  dbAddCategory(name);
+  const existing = getCategoryByName(name);
+  if (!existing) {
+    dbAddCategory(name);
+  }
 }
 
 export function renameCategory(id, name) {
@@ -330,7 +336,14 @@ export function renameCategory(id, name) {
 }
 
 export function removeCategory(id) {
-  dbDeleteCategory(id);
+  const cat = getCategoryById(id);
+  if (!cat) return;
+  const count = countProductsForCategory(cat.name);
+  if (count === 0) {
+    dbDeleteCategory(id);
+  } else {
+    throw new Error('category in use');
+  }
 }
 
 export function deleteProduct(id) {

--- a/pages/api/admin/categories.js
+++ b/pages/api/admin/categories.js
@@ -5,6 +5,7 @@ import {
   removeCategory,
 } from '../../../lib/products';
 import { withRole } from '../../../lib/withRole';
+import { logAudit } from '../../../lib/audit';
 
 function handler(req, res) {
   if (req.method === 'GET') {
@@ -13,7 +14,14 @@ function handler(req, res) {
   if (req.method === 'POST') {
     const { name } = req.body || {};
     if (!name) return res.status(400).json({ message: 'name required' });
+    const exists = getCategories().find(
+      (c) => c.name.toLowerCase() === name.toLowerCase()
+    );
+    if (exists) {
+      return res.status(409).json({ message: 'category exists' });
+    }
     createCategory(name);
+    logAudit('create_category', { name });
     return res.status(201).json({ message: 'category created' });
   }
   if (req.method === 'PUT') {
@@ -21,13 +29,24 @@ function handler(req, res) {
     if (!id || !name)
       return res.status(400).json({ message: 'id and name required' });
     renameCategory(id, name);
+    logAudit('rename_category', { id, name });
     return res.status(200).json({ message: 'category updated' });
   }
   if (req.method === 'DELETE') {
     const { id } = req.query;
     if (!id) return res.status(400).json({ message: 'id required' });
-    removeCategory(id);
-    return res.status(200).json({ message: 'category deleted' });
+    try {
+      removeCategory(id);
+      logAudit('delete_category', { id });
+      return res.status(200).json({ message: 'category deleted' });
+    } catch (e) {
+      if (e.message === 'category in use') {
+        return res
+          .status(400)
+          .json({ message: 'cannot delete category with products' });
+      }
+      throw e;
+    }
   }
   return res.status(405).json({ message: 'Method Not Allowed' });
 }

--- a/pages/api/admin/products.js
+++ b/pages/api/admin/products.js
@@ -5,6 +5,7 @@ import {
   loadAndIndexProducts,
 } from '../../../lib/products';
 import { getProductById } from '../../../lib/db.js';
+import { hasOrdersForProduct } from '../../../lib/orders';
 import formidable from 'formidable';
 import fs from 'fs';
 import path from 'path';
@@ -99,6 +100,15 @@ async function handler(req, res) {
     const { id } = req.query;
     if (!id) {
       return res.status(400).json({ message: 'id required' });
+    }
+    const existing = getProductById(String(id));
+    if (!existing) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+    if (existing.quantity > 0 || hasOrdersForProduct(String(id))) {
+      return res
+        .status(400)
+        .json({ message: 'cannot delete product with stock or orders' });
     }
     deleteProduct(String(id));
     await loadAndIndexProducts();


### PR DESCRIPTION
## Summary
- block deleting products that still have stock or orders in admin API
- enforce case-insensitive category names
- prevent deletion of categories in use
- record admin category actions to `data/audit.log`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68529d274e24832fb22667c8a5ee722f