### PR TITLE
Move product data migration into DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,18 @@ NEXTAUTH_SECRET=random-secret
 npm run migrate
 ```
 
-5. **Place your product data**
+5. **Import products from Blob**
+
+```bash
+npm run migrate:blob
+```
+
+6. **Place your product data**
 
 Either put your `products.csv` inside the `/data/` directory **or** specify a
 remote file via the `PRODUCTS_URL` environment variable.
 
-6. **Run the project**
+7. **Run the project**
 
 ```bash
 npm run dev

--- a/lib/products.js
+++ b/lib/products.js
@@ -114,6 +114,30 @@ async function loadProductsData() {
   );
 }
 
+export function mapDbRowToProduct(row) {
+  return processProductRow({
+    ID: row.id,
+    TITLE: row.title,
+    VENDOR: row.vendor,
+    DESCRIPTION: row.description,
+    PRODUCT_TYPE: row.product_type,
+    TAGS: row.tags,
+    CATEGORY: row.category,
+    IMAGES: row.images ? JSON.parse(row.images) : [],
+    TOTAL_INVENTORY: row.quantity,
+    PRICE_RANGE_V2: {
+      min_variant_price: {
+        amount: row.min_price,
+        currency_code: row.currency,
+      },
+      max_variant_price: {
+        amount: row.max_price,
+        currency_code: row.currency,
+      },
+    },
+  });
+}
+
 function createFlexDoc() {
   return new Document({
     document: {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "migrate": "node scripts/migrate.mjs",
+    "migrate:blob": "node scripts/migrate-from-blob.mjs",
     "format": "prettier --write .",
     "test": "jest"
   },

--- a/pages/api/products/[id].js
+++ b/pages/api/products/[id].js
@@ -1,4 +1,5 @@
-import { loadAndIndexProducts } from '../../../lib/products';
+import { getProductById } from '../../../lib/db.js';
+import { mapDbRowToProduct } from '../../../lib/products.js';
 
 export default async function handler(req, res) {
   const { id } = req.query;
@@ -6,11 +7,11 @@ export default async function handler(req, res) {
     return res.status(400).json({ message: 'id required' });
   }
   try {
-    const { products } = await loadAndIndexProducts();
-    const product = products.find((p) => p.ID === String(id));
-    if (!product) {
+    const row = getProductById(String(id));
+    if (!row) {
       return res.status(404).json({ message: 'Not found' });
     }
+    const product = mapDbRowToProduct(row);
     res.status(200).json(product);
   } catch (e) {
     res.status(500).json({ message: 'Failed to load product' });

--- a/scripts/migrate-from-blob.mjs
+++ b/scripts/migrate-from-blob.mjs
@@ -1,0 +1,77 @@
+import fs from 'fs';
+import { list } from '@vercel/blob';
+import fetch from 'node-fetch';
+import { getDb } from '../lib/db.js';
+
+const FLAG_FILE = './data/blob_migrated.flag';
+const BLOB_FILE = 'flexsearch_index.json';
+
+async function loadProductsFromBlob() {
+  const { blobs } = await list();
+  const target = blobs.find((b) => b.pathname === BLOB_FILE);
+  if (!target || !target.downloadUrl) {
+    throw new Error('Blob file not found');
+  }
+  const res = await fetch(target.downloadUrl);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch blob: ${res.statusText}`);
+  }
+  const { loadedProducts } = await res.json();
+  return loadedProducts || [];
+}
+
+function insertProducts(products) {
+  const db = getDb();
+  const existsStmt = db.prepare('SELECT 1 FROM products WHERE id = ?');
+  const insertStmt = db.prepare(`INSERT INTO products (
+    id, title, vendor, description, product_type, tags, category,
+    quantity, min_price, max_price, currency, status, images
+  ) VALUES (
+    @id, @title, @vendor, @description, @product_type, @tags, @category,
+    @quantity, @min_price, @max_price, @currency, @status, @images
+  )`);
+  let inserted = 0;
+  let skipped = 0;
+  const tx = db.transaction(() => {
+    for (const p of products) {
+      if (existsStmt.get(String(p.ID))) {
+        skipped++;
+        continue;
+      }
+      insertStmt.run({
+        id: String(p.ID),
+        title: p.TITLE,
+        vendor: p.VENDOR,
+        description: p.DESCRIPTION,
+        product_type: p.PRODUCT_TYPE,
+        tags: p.TAGS,
+        category: p.CATEGORY,
+        quantity: p.TOTAL_INVENTORY || 0,
+        min_price: p.MIN_PRICE || 0,
+        max_price: p.MAX_PRICE || 0,
+        currency: p.CURRENCY || 'USD',
+        status: 'approved',
+        images: JSON.stringify(p.IMAGES || []),
+      });
+      inserted++;
+    }
+  });
+  tx();
+  return { inserted, skipped };
+}
+
+async function main() {
+  if (fs.existsSync(FLAG_FILE)) {
+    console.log('Migration already completed.');
+    return;
+  }
+  const products = await loadProductsFromBlob();
+  const { inserted, skipped } = insertProducts(products);
+  fs.writeFileSync(FLAG_FILE, 'done');
+  console.log(`Inserted ${inserted} products, skipped ${skipped}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- map DB rows to product index shape
- load product details directly from the database
- add script to migrate products from Vercel Blob into SQLite
- document migration step in README

## Testing
- `npx prettier --write lib/products.js pages/api/products/[id].js scripts/migrate-from-blob.mjs README.md package.json`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ce90c4b0832faf4dbfd65fc268f3