### PR TITLE
Migrate user auth to Prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# PostgreSQL connection string
+DATABASE_URL="postgresql://user:password@localhost:5432/dbname"

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis;
+
+export const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,79 +1,71 @@
-import { getDb } from './db.js';
+import { prisma } from './prisma.js';
 
-export function addUser({
+export async function addUser({
   email,
   password,
   first_name,
   last_name,
   brand_name,
   gender,
-  role = 'user',
+  role = 'USER',
   verification_token,
 }) {
-  const db = getDb();
-  const stmt =
-    db.prepare(`INSERT INTO users (email, first_name, last_name, password, brand_name, gender, role, verification_token)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);
-  stmt.run(
-    email,
-    first_name,
-    last_name,
-    password,
-    brand_name || null,
-    gender,
-    role,
-    verification_token
-  );
+  await prisma.user.create({
+    data: {
+      email,
+      password,
+      firstName: first_name,
+      lastName: last_name,
+      brandName: brand_name,
+      gender,
+      role,
+      verificationToken: verification_token,
+    },
+  });
 }
 
 export function findUser(email) {
-  const db = getDb();
-  const stmt = db.prepare(
-    'SELECT email, first_name, last_name, password, brand_name, gender, role, verified, verification_token, reset_token, reset_expires FROM users WHERE email = ?'
-  );
-  return stmt.get(email);
+  return prisma.user.findUnique({ where: { email } });
 }
+
 export function getAllUsers() {
-  const db = getDb();
-  return db
-    .prepare(
-      'SELECT email, first_name, last_name, brand_name, gender, role FROM users'
-    )
-    .all();
+  return prisma.user.findMany({
+    select: {
+      email: true,
+      firstName: true,
+      lastName: true,
+      brandName: true,
+      gender: true,
+      role: true,
+    },
+  });
 }
 
 export function updateUserRole(email, role) {
-  const db = getDb();
-  const stmt = db.prepare('UPDATE users SET role = ? WHERE email = ?');
-  stmt.run(role, email);
+  return prisma.user.update({ where: { email }, data: { role } });
 }
 
 export function deleteUser(email) {
-  const db = getDb();
-  const stmt = db.prepare('DELETE FROM users WHERE email = ?');
-  stmt.run(email);
+  return prisma.user.delete({ where: { email } });
 }
 
 export function verifyUser(token) {
-  const db = getDb();
-  const stmt = db.prepare(
-    'UPDATE users SET verified = 1, verification_token = NULL WHERE verification_token = ?'
-  );
-  return stmt.run(token);
+  return prisma.user.updateMany({
+    where: { verificationToken: token },
+    data: { verified: true, verificationToken: null },
+  });
 }
 
 export function setResetToken(email, token, expires) {
-  const db = getDb();
-  const stmt = db.prepare(
-    'UPDATE users SET reset_token = ?, reset_expires = ? WHERE email = ?'
-  );
-  return stmt.run(token, expires, email);
+  return prisma.user.update({
+    where: { email },
+    data: { resetToken: token, resetExpires: new Date(expires) },
+  });
 }
 
 export function resetPassword(token, password) {
-  const db = getDb();
-  const stmt = db.prepare(
-    'UPDATE users SET password = ?, reset_token = NULL, reset_expires = NULL WHERE reset_token = ? AND reset_expires > ?'
-  );
-  return stmt.run(password, token, Date.now());
+  return prisma.user.updateMany({
+    where: { resetToken: token, resetExpires: { gt: new Date() } },
+    data: { password, resetToken: null, resetExpires: null },
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@prisma/client": "^6.9.0",
         "@vercel/blob": "^0.23.0",
+        "bcryptjs": "^3.0.2",
         "better-sqlite3": "^9.4.0",
         "csv-parser": "^3.0.0",
         "dotenv": "^16.3.1",
@@ -5071,6 +5072,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/better-sqlite3": {
       "version": "9.6.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@prisma/client": "^6.9.0",
     "@vercel/blob": "^0.23.0",
+    "bcryptjs": "^3.0.2",
     "better-sqlite3": "^9.4.0",
     "csv-parser": "^3.0.0",
     "dotenv": "^16.3.1",

--- a/pages/api/admin/categories.js
+++ b/pages/api/admin/categories.js
@@ -52,4 +52,4 @@ function handler(req, res) {
 }
 
 
-export default withRole(['super-admin'])(handler);
+export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/admin/products.js
+++ b/pages/api/admin/products.js
@@ -128,4 +128,4 @@ async function handler(req, res) {
 }
 
 
-export default withRole(['brand','super-admin'])(handler);
+export default withRole(['BRAND','SUPER_ADMIN'])(handler);

--- a/pages/api/admin/users.js
+++ b/pages/api/admin/users.js
@@ -6,21 +6,21 @@ import {
 } from '../../../lib/users';
 import { withRole } from '../../../lib/withRole';
 
-function handler(req, res) {
+async function handler(req, res) {
   if (req.method === 'GET') {
-    return res.status(200).json(getAllUsers());
+    return res.status(200).json(await getAllUsers());
   }
   if (req.method === 'PUT') {
     const { email, role } = req.body || {};
     if (!email || !role)
       return res.status(400).json({ message: 'email and role required' });
-    updateUserRole(email, role);
+    await updateUserRole(email, role);
     return res.status(200).json({ message: 'role updated' });
   }
   if (req.method === 'DELETE') {
     const { email } = req.query;
     if (!email) return res.status(400).json({ message: 'email required' });
-    deleteUser(email);
+    await deleteUser(email);
     return res.status(200).json({ message: 'user deleted' });
   }
   if (req.method === 'POST') {
@@ -29,19 +29,18 @@ function handler(req, res) {
     if (!email || !password || !firstName || !lastName || !gender) {
       return res.status(400).json({ message: 'missing required fields' });
     }
-    addUser({
+    await addUser({
       email,
       password,
       first_name: firstName,
       last_name: lastName,
       brand_name: brandName,
       gender,
-      role: role || 'user',
+      role: role || 'USER',
     });
     return res.status(201).json({ message: 'user created' });
   }
   return res.status(405).json({ message: 'Method Not Allowed' });
 }
 
-
-export default withRole(['super-admin'])(handler);
+export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/admin/vendor-products.js
+++ b/pages/api/admin/vendor-products.js
@@ -27,4 +27,4 @@ function handler(req, res) {
 }
 
 
-export default withRole(['super-admin'])(handler);
+export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 import GitHubProvider from 'next-auth/providers/github';
 import CredentialsProvider from 'next-auth/providers/credentials';
+import bcrypt from 'bcryptjs';
 import { findUser, addUser } from '../../../lib/users.js';
 
 export const authOptions = {
@@ -20,15 +21,15 @@ export const authOptions = {
         email: { label: 'Email', type: 'text' },
         password: { label: 'Password', type: 'password' },
       },
-      authorize(credentials) {
-        const user = findUser(credentials.email);
-        if (user && user.password === credentials.password) {
-          const { first_name, last_name, brand_name, gender, role } = user;
+      async authorize(credentials) {
+        const user = await findUser(credentials.email);
+        if (user && (await bcrypt.compare(credentials.password, user.password))) {
+          const { firstName, lastName, brandName, gender, role } = user;
           return {
             id: user.email,
             email: user.email,
-            name: `${first_name} ${last_name}`,
-            brandName: brand_name,
+            name: `${firstName} ${lastName}`,
+            brandName,
             gender,
             role,
           };
@@ -40,28 +41,27 @@ export const authOptions = {
   callbacks: {
     async signIn({ user, account, profile }) {
       if (account.provider === 'google' || account.provider === 'github') {
-        const existing = findUser(user.email);
+        const existing = await findUser(user.email);
         if (!existing) {
           const nameParts = (profile?.name || '').split(' ');
-          addUser({
+          await addUser({
             email: user.email,
             password: '',
             first_name: profile?.given_name || nameParts[0] || '',
-            last_name:
-              profile?.family_name || nameParts.slice(1).join(' ') || '',
+            last_name: profile?.family_name || nameParts.slice(1).join(' ') || '',
             brand_name: null,
             gender: profile?.gender || '',
-            role: 'user',
+            role: 'USER',
           });
         }
       }
       return true;
     },
-    jwt({ token, user }) {
+    async jwt({ token, user }) {
       if (user) {
         token.role = user.role;
       } else if (!token.role) {
-        const dbUser = findUser(token.email);
+        const dbUser = await findUser(token.email);
         if (dbUser) token.role = dbUser.role;
       }
       return token;

--- a/pages/api/check-email.js
+++ b/pages/api/check-email.js
@@ -1,10 +1,10 @@
 import { findUser } from '../../lib/users';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   const { email } = req.query;
   if (!email) {
     return res.status(400).json({ message: 'email required' });
   }
-  const user = findUser(email);
+  const user = await findUser(email);
   return res.status(200).json({ exists: !!user });
 }

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,6 +1,7 @@
 import { findUser } from '../../lib/users';
+import bcrypt from 'bcryptjs';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
@@ -8,18 +9,18 @@ export default function handler(req, res) {
   if (!email || !password) {
     return res.status(400).json({ message: 'email and password required' });
   }
-  const user = findUser(email);
-  if (!user || user.password !== password) {
+  const user = await findUser(email);
+  if (!user || !(await bcrypt.compare(password, user.password))) {
     return res.status(401).json({ message: 'Invalid credentials' });
   }
-  const { first_name, last_name, brand_name, gender, role } = user;
+  const { firstName, lastName, brandName, gender, role } = user;
   return res.status(200).json({
     message: 'Login successful',
     user: {
       email,
-      firstName: first_name,
-      lastName: last_name,
-      brandName: brand_name,
+      firstName,
+      lastName,
+      brandName,
       gender,
       role,
     },

--- a/pages/api/orders.js
+++ b/pages/api/orders.js
@@ -7,7 +7,7 @@ import {
 import { findUser } from '../../lib/users.js';
 import { withRole } from '../../lib/withRole';
 
-function handler(req, res) {
+async function handler(req, res) {
   if (req.method === 'POST') {
     const { email, items, total } = req.body;
     if (!email || !items) {
@@ -20,13 +20,13 @@ function handler(req, res) {
   if (req.method === 'GET') {
     const { email } = req.query;
     if (!email) return res.status(400).json({ message: 'email required' });
-    const user = findUser(email);
+    const user = await findUser(email);
     if (!user) return res.status(404).json({ message: 'user not found' });
-    if (user.role === 'super-admin') {
+    if (user.role === 'SUPER_ADMIN') {
       return res.status(200).json(getAllOrders());
     }
-    if (user.role === 'brand') {
-      return res.status(200).json(getOrdersForVendor(user.brand_name));
+    if (user.role === 'BRAND') {
+      return res.status(200).json(getOrdersForVendor(user.brandName));
     }
     return res.status(200).json(getOrdersForUser(email));
   }
@@ -34,5 +34,4 @@ function handler(req, res) {
   return res.status(405).json({ message: 'Method Not Allowed' });
 }
 
-
-export default withRole(['user','brand','super-admin'])(handler);
+export default withRole(['USER','BRAND','SUPER_ADMIN'])(handler);

--- a/pages/api/request-reset.js
+++ b/pages/api/request-reset.js
@@ -1,15 +1,15 @@
 import { findUser, setResetToken } from '../../lib/users';
 import crypto from 'crypto';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   if (req.method !== 'POST')
     return res.status(405).json({ message: 'Method Not Allowed' });
   const { email } = req.body;
   if (!email) return res.status(400).json({ message: 'email required' });
-  const user = findUser(email);
+  const user = await findUser(email);
   if (!user) return res.status(404).json({ message: 'User not found' });
   const token = crypto.randomBytes(20).toString('hex');
   const expires = Date.now() + 3600 * 1000; // 1 hour
-  setResetToken(email, token, expires);
+  await setResetToken(email, token, expires);
   return res.status(200).json({ message: 'Reset email sent', token });
 }

--- a/pages/api/reset-password.js
+++ b/pages/api/reset-password.js
@@ -1,13 +1,13 @@
 import { resetPassword } from '../../lib/users';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   if (req.method !== 'POST')
     return res.status(405).json({ message: 'Method Not Allowed' });
   const { token, password } = req.body;
   if (!token || !password)
     return res.status(400).json({ message: 'token and password required' });
   try {
-    resetPassword(token, password);
+    await resetPassword(token, password);
     return res.status(200).json({ message: 'Password reset' });
   } catch (e) {
     return res.status(500).json({ message: 'Error resetting password' });

--- a/pages/api/signup.js
+++ b/pages/api/signup.js
@@ -1,7 +1,8 @@
 import { addUser, findUser } from '../../lib/users';
 import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
@@ -11,18 +12,19 @@ export default function handler(req, res) {
     return res.status(400).json({ message: 'missing required fields' });
   }
   try {
-    if (findUser(email)) {
+    if (await findUser(email)) {
       return res.status(409).json({ message: 'User exists' });
     }
+    const hashed = await bcrypt.hash(password, 10);
     const token = crypto.randomBytes(20).toString('hex');
-    addUser({
+    await addUser({
       email,
-      password,
+      password: hashed,
       first_name: firstName,
       last_name: lastName,
       brand_name: brandName,
       gender,
-      role: role || 'user',
+      role: role || 'USER',
       verification_token: token,
     });
     return res.status(201).json({
@@ -33,7 +35,7 @@ export default function handler(req, res) {
         lastName,
         brandName,
         gender,
-        role: role || 'user',
+        role: role || 'USER',
       },
       token,
     });

--- a/pages/api/vendor/orders.js
+++ b/pages/api/vendor/orders.js
@@ -13,5 +13,4 @@ function handler(req, res) {
   return res.status(200).json(orders);
 }
 
-
-export default withRole(['brand'])(handler);
+export default withRole(['BRAND'])(handler);

--- a/pages/api/verify-email.js
+++ b/pages/api/verify-email.js
@@ -1,10 +1,10 @@
 import { verifyUser } from '../../lib/users';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   const { token } = req.query;
   if (!token) return res.status(400).json({ message: 'token required' });
   try {
-    verifyUser(token);
+    await verifyUser(token);
     return res.status(200).json({ message: 'Email verified' });
   } catch (e) {
     return res.status(500).json({ message: 'Error verifying email' });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,49 +1,90 @@
 datasource db {
-  provider = "sqlite"
-  url      = "file:./dev.db"
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 generator client {
   provider = "prisma-client-js"
 }
 
-model User {
-  id       Int      @id @default(autoincrement())
-  name     String
-  email    String   @unique
-  role     String
-  password String
-  products Product[]
-  orders   Order[]
+enum Role {
+  USER
+  BRAND
+  SUPER_ADMIN
 }
 
-model Product {
-  id          Int      @id @default(autoincrement())
-  title       String
-  description String
-  price       Float
-  image       String
-  categoryId  Int
-  vendorId    Int
-  category    Category @relation(fields: [categoryId], references: [id])
-  vendor      User     @relation(fields: [vendorId], references: [id])
-  orders      Order[]
+model User {
+  id                Int      @id @default(autoincrement())
+  email             String   @unique
+  password          String
+  firstName         String
+  lastName          String
+  brandName         String?
+  gender            String
+  role              Role     @default(USER)
+  verified          Boolean  @default(false)
+  verificationToken String?
+  resetToken        String?
+  resetExpires      DateTime?
+  products          Product[]
+  orders            Order[]
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 }
 
 model Category {
-  id       Int      @id @default(autoincrement())
-  name     String
-  slug     String   @unique
-  products Product[]
+  id        Int       @id @default(autoincrement())
+  name      String
+  slug      String    @unique
+  products  Product[]
+  requests  DeletionRequest[]
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+}
+
+model Product {
+  id          Int       @id @default(autoincrement())
+  title       String
+  description String
+  productType String
+  tags        String?
+  quantity    Int      @default(0)
+  minPrice    Float    @default(0)
+  maxPrice    Float    @default(0)
+  currency    String   @default("USD")
+  status      String   @default("approved")
+  images      String?
+  vendor      User     @relation(fields: [vendorId], references: [id])
+  vendorId    Int
+  category    Category @relation(fields: [categoryId], references: [id])
+  categoryId  Int
+  orders      Order[]
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model Order {
-  id        Int    @id @default(autoincrement())
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
   userId    Int
+  product   Product  @relation(fields: [productId], references: [id])
   productId Int
   quantity  Int
   total     Float
-  status    String
-  user      User    @relation(fields: [userId], references: [id])
-  product   Product @relation(fields: [productId], references: [id])
+  status    String   @default("pending")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
+
+model DeletionRequest {
+  id        Int       @id @default(autoincrement())
+  category  Category  @relation(fields: [categoryId], references: [id])
+  categoryId Int
+  brand     User      @relation(fields: [brandId], references: [id])
+  brandId   Int
+  reason    String?
+  status    String   @default("pending")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+


### PR DESCRIPTION
## Summary
- switch Prisma to PostgreSQL and add Role enum
- seed Prisma client helper
- store hashed passwords and roles in PostgreSQL
- update authentication endpoints and NextAuth to use Prisma
- expose `.env.example` for database configuration

## Testing
- `npm test`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68530d94fa6c832f97f05a3c41a327e5