### PR TITLE
Implement checkout flow

### DIFF
--- a/contexts/AppContext.js
+++ b/contexts/AppContext.js
@@ -20,6 +20,16 @@ export function AppProvider({ children }) {
   }, []);
 
   useEffect(() => {
+    if (!user) return;
+    fetch('/api/cart')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => {
+        if (Array.isArray(data)) setCart(data);
+      })
+      .catch(() => {});
+  }, [user]);
+
+  useEffect(() => {
     if (session?.user) {
       const { email, name, role, brandName, gender } = session.user;
       const [firstName = '', lastName = ''] = (name || '').split(' ');
@@ -31,7 +41,14 @@ export function AppProvider({ children }) {
 
   useEffect(() => {
     localStorage.setItem('app-cart', JSON.stringify(cart));
-  }, [cart]);
+    if (user) {
+      fetch('/api/cart', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: cart }),
+      }).catch(() => {});
+    }
+  }, [cart, user]);
 
   const login = async (email, password) => {
     const res = await nextSignIn('credentials', {
@@ -57,9 +74,9 @@ export function AppProvider({ children }) {
     nextSignOut({ redirect: false });
   };
 
-  const placeOrder = async () => {
-    if (!user || cart.length === 0) return;
-    await fetch('/api/orders', {
+  const placeOrder = async ({ shippingName, shippingAddress }) => {
+    if (!user || cart.length === 0) return false;
+    const res = await fetch('/api/orders', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -69,9 +86,16 @@ export function AppProvider({ children }) {
           (s, i) => s + i.qty * parseFloat(i.MIN_PRICE || 0),
           0
         ),
+        shippingName,
+        shippingAddress,
       }),
     });
+    if (!res.ok) {
+      const data = await res.json().catch(() => null);
+      throw new Error(data?.message || 'Order failed');
+    }
     setCart([]);
+    return true;
   };
 
   const addToCart = (product) => {

--- a/lib/db.js
+++ b/lib/db.js
@@ -58,7 +58,26 @@ export function getDb() {
       items TEXT,
       total REAL,
       status TEXT DEFAULT 'pending',
+      shipping_name TEXT,
+      shipping_address TEXT,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(user_email) REFERENCES users(email)
+    )`);
+
+    const orderInfo = db.prepare('PRAGMA table_info(orders)').all();
+    const hasShipName = orderInfo.some((c) => c.name === 'shipping_name');
+    if (!hasShipName) {
+      db.exec('ALTER TABLE orders ADD COLUMN shipping_name TEXT');
+    }
+    const hasShipAddr = orderInfo.some((c) => c.name === 'shipping_address');
+    if (!hasShipAddr) {
+      db.exec('ALTER TABLE orders ADD COLUMN shipping_address TEXT');
+    }
+
+    db.exec(`CREATE TABLE IF NOT EXISTS carts (
+      user_email TEXT PRIMARY KEY,
+      items TEXT,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       FOREIGN KEY(user_email) REFERENCES users(email)
     )`);
   }
@@ -171,4 +190,43 @@ export function getProductById(id) {
   const db = getDb();
   const stmt = db.prepare('SELECT * FROM products WHERE id = ?');
   return stmt.get(id);
+}
+
+export function updateProductQuantity(id, quantity) {
+  const db = getDb();
+  const stmt = db.prepare('UPDATE products SET quantity = ? WHERE id = ?');
+  stmt.run(quantity, id);
+}
+
+export function decreaseProductQuantity(id, delta) {
+  const product = getProductById(id);
+  if (!product) return;
+  const newQty = Math.max(0, (product.quantity || 0) - delta);
+  updateProductQuantity(id, newQty);
+}
+
+export function getCart(email) {
+  const db = getDb();
+  const row = db
+    .prepare('SELECT items FROM carts WHERE user_email = ?')
+    .get(email);
+  if (!row) return [];
+  try {
+    return JSON.parse(row.items);
+  } catch (_) {
+    return [];
+  }
+}
+
+export function setCart(email, items) {
+  const db = getDb();
+  const stmt = db.prepare(`INSERT INTO carts (user_email, items)
+    VALUES (?, ?)
+    ON CONFLICT(user_email) DO UPDATE SET items=excluded.items, updated_at=CURRENT_TIMESTAMP`);
+  stmt.run(email, JSON.stringify(items));
+}
+
+export function clearCart(email) {
+  const db = getDb();
+  db.prepare('DELETE FROM carts WHERE user_email = ?').run(email);
 }

--- a/lib/orders.js
+++ b/lib/orders.js
@@ -1,11 +1,26 @@
 import { getDb } from './db.js';
 
-export function addOrder({ user_email, items, total, status = 'pending' }) {
+export function addOrder({
+  user_email,
+  items,
+  total,
+  status = 'pending',
+  shipping_name = null,
+  shipping_address = null,
+}) {
   const db = getDb();
   const stmt = db.prepare(
-    `INSERT INTO orders (user_email, items, total, status) VALUES (?, ?, ?, ?)`
+    `INSERT INTO orders (user_email, items, total, status, shipping_name, shipping_address)
+      VALUES (?, ?, ?, ?, ?, ?)`
   );
-  const info = stmt.run(user_email, JSON.stringify(items), total, status);
+  const info = stmt.run(
+    user_email,
+    JSON.stringify(items),
+    total,
+    status,
+    shipping_name,
+    shipping_address
+  );
   return info.lastInsertRowid;
 }
 
@@ -14,15 +29,19 @@ export function getOrdersForUser(email) {
   const stmt = db.prepare(
     `SELECT * FROM orders WHERE user_email = ? ORDER BY created_at DESC`
   );
-  return stmt
-    .all(email)
-    .map((row) => ({ ...row, items: JSON.parse(row.items) }));
+  return stmt.all(email).map((row) => ({
+    ...row,
+    items: JSON.parse(row.items),
+  }));
 }
 
 export function getAllOrders() {
   const db = getDb();
   const stmt = db.prepare(`SELECT * FROM orders ORDER BY created_at DESC`);
-  return stmt.all().map((row) => ({ ...row, items: JSON.parse(row.items) }));
+  return stmt.all().map((row) => ({
+    ...row,
+    items: JSON.parse(row.items),
+  }));
 }
 
 export function getOrdersForVendor(vendor) {
@@ -30,7 +49,10 @@ export function getOrdersForVendor(vendor) {
   const stmt = db.prepare(`SELECT * FROM orders ORDER BY created_at DESC`);
   const rows = stmt.all();
   return rows
-    .map((row) => ({ ...row, items: JSON.parse(row.items) }))
+    .map((row) => ({
+      ...row,
+      items: JSON.parse(row.items),
+    }))
     .filter((order) => order.items.some((item) => item.VENDOR === vendor));
 }
 

--- a/pages/api/cart.js
+++ b/pages/api/cart.js
@@ -1,0 +1,24 @@
+import { getCart, setCart } from '../../lib/db.js';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  const email = session.user.email;
+  if (req.method === 'GET') {
+    const items = getCart(email);
+    return res.status(200).json(items);
+  }
+  if (req.method === 'POST') {
+    const { items } = req.body || {};
+    if (!Array.isArray(items)) {
+      return res.status(400).json({ message: 'items required' });
+    }
+    setCart(email, items);
+    return res.status(200).json({ message: 'saved' });
+  }
+  return res.status(405).json({ message: 'Method Not Allowed' });
+}

--- a/pages/api/orders.js
+++ b/pages/api/orders.js
@@ -5,16 +5,45 @@ import {
   getOrdersForVendor,
 } from '../../lib/orders.js';
 import { findUser } from '../../lib/users.js';
+import {
+  getProductById,
+  decreaseProductQuantity,
+  clearCart,
+} from '../../lib/db.js';
 import { withRole } from '../../lib/withRole';
 
 async function handler(req, res) {
   if (req.method === 'POST') {
-    const { email, items, total } = req.body;
+    const { email, items, total, shippingName, shippingAddress } = req.body;
     if (!email || !items) {
       return res.status(400).json({ message: 'email and items required' });
     }
-    addOrder({ user_email: email, items, total: total || 0 });
-    return res.status(201).json({ message: 'order placed' });
+
+    for (const item of items) {
+      const product = getProductById(String(item.ID));
+      if (!product) {
+        return res.status(404).json({ message: 'Product not found' });
+      }
+      if ((product.quantity || 0) < item.qty) {
+        return res
+          .status(409)
+          .json({ message: `Insufficient stock for ${product.title}` });
+      }
+    }
+
+    for (const item of items) {
+      decreaseProductQuantity(String(item.ID), item.qty);
+    }
+
+    const orderId = addOrder({
+      user_email: email,
+      items,
+      total: total || 0,
+      shipping_name: shippingName,
+      shipping_address: shippingAddress,
+    });
+    clearCart(email);
+    return res.status(201).json({ message: 'order placed', id: orderId });
   }
 
   if (req.method === 'GET') {
@@ -34,4 +63,4 @@ async function handler(req, res) {
   return res.status(405).json({ message: 'Method Not Allowed' });
 }
 
-export default withRole(['USER','BRAND','SUPER_ADMIN'])(handler);
+export default withRole(['USER', 'BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -1,9 +1,10 @@
 import { useContext } from 'react';
+import { useRouter } from 'next/router';
 import { AppContext } from '../contexts/AppContext';
 
 export default function Cart() {
-  const { cart, changeQty, removeFromCart, placeOrder } =
-    useContext(AppContext);
+  const router = useRouter();
+  const { cart, changeQty, removeFromCart } = useContext(AppContext);
   const itemCount = cart.reduce((sum, item) => sum + item.qty, 0);
   const totalPrice = cart.reduce(
     (sum, item) => sum + item.qty * parseFloat(item.MIN_PRICE || 0),
@@ -61,7 +62,10 @@ export default function Cart() {
               Total Price: £{totalPrice.toFixed(2)}
             </p>
           </div>
-          <button className="btn btn-primary" onClick={placeOrder}>
+          <button
+            className="btn btn-primary"
+            onClick={() => router.push('/checkout')}
+          >
             Checkout
           </button>
         </div>

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -1,0 +1,90 @@
+import { useContext, useState } from 'react';
+import { useRouter } from 'next/router';
+import { AppContext } from '../contexts/AppContext';
+
+export default function Checkout() {
+  const router = useRouter();
+  const { cart, user, placeOrder } = useContext(AppContext);
+  const [name, setName] = useState(
+    user ? `${user.firstName} ${user.lastName}` : ''
+  );
+  const [address, setAddress] = useState('');
+  const [error, setError] = useState('');
+
+  const itemCount = cart.reduce((s, i) => s + i.qty, 0);
+  const totalPrice = cart.reduce(
+    (s, i) => s + i.qty * parseFloat(i.MIN_PRICE || 0),
+    0
+  );
+
+  if (!user) return <div className="p-4">Please log in to checkout.</div>;
+  if (cart.length === 0) return <div className="p-4">Your cart is empty.</div>;
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await placeOrder({ shippingName: name, shippingAddress: address });
+      router.push('/user/orders');
+    } catch (e) {
+      setError(e.message || 'Order failed');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">Checkout</h1>
+      <ul className="space-y-2 mb-4">
+        {cart.map((item) => {
+          const price = parseFloat(item.MIN_PRICE || 0);
+          const subtotal = price * item.qty;
+          return (
+            <li key={item.ID} className="border p-2 flex justify-between">
+              <div>
+                <p className="font-medium">{item.TITLE}</p>
+                <p className="text-sm">
+                  £{price.toFixed(2)} x {item.qty}
+                </p>
+              </div>
+              <span>£{subtotal.toFixed(2)}</span>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="border-t pt-4 mb-4 flex justify-between">
+        <p className="font-semibold">Items: {itemCount}</p>
+        <p className="font-semibold">Total: £{totalPrice.toFixed(2)}</p>
+      </div>
+      <form onSubmit={submit} className="space-y-3">
+        <div>
+          <label className="label" htmlFor="name">
+            Name
+          </label>
+          <input
+            id="name"
+            className="input input-bordered w-full"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="label" htmlFor="address">
+            Address
+          </label>
+          <textarea
+            id="address"
+            className="textarea textarea-bordered w-full"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            required
+          />
+        </div>
+        {error && <p className="text-red-500">{error}</p>}
+        <button className="btn btn-primary" type="submit">
+          Place Order
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -25,6 +25,12 @@ export default function Orders() {
             <p>
               Order #{o.id} - {o.status}
             </p>
+            {o.shipping_name && (
+              <p className="text-sm">Ship To: {o.shipping_name}</p>
+            )}
+            {o.shipping_address && (
+              <p className="text-sm">Address: {o.shipping_address}</p>
+            )}
             {(user.role === 'super-admin' || user.role === 'brand') && (
               <p className="text-sm text-gray-600">Customer: {o.user_email}</p>
             )}

--- a/pages/user/orders.js
+++ b/pages/user/orders.js
@@ -25,6 +25,12 @@ export default function UserOrders() {
             <p>
               Order #{o.id} - {o.status}
             </p>
+            {o.shipping_name && (
+              <p className="text-sm">Ship To: {o.shipping_name}</p>
+            )}
+            {o.shipping_address && (
+              <p className="text-sm">Address: {o.shipping_address}</p>
+            )}
             <ul className="list-disc pl-4 text-sm mb-1">
               {o.items.map((item) => (
                 <li key={item.ID}>


### PR DESCRIPTION
## Summary
- store cart server-side and create checkout page
- validate stock and update quantities when placing order
- add shipping fields to orders and display in history

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853bf861b0c832f954e34c7fbbff171