### PR TITLE
Support nested categories

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -67,6 +67,19 @@ export default function Header() {
     setSuggestions([]);
     setSearch('');
   };
+
+  const renderCat = (cat) => (
+    <li key={cat.id} className={cat.parentId ? 'ml-4' : ''}>
+      <Link href={`/categories/${encodeURIComponent(cat.name)}`}>
+        {cat.name}
+      </Link>
+      {cat.children && cat.children.length > 0 && (
+        <ul className="ml-4">
+          {cat.children.map((child) => renderCat(child))}
+        </ul>
+      )}
+    </li>
+  );
   return (
     <header className="navbar bg-base-300 mb-6">
       <div className="flex-1 flex items-center gap-2">
@@ -106,13 +119,7 @@ export default function Header() {
             tabIndex={0}
             className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52"
           >
-            {categories.map((cat) => (
-              <li key={cat}>
-                <Link href={`/categories/${encodeURIComponent(cat)}`}>
-                  {cat}
-                </Link>
-              </li>
-            ))}
+            {categories.map((cat) => renderCat(cat))}
           </ul>
         </div>
         <div className="relative mr-2">
@@ -221,22 +228,16 @@ export default function Header() {
               <li>
                 <details>
                   <summary>Categories</summary>
-                  <ul>
-                    {categories.map((cat) => (
-                      <li key={cat}>
-                        <Link href={`/categories/${encodeURIComponent(cat)}`}>
-                          {cat}
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
+                  <ul>{categories.map((cat) => renderCat(cat))}</ul>
                 </details>
               </li>
             )}
             {user ? (
               <>
                 {user.role === 'super-admin' ? (
-                  <li><Link href="/admin">Admin</Link></li>
+                  <li>
+                    <Link href="/admin">Admin</Link>
+                  </li>
                 ) : (
                   <li>
                     <Link href="/user/orders">Orders</Link>

--- a/lib/db.js
+++ b/lib/db.js
@@ -37,8 +37,13 @@ export function getDb() {
       db.exec('ALTER TABLE products ADD COLUMN images TEXT');
     }
     db.exec(
-      'CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE)'
+      'CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE, parent_id INTEGER, FOREIGN KEY(parent_id) REFERENCES categories(id))'
     );
+    const catInfo = db.prepare('PRAGMA table_info(categories)').all();
+    const hasParent = catInfo.some((c) => c.name === 'parent_id');
+    if (!hasParent) {
+      db.exec('ALTER TABLE categories ADD COLUMN parent_id INTEGER');
+    }
     db.exec(`CREATE TABLE IF NOT EXISTS users (
       email TEXT PRIMARY KEY,
       first_name TEXT,
@@ -123,19 +128,27 @@ export function setProductStatus(id, status) {
 
 export function getCategories() {
   const db = getDb();
-  return db.prepare('SELECT id, name FROM categories ORDER BY name').all();
+  return db
+    .prepare(
+      'SELECT id, name, parent_id as parentId FROM categories ORDER BY name'
+    )
+    .all();
 }
 
-export function addCategory(name) {
+export function addCategory(name, parentId = null) {
   const db = getDb();
-  const stmt = db.prepare('INSERT OR IGNORE INTO categories (name) VALUES (?)');
-  stmt.run(name);
+  const stmt = db.prepare(
+    'INSERT OR IGNORE INTO categories (name, parent_id) VALUES (?, ?)'
+  );
+  stmt.run(name, parentId);
 }
 
-export function updateCategory(id, name) {
+export function updateCategory(id, name, parentId = null) {
   const db = getDb();
-  const stmt = db.prepare('UPDATE categories SET name = ? WHERE id = ?');
-  stmt.run(name, id);
+  const stmt = db.prepare(
+    'UPDATE categories SET name = ?, parent_id = ? WHERE id = ?'
+  );
+  stmt.run(name, parentId, id);
 }
 
 export function deleteCategory(id) {
@@ -146,14 +159,16 @@ export function deleteCategory(id) {
 
 export function getCategoryById(id) {
   const db = getDb();
-  const stmt = db.prepare('SELECT id, name FROM categories WHERE id = ?');
+  const stmt = db.prepare(
+    'SELECT id, name, parent_id as parentId FROM categories WHERE id = ?'
+  );
   return stmt.get(id);
 }
 
 export function getCategoryByName(name) {
   const db = getDb();
   const stmt = db.prepare(
-    'SELECT id, name FROM categories WHERE lower(name) = lower(?)'
+    'SELECT id, name, parent_id as parentId FROM categories WHERE lower(name) = lower(?)'
   );
   return stmt.get(name);
 }

--- a/lib/products.js
+++ b/lib/products.js
@@ -320,19 +320,45 @@ export function rejectProduct(id) {
   isDataLoaded = false;
 }
 
-export function getCategories() {
+export function getCategoriesFlat() {
   return dbGetCategories();
 }
 
-export function createCategory(name) {
+export function getCategories() {
+  const flat = getCategoriesFlat();
+  const map = {};
+  flat.forEach((c) => {
+    map[c.id] = { ...c, children: [] };
+  });
+  const tree = [];
+  flat.forEach((c) => {
+    if (c.parentId) {
+      const parent = map[c.parentId];
+      if (parent) {
+        parent.children.push(map[c.id]);
+      }
+    } else {
+      tree.push(map[c.id]);
+    }
+  });
+  return tree;
+}
+
+export function createCategory(name, parentId = null) {
   const existing = getCategoryByName(name);
   if (!existing) {
-    dbAddCategory(name);
+    if (parentId) {
+      const parent = getCategoryById(parentId);
+      if (parent?.parentId) {
+        throw new Error('depth');
+      }
+    }
+    dbAddCategory(name, parentId);
   }
 }
 
-export function renameCategory(id, name) {
-  dbUpdateCategory(id, name);
+export function renameCategory(id, name, parentId = null) {
+  dbUpdateCategory(id, name, parentId);
 }
 
 export function removeCategory(id) {

--- a/pages/admin/categories.js
+++ b/pages/admin/categories.js
@@ -5,6 +5,7 @@ export default function Categories() {
   const { user } = useContext(AppContext);
   const [categories, setCategories] = useState([]);
   const [newCat, setNewCat] = useState('');
+  const [newParent, setNewParent] = useState('');
   const [message, setMessage] = useState('');
   const [editing, setEditing] = useState(null);
   const [editName, setEditName] = useState('');
@@ -24,7 +25,7 @@ export default function Categories() {
     const res = await fetch('/api/admin/categories', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: newCat }),
+      body: JSON.stringify({ name: newCat, parentId: newParent || null }),
     });
     if (res.ok) {
       setNewCat('');
@@ -73,47 +74,93 @@ export default function Categories() {
           placeholder="New category"
           className="input input-bordered flex-1"
         />
+        <select
+          className="select select-bordered"
+          value={newParent}
+          onChange={(e) => setNewParent(e.target.value)}
+        >
+          <option value="">No parent</option>
+          {categories
+            .filter((c) => !c.parentId)
+            .map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+        </select>
         <button onClick={add} className="btn btn-primary">
           Add
         </button>
       </div>
       <ul className="space-y-2">
-        {categories.map((c) => (
-          <li key={c.id} className="flex items-center gap-2">
-            {editing === c.id ? (
-              <>
-                <input
-                  className="input input-bordered flex-1"
-                  value={editName}
-                  onChange={(e) => setEditName(e.target.value)}
-                />
-                <button onClick={update} className="btn btn-sm">
-                  Save
-                </button>
-                <button onClick={() => setEditing(null)} className="btn btn-sm">
-                  Cancel
-                </button>
-              </>
-            ) : (
-              <>
-                <span className="flex-1">{c.name}</span>
-                <button
-                  onClick={() => {
-                    setEditing(c.id);
-                    setEditName(c.name);
-                  }}
-                  className="btn btn-sm"
-                >
-                  Edit
-                </button>
-                <button onClick={() => remove(c.id)} className="btn btn-sm">
-                  Delete
-                </button>
-              </>
-            )}
-          </li>
+        {buildTree(categories).map((c) => (
+          <CategoryItem key={c.id} cat={c} />
         ))}
       </ul>
     </div>
   );
+
+  function buildTree(list) {
+    const map = {};
+    list.forEach((c) => {
+      map[c.id] = { ...c, children: [] };
+    });
+    const tree = [];
+    list.forEach((c) => {
+      if (c.parentId) {
+        map[c.parentId]?.children.push(map[c.id]);
+      } else {
+        tree.push(map[c.id]);
+      }
+    });
+    return tree;
+  }
+
+  function CategoryItem({ cat }) {
+    const hasChildren = cat.children && cat.children.length > 0;
+    return (
+      <li className={cat.parentId ? 'ml-4' : ''}>
+        <div className="flex items-center gap-2">
+          {editing === cat.id ? (
+            <>
+              <input
+                className="input input-bordered flex-1"
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+              />
+              <button onClick={update} className="btn btn-sm">
+                Save
+              </button>
+              <button onClick={() => setEditing(null)} className="btn btn-sm">
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <span className="flex-1">{cat.name}</span>
+              <button
+                onClick={() => {
+                  setEditing(cat.id);
+                  setEditName(cat.name);
+                }}
+                className="btn btn-sm"
+              >
+                Edit
+              </button>
+              <button onClick={() => remove(cat.id)} className="btn btn-sm">
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+        {hasChildren && (
+          <ul className="ml-4 space-y-2">
+            {cat.children.map((child) => (
+              <CategoryItem key={child.id} cat={child} />
+            ))}
+          </ul>
+        )}
+      </li>
+    );
+  }
 }

--- a/pages/api/admin/categories.js
+++ b/pages/api/admin/categories.js
@@ -1,5 +1,5 @@
 import {
-  getCategories,
+  getCategoriesFlat,
   createCategory,
   renameCategory,
   removeCategory,
@@ -9,27 +9,34 @@ import { logAudit } from '../../../lib/audit';
 
 function handler(req, res) {
   if (req.method === 'GET') {
-    return res.status(200).json(getCategories());
+    return res.status(200).json(getCategoriesFlat());
   }
   if (req.method === 'POST') {
-    const { name } = req.body || {};
+    const { name, parentId } = req.body || {};
     if (!name) return res.status(400).json({ message: 'name required' });
-    const exists = getCategories().find(
+    const exists = getCategoriesFlat().find(
       (c) => c.name.toLowerCase() === name.toLowerCase()
     );
     if (exists) {
       return res.status(409).json({ message: 'category exists' });
     }
-    createCategory(name);
-    logAudit('create_category', { name });
+    try {
+      createCategory(name, parentId || null);
+    } catch (e) {
+      if (e.message === 'depth') {
+        return res.status(400).json({ message: 'max depth exceeded' });
+      }
+      throw e;
+    }
+    logAudit('create_category', { name, parentId });
     return res.status(201).json({ message: 'category created' });
   }
   if (req.method === 'PUT') {
-    const { id, name } = req.body || {};
+    const { id, name, parentId } = req.body || {};
     if (!id || !name)
       return res.status(400).json({ message: 'id and name required' });
-    renameCategory(id, name);
-    logAudit('rename_category', { id, name });
+    renameCategory(id, name, parentId || null);
+    logAudit('rename_category', { id, name, parentId });
     return res.status(200).json({ message: 'category updated' });
   }
   if (req.method === 'DELETE') {
@@ -50,6 +57,5 @@ function handler(req, res) {
   }
   return res.status(405).json({ message: 'Method Not Allowed' });
 }
-
 
 export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/brand/categories.js
+++ b/pages/api/brand/categories.js
@@ -1,16 +1,23 @@
-import { getCategories, createCategory } from '../../../lib/products';
+import { getCategoriesFlat, createCategory } from '../../../lib/products';
 
 export default function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
-  const { name } = req.body || {};
+  const { name, parentId } = req.body || {};
   if (!name) return res.status(400).json({ message: 'name required' });
-  const exists = getCategories().find(
+  const exists = getCategoriesFlat().find(
     (c) => c.name.toLowerCase() === name.toLowerCase()
   );
   if (!exists) {
-    createCategory(name);
+    try {
+      createCategory(name, parentId || null);
+    } catch (e) {
+      if (e.message === 'depth') {
+        return res.status(400).json({ message: 'max depth exceeded' });
+      }
+      throw e;
+    }
   }
   return res.status(201).json({ message: 'ok' });
 }

--- a/pages/api/categories.js
+++ b/pages/api/categories.js
@@ -2,7 +2,7 @@ import { getCategories } from '../../lib/products';
 
 export default function handler(req, res) {
   if (req.method === 'GET') {
-    const cats = getCategories().map((c) => c.name);
+    const cats = getCategories();
     return res.status(200).json(cats);
   }
   return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/categories/index.js
+++ b/pages/categories/index.js
@@ -13,13 +13,24 @@ export default function Categories() {
     <div className="p-4 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Categories</h1>
       <ul className="list-disc pl-4 space-y-1">
-        {categories.map((c) => (
-          <li key={c}>
-            <Link href={`/categories/${encodeURIComponent(c)}`}>{c}</Link>
-          </li>
-        ))}
+        {categories.map((c) => renderCat(c))}
         {categories.length === 0 && <li>No categories found.</li>}
       </ul>
     </div>
   );
+
+  function renderCat(cat) {
+    return (
+      <li key={cat.id} className={cat.parentId ? 'ml-4 list-disc' : ''}>
+        <Link href={`/categories/${encodeURIComponent(cat.name)}`}>
+          {cat.name}
+        </Link>
+        {cat.children && cat.children.length > 0 && (
+          <ul className="ml-4 space-y-1 list-disc">
+            {cat.children.map((child) => renderCat(child))}
+          </ul>
+        )}
+      </li>
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- allow categories to have an optional parent
- build nested category tree in backend and return it from `/api/categories`
- update admin category API and UI to handle `parentId`
- render nested category lists on the frontend header and category index page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c07be458832fa534177e09bcccba