### PR TITLE
Improve category navigation

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -119,7 +119,32 @@ export default function Header() {
             tabIndex={0}
             className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52"
           >
-            {categories.map((cat) => renderCat(cat))}
+            {categories.map((cat) => (
+              <li key={cat.name}>
+                {cat.subcategories && cat.subcategories.length > 0 ? (
+                  <details>
+                    <summary>{cat.name}</summary>
+                    <ul>
+                      {cat.subcategories.map((sub) => (
+                        <li key={sub}>
+                          <Link
+                            href={`/categories/${encodeURIComponent(
+                              cat.name
+                            )}?type=${encodeURIComponent(sub)}`}
+                          >
+                            {sub}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </details>
+                ) : (
+                  <Link href={`/categories/${encodeURIComponent(cat.name)}`}>
+                    {cat.name}
+                  </Link>
+                )}
+              </li>
+            ))}
           </ul>
         </div>
         <div className="relative mr-2">
@@ -228,7 +253,34 @@ export default function Header() {
               <li>
                 <details>
                   <summary>Categories</summary>
-                  <ul>{categories.map((cat) => renderCat(cat))}</ul>
+                  <ul>
+                    {categories.map((cat) => (
+                      <li key={cat.name}>
+                        {cat.subcategories && cat.subcategories.length > 0 ? (
+                          <details>
+                            <summary>{cat.name}</summary>
+                            <ul>
+                              {cat.subcategories.map((sub) => (
+                                <li key={sub}>
+                                  <Link
+                                    href={`/categories/${encodeURIComponent(
+                                      cat.name
+                                    )}?type=${encodeURIComponent(sub)}`}
+                                  >
+                                    {sub}
+                                  </Link>
+                                </li>
+                              ))}
+                            </ul>
+                          </details>
+                        ) : (
+                          <Link href={`/categories/${encodeURIComponent(cat.name)}`}>
+                            {cat.name}
+                          </Link>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
                 </details>
               </li>
             )}

--- a/components/Header.js
+++ b/components/Header.js
@@ -17,7 +17,7 @@ export default function Header() {
   useEffect(() => {
     async function loadCategories() {
       try {
-        const res = await fetch('/api/categories');
+        const res = await fetch('/api/category-tree');
         if (res.ok) {
           const data = await res.json();
           setCategories(data || []);
@@ -99,7 +99,7 @@ export default function Header() {
       </div>
       <div className="hidden md:flex flex-none gap-2">
         <div className="dropdown dropdown-hover">
-          <label tabIndex={0} className="btn btn-outline">
+          <label tabIndex={0} className="btn btn-ghost">
             Categories
           </label>
           <ul
@@ -107,10 +107,29 @@ export default function Header() {
             className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52"
           >
             {categories.map((cat) => (
-              <li key={cat}>
-                <Link href={`/categories/${encodeURIComponent(cat)}`}>
-                  {cat}
-                </Link>
+              <li key={cat.name}>
+                {cat.subcategories && cat.subcategories.length > 0 ? (
+                  <details>
+                    <summary>{cat.name}</summary>
+                    <ul>
+                      {cat.subcategories.map((sub) => (
+                        <li key={sub}>
+                          <Link
+                            href={`/categories/${encodeURIComponent(
+                              cat.name
+                            )}?type=${encodeURIComponent(sub)}`}
+                          >
+                            {sub}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </details>
+                ) : (
+                  <Link href={`/categories/${encodeURIComponent(cat.name)}`}>
+                    {cat.name}
+                  </Link>
+                )}
               </li>
             ))}
           </ul>
@@ -223,10 +242,29 @@ export default function Header() {
                   <summary>Categories</summary>
                   <ul>
                     {categories.map((cat) => (
-                      <li key={cat}>
-                        <Link href={`/categories/${encodeURIComponent(cat)}`}>
-                          {cat}
-                        </Link>
+                      <li key={cat.name}>
+                        {cat.subcategories && cat.subcategories.length > 0 ? (
+                          <details>
+                            <summary>{cat.name}</summary>
+                            <ul>
+                              {cat.subcategories.map((sub) => (
+                                <li key={sub}>
+                                  <Link
+                                    href={`/categories/${encodeURIComponent(
+                                      cat.name
+                                    )}?type=${encodeURIComponent(sub)}`}
+                                  >
+                                    {sub}
+                                  </Link>
+                                </li>
+                              ))}
+                            </ul>
+                          </details>
+                        ) : (
+                          <Link href={`/categories/${encodeURIComponent(cat.name)}`}>
+                            {cat.name}
+                          </Link>
+                        )}
                       </li>
                     ))}
                   </ul>

--- a/lib/products.js
+++ b/lib/products.js
@@ -324,6 +324,19 @@ export function getCategories() {
   return dbGetCategories();
 }
 
+export function getCategoryTree() {
+  const rows = getAllFromDb();
+  const map = {};
+  for (const row of rows) {
+    if (!row.category) continue;
+    if (!map[row.category]) map[row.category] = new Set();
+    if (row.product_type) map[row.category].add(row.product_type);
+  }
+  return Object.entries(map)
+    .map(([name, set]) => ({ name, subcategories: Array.from(set).sort() }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
 export function createCategory(name) {
   const existing = getCategoryByName(name);
   if (!existing) {

--- a/pages/api/category-tree.js
+++ b/pages/api/category-tree.js
@@ -1,0 +1,8 @@
+import { getCategoryTree } from '../../lib/products';
+
+export default function handler(req, res) {
+  if (req.method === 'GET') {
+    return res.status(200).json(getCategoryTree());
+  }
+  return res.status(405).json({ message: 'Method Not Allowed' });
+}

--- a/pages/categories/[name].js
+++ b/pages/categories/[name].js
@@ -5,7 +5,7 @@ import { AppContext } from '../../contexts/AppContext';
 
 export default function CategoryPage() {
   const router = useRouter();
-  const { name } = router.query;
+  const { name, type } = router.query;
   const { addToCart } = useContext(AppContext);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -14,9 +14,10 @@ export default function CategoryPage() {
     if (!name) return;
     async function load() {
       setLoading(true);
-      const res = await fetch(
-        `/api/search?filterByCategory=${encodeURIComponent(name)}`
-      );
+      const url = `/api/search?filterByCategory=${encodeURIComponent(name)}${
+        type ? `&filterByType=${encodeURIComponent(type)}` : ''
+      }`;
+      const res = await fetch(url);
       if (res.ok) {
         const data = await res.json();
         setProducts(data.results || []);
@@ -24,13 +25,16 @@ export default function CategoryPage() {
       setLoading(false);
     }
     load();
-  }, [name]);
+  }, [name, type]);
 
   if (!name) return <div className="p-4">Loading...</div>;
 
   return (
     <div className="p-4 max-w-screen-2xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Category: {name}</h1>
+      <h1 className="text-2xl font-bold mb-4">
+        Category: {name}
+        {type && ` - ${type}`}
+      </h1>
       {loading && <div>Loading...</div>}
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {products.map((p) => (

--- a/pages/categories/index.js
+++ b/pages/categories/index.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 export default function Categories() {
   const [categories, setCategories] = useState([]);
   useEffect(() => {
-    fetch('/api/categories')
+    fetch('/api/category-tree')
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => setCategories(data));
   }, []);
@@ -14,8 +14,8 @@ export default function Categories() {
       <h1 className="text-2xl font-bold mb-4">Categories</h1>
       <ul className="list-disc pl-4 space-y-1">
         {categories.map((c) => (
-          <li key={c}>
-            <Link href={`/categories/${encodeURIComponent(c)}`}>{c}</Link>
+          <li key={c.name}>
+            <Link href={`/categories/${encodeURIComponent(c.name)}`}>{c.name}</Link>
           </li>
         ))}
         {categories.length === 0 && <li>No categories found.</li>}

--- a/pages/categories/index.js
+++ b/pages/categories/index.js
@@ -13,7 +13,11 @@ export default function Categories() {
     <div className="p-4 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Categories</h1>
       <ul className="list-disc pl-4 space-y-1">
-        {categories.map((c) => renderCat(c))}
+        {categories.map((c) => (
+          <li key={c.name}>
+            <Link href={`/categories/${encodeURIComponent(c.name)}`}>{c.name}</Link>
+          </li>
+        ))}
         {categories.length === 0 && <li>No categories found.</li>}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- implement database helper `getCategoryTree`
- expose new `/api/category-tree` endpoint
- update header hover menu to show categories and subcategories
- fetch category tree on categories listing page
- support filtering by product type on category page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c089b950832f81e545c0a6b3ed5b