### PR TITLE
Improve checkout UI and toasts

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -175,7 +175,7 @@ export default function Header() {
               {menuOpen && (
                 <div
                   id="mega-menu"
-                  className="absolute left-0 mt-2 p-4 bg-base-100 shadow-lg rounded w-screen max-w-3xl"
+                  className="absolute left-0 top-full mt-2 z-20 p-4 bg-base-100 shadow-lg rounded w-screen max-w-3xl"
                 >
                   <div
                     className="grid grid-cols-2 md:grid-cols-3 gap-4"

--- a/contexts/AppContext.js
+++ b/contexts/AppContext.js
@@ -129,16 +129,18 @@ export function AppProvider({ children }) {
   };
 
   const addToCart = (product) => {
+    let qty = 1;
     setCart((prev) => {
       const existing = prev.find((p) => p.ID === product.ID);
       if (existing) {
+        qty = existing.qty + 1;
         return prev.map((p) =>
-          p.ID === product.ID ? { ...p, qty: p.qty + 1 } : p
+          p.ID === product.ID ? { ...p, qty } : p
         );
       }
-      return [...prev, { ...product, qty: 1 }];
+      return [...prev, { ...product, qty }];
     });
-    addNotification('Added to cart', 'success');
+    addNotification(`Added ${product.TITLE} (x${qty}) to cart`, 'success', 'center');
   };
 
   const changeQty = (id, delta) => {

--- a/contexts/NotificationContext.js
+++ b/contexts/NotificationContext.js
@@ -5,23 +5,63 @@ export const NotificationContext = createContext();
 export function NotificationProvider({ children }) {
   const [notifs, setNotifs] = useState([]);
 
-  const addNotification = useCallback((message, type = 'info') => {
-    const id = Date.now() + Math.random();
-    setNotifs((prev) => [...prev, { id, message, type }]);
-    setTimeout(() => {
-      setNotifs((prev) => prev.filter((n) => n.id !== id));
-    }, 5000);
+  const addNotification = useCallback(
+    (message, type = 'info', position = 'end') => {
+      const id = Date.now() + Math.random();
+      setNotifs((prev) => [...prev, { id, message, type, position }]);
+      setTimeout(() => {
+        setNotifs((prev) => prev.filter((n) => n.id !== id));
+      }, 5000);
+    },
+    []
+  );
+
+  const removeNotification = useCallback((id) => {
+    setNotifs((prev) => prev.filter((n) => n.id !== id));
   }, []);
 
   return (
     <NotificationContext.Provider value={{ addNotification }}>
       {children}
-      <div className="toast toast-end space-y-2">
-        {notifs.map((n) => (
-          <div key={n.id} className={`alert alert-${n.type} shadow-md`}>
-            {n.message}
-          </div>
-        ))}
+      <div className="fixed inset-0 pointer-events-none z-50">
+        <div className="absolute left-1/2 top-5 -translate-x-1/2 space-y-2">
+          {notifs
+            .filter((n) => n.position === 'center')
+            .map((n) => (
+              <div
+                key={n.id}
+                className={`alert alert-${n.type} shadow-md relative`}
+              >
+                {n.message}
+                <button
+                  type="button"
+                  className="absolute right-2 top-1"
+                  onClick={() => removeNotification(n.id)}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+        </div>
+        <div className="absolute right-5 bottom-5 space-y-2">
+          {notifs
+            .filter((n) => n.position !== 'center')
+            .map((n) => (
+              <div
+                key={n.id}
+                className={`alert alert-${n.type} shadow-md relative`}
+              >
+                {n.message}
+                <button
+                  type="button"
+                  className="absolute right-2 top-1"
+                  onClick={() => removeNotification(n.id)}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+        </div>
       </div>
     </NotificationContext.Provider>
   );

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -1,5 +1,6 @@
 import { useContext, useState } from 'react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 import { AppContext } from '../contexts/AppContext';
 
 export default function Checkout() {
@@ -17,7 +18,15 @@ export default function Checkout() {
     0
   );
 
-  if (!user) return <div className="p-4">Please log in to checkout.</div>;
+  if (!user)
+    return (
+      <div className="h-64 flex flex-col items-center justify-center space-y-4">
+        <p className="text-lg">Please log in to checkout.</p>
+        <Link href="/login" className="btn btn-primary">
+          Login
+        </Link>
+      </div>
+    );
   if (cart.length === 0) return <div className="p-4">Your cart is empty.</div>;
 
   const submit = async (e) => {


### PR DESCRIPTION
## Summary
- center the login notice and add login button on the checkout page
- show centered toasts when adding items to the cart and add a close button
- include product name and quantity in cart toast messages
- adjust category dropdown positioning and z-index so it doesn't overlap the search bar

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853e23bcbd0832faf2d6a090b7e735f