### PR TITLE
Fix cart icon styling in header

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -288,17 +288,16 @@ export default function Header() {
       </div>
       <nav className="hidden md:flex flex-none ml-auto">
         <ul className="menu menu-horizontal gap-2">
-          <li>
-            <div className="relative mr-2">
-              <Link
-                href="/cart"
-                className="p-2 rounded-full shadow hover:bg-base-200 relative"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
+          <li className="relative mr-1">
+            <Link
+              href="/cart"
+              className="p-2 rounded-full shadow-sm hover:bg-base-200"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
                   strokeWidth="1.5"
                   className="w-5 h-5"
                   aria-hidden="true"
@@ -306,16 +305,15 @@ export default function Header() {
                   <path
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
-                  />
-                </svg>
-                {itemCount > 0 && (
-                  <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full px-1">
-                    {itemCount}
-                  </span>
-                )}
-              </Link>
-            </div>
+                d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+                />
+              </svg>
+              {itemCount > 0 && (
+                <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full px-1">
+                  {itemCount}
+                </span>
+              )}
+            </Link>
           </li>
           {user ? (
             <>
@@ -387,17 +385,16 @@ export default function Header() {
             tabIndex={0}
             className="menu dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52"
           >
-            <li>
-              <div className="relative flex items-center">
-                <Link
-                  href="/cart"
-                  className="p-2 rounded-full shadow hover:bg-base-200 relative"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
+            <li className="relative">
+              <Link
+                href="/cart"
+                className="p-2 rounded-full shadow-sm hover:bg-base-200"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
                     strokeWidth="1.5"
                     className="w-5 h-5"
                     aria-hidden="true"
@@ -409,12 +406,11 @@ export default function Header() {
                     />
                   </svg>
                 </Link>
-                {itemCount > 0 && (
-                  <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full px-1">
-                    {itemCount}
-                  </span>
-                )}
-              </div>
+              {itemCount > 0 && (
+                <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full px-1">
+                  {itemCount}
+                </span>
+              )}
             </li>
             <li>
               <details>


### PR DESCRIPTION
## Summary
- remove extra wrapper around cart icon to avoid stacked shadows
- tweak cart icon styling and spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853df1b07a4832fb71b0b274693a3bf