### PR TITLE
Fix category dropdown

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -54,7 +54,7 @@ export default function Header() {
   useEffect(() => {
     async function loadCategories() {
       try {
-        const res = await fetch('/api/category-tree');
+        const res = await fetch('/api/categories');
         if (res.ok) {
           const data = await res.json();
           setCategories(data || []);
@@ -175,7 +175,7 @@ export default function Header() {
               {menuOpen && (
                 <div
                   id="mega-menu"
-                  className="absolute left-0 mt-2 p-4 bg-white shadow rounded w-screen max-w-3xl"
+                  className="absolute left-0 mt-2 p-4 bg-base-100 shadow-lg rounded w-screen max-w-3xl"
                 >
                   <div
                     className="grid grid-cols-2 md:grid-cols-3 gap-4"
@@ -190,16 +190,16 @@ export default function Header() {
                         >
                           <Link
                             href={`/categories/${encodeURIComponent(cat.name)}`}
-                            className="flex items-center text-indigo-600 font-medium mb-1"
+                            className="flex items-center font-semibold mb-1 hover:text-indigo-600"
                           >
                             {iconMap[cat.name] || null}
                             {cat.name}
                           </Link>
                           {cat.subcategories &&
                             cat.subcategories.length > 0 && (
-                              <ul className="ml-6 space-y-1">
+                              <ul className="ml-4 space-y-1">
                                 {cat.subcategories.slice(0, 5).map((sub) => (
-                                  <li key={sub}>
+                                  <li key={sub} className="text-sm">
                                     <Link
                                       href={`/categories/${encodeURIComponent(cat.name)}?type=${encodeURIComponent(sub)}`}
                                       className="hover:text-indigo-600"

--- a/pages/api/categories.js
+++ b/pages/api/categories.js
@@ -1,9 +1,8 @@
-import { getCategories } from '../../lib/products';
+import { getCategoryTree } from '../../lib/products';
 
 export default function handler(req, res) {
   if (req.method === 'GET') {
-    const cats = getCategories();
-    return res.status(200).json(cats);
+    return res.status(200).json(getCategoryTree());
   }
   return res.status(405).json({ message: 'Method Not Allowed' });
 }

--- a/pages/categories/index.js
+++ b/pages/categories/index.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 export default function Categories() {
   const [categories, setCategories] = useState([]);
   useEffect(() => {
-    fetch('/api/category-tree')
+    fetch('/api/categories')
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => setCategories(data));
   }, []);

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -34,15 +34,30 @@ db.exec(`CREATE TABLE IF NOT EXISTS products (
   currency TEXT,
   status TEXT DEFAULT 'approved'
 )`);
-db.exec(
-  'CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE)'
-);
-
 // Categories table for grouping products
 db.exec(`CREATE TABLE IF NOT EXISTS categories (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  name TEXT UNIQUE
+  name TEXT UNIQUE,
+  parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES categories(id)
 )`);
+
+// Seed base categories if none exist
+const existingCount = db.prepare('SELECT COUNT(*) as c FROM categories').get();
+if (existingCount.c === 0) {
+  const sample = [
+    { name: 'Electronics', subs: ['Mobiles', 'Laptops'] },
+    { name: 'Fashion', subs: ['Men', 'Women'] },
+  ];
+  const insert = db.prepare(
+    'INSERT INTO categories (name, parent_id) VALUES (?, ?)'
+  );
+  sample.forEach((cat) => {
+    const info = insert.run(cat.name, null);
+    const parentId = info.lastInsertRowid;
+    cat.subs.forEach((sub) => insert.run(sub, parentId));
+  });
+}
 
 // Orders table
 db.exec(`CREATE TABLE IF NOT EXISTS orders (


### PR DESCRIPTION
## Summary
- seed demo categories with parent/subcategory structure
- update categories API to return nested data
- load categories from new endpoint in header
- display parent/subcategory dropdown menu styling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853dad37e90832f8d4ebde71c25bf5c