### PR TITLE
Add analytics dashboards for admins and brands

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -320,11 +320,18 @@ export default function Header() {
           {user ? (
             <>
               {user.role === 'super-admin' ? (
-                <li>
-                  <Link href="/admin" className="btn btn-ghost mr-2">
-                    Admin
-                  </Link>
-                </li>
+                <>
+                  <li>
+                    <Link href="/admin" className="btn btn-ghost mr-2">
+                      Admin
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/admin/analytics" className="btn btn-ghost mr-2">
+                      Analytics
+                    </Link>
+                  </li>
+                </>
               ) : (
                 <>
                   <li>
@@ -454,15 +461,25 @@ export default function Header() {
             </li>
             {user ? (
               <>
-                {user.role === 'super-admin' ? (
+              {user.role === 'super-admin' ? (
+                <>
                   <li>
                     <Link href="/admin">Admin</Link>
                   </li>
-                ) : user.role === 'brand' ? (
+                  <li>
+                    <Link href="/admin/analytics">Analytics</Link>
+                  </li>
+                </>
+              ) : user.role === 'brand' ? (
+                <>
                   <li>
                     <Link href="/brand/profile">Profile</Link>
                   </li>
-                ) : (
+                  <li>
+                    <Link href="/brand/analytics">Analytics</Link>
+                  </li>
+                </>
+              ) : (
                   <>
                     <li>
                       <Link href="/user/orders">Orders</Link>

--- a/lib/users.js
+++ b/lib/users.js
@@ -37,6 +37,7 @@ export async function addUser({
       logo,
       taxId: tax_id,
       role,
+      disabled: false,
       verificationToken: verification_token,
     },
   });
@@ -55,12 +56,17 @@ export function getAllUsers() {
       brandName: true,
       gender: true,
       role: true,
+      disabled: true,
     },
   });
 }
 
 export function updateUserRole(email, role) {
   return prisma.user.update({ where: { email }, data: { role } });
+}
+
+export function setUserDisabled(email, disabled) {
+  return prisma.user.update({ where: { email }, data: { disabled } });
 }
 
 export function deleteUser(email) {

--- a/pages/admin/analytics.js
+++ b/pages/admin/analytics.js
@@ -1,0 +1,50 @@
+import { useContext, useEffect, useState } from 'react';
+import { AppContext } from '../../contexts/AppContext';
+import Link from 'next/link';
+
+export default function AdminAnalytics() {
+  const { user } = useContext(AppContext);
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    if (!user) return;
+    fetch('/api/admin/analytics')
+      .then((res) => (res.ok ? res.json() : null))
+      .then(setData);
+  }, [user]);
+
+  if (!user) return <div className="p-4">Please log in to view analytics.</div>;
+  if (user.role !== 'super-admin')
+    return <div className="p-4">Admin access required.</div>;
+
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Super Admin Dashboard</h1>
+      <div className="mb-4 space-x-2">
+        <Link href="/admin/users" className="btn btn-sm">
+          Users
+        </Link>
+        <Link href="/admin/categories" className="btn btn-sm">
+          Categories
+        </Link>
+        <Link href="/admin/approvals" className="btn btn-sm">
+          Approvals
+        </Link>
+      </div>
+      <p>Total Orders: {data.totalOrders}</p>
+      <p>Total Revenue: £{data.totalRevenue.toFixed(2)}</p>
+      <h2 className="text-xl font-semibold mt-4 mb-2">Top Products</h2>
+      <ul className="list-disc list-inside">
+        {data.topProducts.map((p) => (
+          <li key={p.id}>
+            {p.id} - {p.qty} sold
+          </li>
+        ))}
+        {data.topProducts.length === 0 && <li>No sales yet.</li>}
+      </ul>
+    </div>
+  );
+}
+

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -107,6 +107,9 @@ export default function Admin() {
         <Link href="/admin/approvals" className="btn btn-sm">
           Approvals
         </Link>
+        <Link href="/admin/analytics" className="btn btn-sm">
+          Analytics
+        </Link>
       </div>
       {message && <div className="mb-4 text-green-600">{message}</div>}
       <button

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -28,6 +28,18 @@ export default function ManageUsers() {
     }
   };
 
+  const toggleDisabled = async (email, disabled) => {
+    const res = await fetch('/api/admin/users', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, disabled }),
+    });
+    if (res.ok) {
+      setMessage('Status updated');
+      fetchUsers();
+    }
+  };
+
   const remove = async (email) => {
     const res = await fetch(
       `/api/admin/users?email=${encodeURIComponent(email)}`,
@@ -60,6 +72,15 @@ export default function ManageUsers() {
               <option value="brand">brand</option>
               <option value="super-admin">super-admin</option>
             </select>
+            <label className="label cursor-pointer gap-1">
+              <span className="label-text">Disabled</span>
+              <input
+                type="checkbox"
+                className="checkbox"
+                checked={u.disabled}
+                onChange={(e) => toggleDisabled(u.email, e.target.checked)}
+              />
+            </label>
             <button onClick={() => remove(u.email)} className="btn btn-sm">
               Delete
             </button>

--- a/pages/api/admin/analytics.js
+++ b/pages/api/admin/analytics.js
@@ -1,0 +1,29 @@
+import { getAllOrders } from '../../../lib/orders';
+import { withRole } from '../../../lib/withRole';
+
+function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const orders = getAllOrders();
+  const summary = {
+    totalOrders: orders.length,
+    totalRevenue: 0,
+    topProducts: [],
+  };
+  const counts = {};
+  orders.forEach((o) => {
+    summary.totalRevenue += o.total || 0;
+    o.items.forEach((i) => {
+      counts[i.ID] = (counts[i.ID] || 0) + i.qty;
+    });
+  });
+  summary.topProducts = Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([id, qty]) => ({ id, qty }));
+  return res.status(200).json(summary);
+}
+
+export default withRole(['SUPER_ADMIN'])(handler);
+

--- a/pages/api/admin/users.js
+++ b/pages/api/admin/users.js
@@ -3,6 +3,7 @@ import {
   updateUserRole,
   deleteUser,
   addUser,
+  setUserDisabled,
 } from '../../../lib/users';
 import { withRole } from '../../../lib/withRole';
 
@@ -16,6 +17,13 @@ async function handler(req, res) {
       return res.status(400).json({ message: 'email and role required' });
     await updateUserRole(email, role);
     return res.status(200).json({ message: 'role updated' });
+  }
+  if (req.method === 'PATCH') {
+    const { email, disabled } = req.body || {};
+    if (typeof disabled !== 'boolean' || !email)
+      return res.status(400).json({ message: 'email and disabled required' });
+    await setUserDisabled(email, disabled);
+    return res.status(200).json({ message: 'status updated' });
   }
   if (req.method === 'DELETE') {
     const { email } = req.query;

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -23,7 +23,11 @@ export const authOptions = {
       },
       async authorize(credentials) {
         const user = await findUser(credentials.email);
-        if (user && (await bcrypt.compare(credentials.password, user.password))) {
+        if (
+          user &&
+          !user.disabled &&
+          (await bcrypt.compare(credentials.password, user.password))
+        ) {
           const { firstName, lastName, brandName, gender, role } = user;
           return {
             id: user.email,
@@ -42,6 +46,9 @@ export const authOptions = {
     async signIn({ user, account, profile }) {
       if (account.provider === 'google' || account.provider === 'github') {
         const existing = await findUser(user.email);
+        if (existing && existing.disabled) {
+          return false;
+        }
         if (!existing) {
           const nameParts = (profile?.name || '').split(' ');
           await addUser({
@@ -54,6 +61,9 @@ export const authOptions = {
             role: 'USER',
           });
         }
+      }
+      if (user && user.disabled) {
+        return false;
       }
       return true;
     },

--- a/pages/api/brand/analytics.js
+++ b/pages/api/brand/analytics.js
@@ -1,0 +1,32 @@
+import { getOrdersForVendor } from '../../../lib/orders';
+
+export default function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const { vendor } = req.query;
+  if (!vendor) {
+    return res.status(400).json({ message: 'vendor required' });
+  }
+  const orders = getOrdersForVendor(vendor);
+  const summary = {
+    totalOrders: orders.length,
+    totalRevenue: 0,
+    topProducts: [],
+  };
+  const counts = {};
+  orders.forEach((o) => {
+    summary.totalRevenue += o.total || 0;
+    o.items
+      .filter((i) => i.VENDOR === vendor)
+      .forEach((i) => {
+        counts[i.ID] = (counts[i.ID] || 0) + i.qty;
+      });
+  });
+  summary.topProducts = Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([id, qty]) => ({ id, qty }));
+  return res.status(200).json(summary);
+}
+

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -10,7 +10,11 @@ export default async function handler(req, res) {
     return res.status(400).json({ message: 'email and password required' });
   }
   const user = await findUser(email);
-  if (!user || !(await bcrypt.compare(password, user.password))) {
+  if (
+    !user ||
+    user.disabled ||
+    !(await bcrypt.compare(password, user.password))
+  ) {
     return res.status(401).json({ message: 'Invalid credentials' });
   }
   const { firstName, lastName, brandName, gender, role } = user;

--- a/pages/brand/analytics.js
+++ b/pages/brand/analytics.js
@@ -1,0 +1,38 @@
+import { useContext, useEffect, useState } from 'react';
+import { AppContext } from '../../contexts/AppContext';
+
+export default function BrandAnalytics() {
+  const { user } = useContext(AppContext);
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    if (!user) return;
+    fetch(`/api/brand/analytics?vendor=${encodeURIComponent(user.brandName || '')}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then(setData);
+  }, [user]);
+
+  if (!user) return <div className="p-4">Please log in.</div>;
+  if (user.role !== 'brand')
+    return <div className="p-4">Brand access required.</div>;
+
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Sales Summary</h1>
+      <p>Total Orders: {data.totalOrders}</p>
+      <p>Total Revenue: £{data.totalRevenue.toFixed(2)}</p>
+      <h2 className="text-xl font-semibold mt-4 mb-2">Top Products</h2>
+      <ul className="list-disc list-inside">
+        {data.topProducts.map((p) => (
+          <li key={p.id}>
+            {p.id} - {p.qty} sold
+          </li>
+        ))}
+        {data.topProducts.length === 0 && <li>No sales yet.</li>}
+      </ul>
+    </div>
+  );
+}
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   taxId             String?
   role              Role     @default(USER)
   verified          Boolean  @default(false)
+  disabled          Boolean  @default(false)
   verificationToken String?
   resetToken        String?
   resetExpires      DateTime?


### PR DESCRIPTION
## Summary
- add `disabled` field to Prisma user model
- allow super admins to disable accounts
- show analytics links in header
- implement brand sales analytics API and dashboard
- implement super admin analytics API and dashboard
- secure login flow for disabled users

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853defee29c832fb82259a8ada5dca8