### PR TITLE
Add basic order status API and Stripe checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,9 @@
 # PostgreSQL connection string
 DATABASE_URL="postgresql://user:password@localhost:5432/dbname"
+# Stripe credentials
+STRIPE_SECRET_KEY="sk_test_yourkey"
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_yourkey"
+
+# Resend API key for email confirmations
+RESEND_API_KEY=""
+RESEND_FROM="orders@example.com"

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,0 +1,28 @@
+export async function sendOrderConfirmation(to, order) {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.RESEND_FROM || 'orders@example.com';
+  if (!apiKey) {
+    console.log('No RESEND_API_KEY configured');
+    return;
+  }
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from,
+        to,
+        subject: `Order #${order.id} Confirmation`,
+        html: `<p>Thank you for your order #${order.id}.</p>`,
+      }),
+    });
+    if (!res.ok) {
+      console.error('Failed to send email', await res.text());
+    }
+  } catch (e) {
+    console.error('Email error', e);
+  }
+}

--- a/lib/orders.js
+++ b/lib/orders.js
@@ -72,3 +72,15 @@ export function hasOrdersForProduct(productId) {
   }
   return false;
 }
+export function getOrderById(id) {
+  const db = getDb();
+  const stmt = db.prepare('SELECT * FROM orders WHERE id = ?');
+  const row = stmt.get(id);
+  return row ? { ...row, items: JSON.parse(row.items) } : null;
+}
+
+export function updateOrderStatus(id, status) {
+  const db = getDb();
+  const stmt = db.prepare('UPDATE orders SET status = ? WHERE id = ?');
+  stmt.run(status, id);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "next": "^14.2.29",
         "next-auth": "^4.24.6",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "stripe": "^12.18.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.27.2",
@@ -3818,7 +3819,6 @@
       "version": "22.15.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
       "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -12183,6 +12183,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-12.18.0.tgz",
+      "integrity": "sha512-cYjgBM2SY/dTm8Lr6eMyyONaHTZHA/QjHxFUIW5WH8FevSRIGAVtXEmBkUXF1fsqe7QvvRgQSGSJZmjDacegGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -12728,7 +12741,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "next": "^14.2.29",
     "next-auth": "^4.24.6",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "stripe": "^12.18.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/pages/api/checkout/complete.js
+++ b/pages/api/checkout/complete.js
@@ -1,0 +1,35 @@
+import Stripe from 'stripe';
+import { addOrder } from '../../../lib/orders.js';
+import { sendOrderConfirmation } from '../../../lib/email.js';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2023-10-16',
+});
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const { sessionId } = req.body || {};
+  if (!sessionId) return res.status(400).json({ message: 'sessionId required' });
+  try {
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+    if (session.payment_status !== 'paid') {
+      return res.status(400).json({ message: 'payment not completed' });
+    }
+    const metadata = session.metadata || {};
+    const orderId = addOrder({
+      user_email: metadata.email,
+      items: JSON.parse(metadata.items || '[]'),
+      total: session.amount_total / 100,
+      status: 'completed',
+      shipping_name: metadata.shippingName,
+      shipping_address: metadata.shippingAddress,
+    });
+    await sendOrderConfirmation(metadata.email, { id: orderId });
+    return res.status(200).json({ id: orderId });
+  } catch (e) {
+    console.error(e);
+    return res.status(500).json({ message: 'stripe error' });
+  }
+}

--- a/pages/api/checkout/create-session.js
+++ b/pages/api/checkout/create-session.js
@@ -1,0 +1,41 @@
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2023-10-16',
+});
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const { items, email, shippingName, shippingAddress } = req.body || {};
+  if (!items || !email) {
+    return res.status(400).json({ message: 'items and email required' });
+  }
+  try {
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      line_items: items.map((it) => ({
+        price_data: {
+          currency: 'usd',
+          product_data: { name: it.TITLE },
+          unit_amount: Math.round(parseFloat(it.MIN_PRICE || 0) * 100),
+        },
+        quantity: it.qty,
+      })),
+      mode: 'payment',
+      success_url: `${req.headers.origin}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${req.headers.origin}/checkout/cancel`,
+      metadata: {
+        email,
+        shippingName: shippingName || '',
+        shippingAddress: shippingAddress || '',
+        items: JSON.stringify(items),
+      },
+    });
+    return res.status(200).json({ url: session.url, id: session.id });
+  } catch (e) {
+    console.error(e);
+    return res.status(500).json({ message: 'stripe error' });
+  }
+}

--- a/pages/api/orders/[id].js
+++ b/pages/api/orders/[id].js
@@ -1,0 +1,30 @@
+import { getOrderById } from '../../../lib/orders.js';
+import { updateOrderStatus } from '../../../lib/orders.js';
+import { withRole } from '../../../lib/withRole';
+
+function handler(req, res) {
+  const { id } = req.query;
+  if (!id) {
+    return res.status(400).json({ message: 'id required' });
+  }
+
+  if (req.method === 'GET') {
+    const order = getOrderById(String(id));
+    if (!order) return res.status(404).json({ message: 'Not found' });
+    return res.status(200).json(order);
+  }
+
+  if (req.method === 'PATCH') {
+    const { status } = req.body || {};
+    if (!status || !['pending', 'shipped', 'completed'].includes(status)) {
+      return res.status(400).json({ message: 'invalid status' });
+    }
+    updateOrderStatus(String(id), status);
+    const order = getOrderById(String(id));
+    return res.status(200).json(order);
+  }
+
+  return res.status(405).json({ message: 'Method Not Allowed' });
+}
+
+export default withRole(['BRAND','SUPER_ADMIN'])(handler);

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -4,7 +4,7 @@ import { AppContext } from '../contexts/AppContext';
 
 export default function Checkout() {
   const router = useRouter();
-  const { cart, user, placeOrder } = useContext(AppContext);
+  const { cart, user } = useContext(AppContext);
   const [name, setName] = useState(
     user ? `${user.firstName} ${user.lastName}` : ''
   );
@@ -24,8 +24,19 @@ export default function Checkout() {
     e.preventDefault();
     setError('');
     try {
-      await placeOrder({ shippingName: name, shippingAddress: address });
-      router.push('/user/orders');
+      const res = await fetch('/api/checkout/create-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          items: cart,
+          email: user.email,
+          shippingName: name,
+          shippingAddress: address,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Checkout failed');
+      window.location.href = data.url;
     } catch (e) {
       setError(e.message || 'Order failed');
     }

--- a/pages/checkout/cancel.js
+++ b/pages/checkout/cancel.js
@@ -1,0 +1,3 @@
+export default function Cancel() {
+  return <p className="p-4">Payment canceled.</p>;
+}

--- a/pages/checkout/success.js
+++ b/pages/checkout/success.js
@@ -1,0 +1,24 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+export default function Success() {
+  const router = useRouter();
+  const { session_id } = router.query;
+  const [status, setStatus] = useState('processing');
+
+  useEffect(() => {
+    if (!session_id) return;
+    fetch('/api/checkout/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: session_id }),
+    })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then(() => setStatus('success'))
+      .catch(() => setStatus('error'));
+  }, [session_id]);
+
+  if (status === 'processing') return <p className="p-4">Processing payment...</p>;
+  if (status === 'error') return <p className="p-4">Payment failed.</p>;
+  return <p className="p-4">Payment successful! Check your email for confirmation.</p>;
+}

--- a/pages/vendor/orders.js
+++ b/pages/vendor/orders.js
@@ -5,14 +5,27 @@ export default function VendorOrders() {
   const { user } = useContext(AppContext);
   const [orders, setOrders] = useState([]);
 
-  useEffect(() => {
+  const fetchOrders = () => {
     if (!user) return;
-    fetch(
-      `/api/vendor/orders?vendor=${encodeURIComponent(user.brandName || '')}`
-    )
+    fetch(`/api/vendor/orders?vendor=${encodeURIComponent(user.brandName || '')}`)
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => setOrders(data));
+  };
+
+  useEffect(() => {
+    fetchOrders();
   }, [user]);
+
+  const updateStatus = async (id, status) => {
+    const res = await fetch(`/api/orders/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    if (res.ok) {
+      fetchOrders();
+    }
+  };
 
   if (!user) {
     return <div className="p-4">Please log in to view orders.</div>;
@@ -26,10 +39,21 @@ export default function VendorOrders() {
       <h1 className="text-2xl font-bold mb-4">Order History</h1>
       <ul className="space-y-2">
         {orders.map((o) => (
-          <li key={o.id} className="border p-2">
+          <li key={o.id} className="border p-2 space-y-1">
             <p>
-              Order #{o.id} - {o.status}
+              Order #{o.id}
             </p>
+            <select
+              className="select select-bordered"
+              value={o.status}
+              onChange={(e) => updateStatus(o.id, e.target.value)}
+            >
+              {['pending', 'shipped', 'completed'].map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
             <p>Total: £{o.total}</p>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- add Stripe dependency for payments
- implement order status helpers and API
- add vendor UI to update order status
- integrate Stripe Checkout flow
- send email confirmations via Resend
- document env vars for Stripe & email

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6853dd46901c832fbe82cbbc96100973