### PR TITLE
Improve signup/login UX

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -9,6 +9,9 @@ export default function Header() {
   const { data: session } = useSession();
   const { cart } = useContext(AppContext);
   const user = session?.user;
+  const pathname = router.pathname || '';
+  const isSignupRoute = pathname.startsWith('/signup');
+  const isLoginRoute = pathname === '/login';
   const logout = () => signOut({ redirect: false });
   const [categories, setCategories] = useState([]);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -298,14 +301,14 @@ export default function Header() {
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                  strokeWidth="1.5"
-                  className="w-5 h-5"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+                strokeWidth="1.5"
+                className="w-5 h-5"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
                 />
               </svg>
               {itemCount > 0 && (
@@ -325,7 +328,10 @@ export default function Header() {
                     </Link>
                   </li>
                   <li>
-                    <Link href="/admin/analytics" className="btn btn-ghost mr-2">
+                    <Link
+                      href="/admin/analytics"
+                      className="btn btn-ghost mr-2"
+                    >
                       Analytics
                     </Link>
                   </li>
@@ -355,16 +361,20 @@ export default function Header() {
             </>
           ) : (
             <>
-              <li>
-                <Link href="/login" className="btn btn-ghost">
-                  Login
-                </Link>
-              </li>
-              <li>
-                <Link href="/signup" className="btn btn-primary ml-2">
-                  Signup
-                </Link>
-              </li>
+              {!isLoginRoute && (
+                <li>
+                  <Link href="/login" className="btn btn-ghost">
+                    Login
+                  </Link>
+                </li>
+              )}
+              {!isSignupRoute && (
+                <li>
+                  <Link href="/signup" className="btn btn-primary ml-2">
+                    Signup
+                  </Link>
+                </li>
+              )}
             </>
           )}
         </ul>
@@ -402,17 +412,17 @@ export default function Header() {
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
-                    strokeWidth="1.5"
-                    className="w-5 h-5"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
-                    />
-                  </svg>
-                </Link>
+                  strokeWidth="1.5"
+                  className="w-5 h-5"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+                  />
+                </svg>
+              </Link>
               {itemCount > 0 && (
                 <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full px-1">
                   {itemCount}
@@ -457,25 +467,25 @@ export default function Header() {
             </li>
             {user ? (
               <>
-              {user.role === 'super-admin' ? (
-                <>
-                  <li>
-                    <Link href="/admin">Admin</Link>
-                  </li>
-                  <li>
-                    <Link href="/admin/analytics">Analytics</Link>
-                  </li>
-                </>
-              ) : user.role === 'brand' ? (
-                <>
-                  <li>
-                    <Link href="/brand/profile">Profile</Link>
-                  </li>
-                  <li>
-                    <Link href="/brand/analytics">Analytics</Link>
-                  </li>
-                </>
-              ) : (
+                {user.role === 'super-admin' ? (
+                  <>
+                    <li>
+                      <Link href="/admin">Admin</Link>
+                    </li>
+                    <li>
+                      <Link href="/admin/analytics">Analytics</Link>
+                    </li>
+                  </>
+                ) : user.role === 'brand' ? (
+                  <>
+                    <li>
+                      <Link href="/brand/profile">Profile</Link>
+                    </li>
+                    <li>
+                      <Link href="/brand/analytics">Analytics</Link>
+                    </li>
+                  </>
+                ) : (
                   <>
                     <li>
                       <Link href="/user/orders">Orders</Link>
@@ -493,12 +503,16 @@ export default function Header() {
               </>
             ) : (
               <>
-                <li>
-                  <Link href="/login">Login</Link>
-                </li>
-                <li>
-                  <Link href="/signup">Signup</Link>
-                </li>
+                {!isLoginRoute && (
+                  <li>
+                    <Link href="/login">Login</Link>
+                  </li>
+                )}
+                {!isSignupRoute && (
+                  <li>
+                    <Link href="/signup">Signup</Link>
+                  </li>
+                )}
               </>
             )}
           </ul>

--- a/pages/login.js
+++ b/pages/login.js
@@ -2,6 +2,7 @@ import { useState, useContext, useEffect } from 'react';
 import { AppContext } from '../contexts/AppContext';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -174,6 +175,12 @@ export default function Login() {
           Login
         </button>
       </form>
+      <p className="text-center mt-4">
+        Don’t have an account?{' '}
+        <Link href="/signup" className="link">
+          Signup
+        </Link>
+      </p>
     </div>
   );
 }

--- a/pages/signup/brand.js
+++ b/pages/signup/brand.js
@@ -1,5 +1,6 @@
 import { useState, useContext, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
 import { signIn } from 'next-auth/react';
 
@@ -186,10 +187,10 @@ export default function BrandSignup() {
       <div className="text-center mb-6">
         <h1 className="text-2xl font-bold">Brand Sign Up</h1>
       </div>
-      <div className="flex flex-col md:flex-row gap-4 mb-4 justify-center">
+      <div className="flex flex-row gap-4 mb-4 justify-center">
         <button
           type="button"
-          className="btn flex-1 md:flex-none hover:bg-red-600 hover:text-white flex items-center justify-center gap-2 rounded-lg"
+          className="btn btn-lg flex-1 hover:bg-red-600 hover:text-white flex items-center justify-center gap-2 rounded-lg"
           onClick={() => signIn('google')}
         >
           <svg
@@ -202,11 +203,11 @@ export default function BrandSignup() {
               d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.362 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
             />
           </svg>
-          Google
+          Continue with Google
         </button>
         <button
           type="button"
-          className="btn flex-1 md:flex-none hover:bg-gray-800 hover:text-white flex items-center justify-center gap-2 rounded-lg"
+          className="btn btn-lg flex-1 hover:bg-gray-800 hover:text-white flex items-center justify-center gap-2 rounded-lg"
           onClick={() => signIn('github')}
         >
           <svg
@@ -219,7 +220,7 @@ export default function BrandSignup() {
               d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.77.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.812 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
             />
           </svg>
-          GitHub
+          Continue with GitHub
         </button>
       </div>
       {formError && <div className="text-red-500 mb-2">{formError}</div>}
@@ -510,6 +511,12 @@ export default function BrandSignup() {
           {loading ? 'Creating...' : 'Create Brand Account'}
         </button>
       </form>
+      <p className="text-center mt-4">
+        Already have an account?{' '}
+        <Link href="/login" className="link">
+          Login
+        </Link>
+      </p>
     </div>
   );
 }

--- a/pages/signup/user.js
+++ b/pages/signup/user.js
@@ -1,5 +1,6 @@
 import { useState, useContext, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
 import { signIn } from 'next-auth/react';
 
@@ -128,40 +129,42 @@ export default function UserSignup() {
   return (
     <div className="p-4 max-w-sm mx-auto">
       <h1 className="text-2xl font-bold mb-4">User Sign Up</h1>
-      <button
-        type="button"
-        className="btn w-full mb-2 hover:bg-red-600 hover:text-white flex items-center justify-center gap-2"
-        onClick={() => signIn('google')}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          className="h-5 w-5"
+      <div className="flex gap-2 mb-2">
+        <button
+          type="button"
+          className="btn btn-lg flex-1 hover:bg-red-600 hover:text-white flex items-center justify-center gap-2"
+          onClick={() => signIn('google')}
         >
-          <path
-            fill="currentColor"
-            d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.362 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
-          />
-        </svg>
-        Sign up with Google
-      </button>
-      <button
-        type="button"
-        className="btn w-full mb-2 hover:bg-gray-800 hover:text-white flex items-center justify-center gap-2"
-        onClick={() => signIn('github')}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          className="h-5 w-5"
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            className="h-5 w-5"
+          >
+            <path
+              fill="currentColor"
+              d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.362 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
+            />
+          </svg>
+          Continue with Google
+        </button>
+        <button
+          type="button"
+          className="btn btn-lg flex-1 hover:bg-gray-800 hover:text-white flex items-center justify-center gap-2"
+          onClick={() => signIn('github')}
         >
-          <path
-            fill="currentColor"
-            d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.77.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.812 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
-          />
-        </svg>
-        Sign up with GitHub
-      </button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            className="h-5 w-5"
+          >
+            <path
+              fill="currentColor"
+              d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.77.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.812 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+            />
+          </svg>
+          Continue with GitHub
+        </button>
+      </div>
       {formError && <div className="text-red-500 mb-2">{formError}</div>}
       <form onSubmit={submit} className="space-y-2">
         <div>
@@ -198,133 +201,135 @@ export default function UserSignup() {
             <p className="text-red-500 text-sm">{errors.email}</p>
           )}
         </div>
-        <div className="relative">
-          <input
-            type={showPassword ? 'text' : 'password'}
-            className={`input input-bordered w-full pr-10 ${errors.password ? 'border-red-500' : ''}`}
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            onBlur={handlePasswordBlur}
-            placeholder="Password"
-          />
-          <button
-            type="button"
-            className="absolute right-2 top-2"
-            onClick={() => setShowPassword(!showPassword)}
-          >
-            {showPassword ? (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                className="h-5 w-5"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.965 9.965 0 012.652-4.304m3.821-2.338A9.953 9.953 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.952 9.952 0 01-.46 1.08M15 12a3 3 0 11-6 0 3 3 0 016 0zm-1.259 4.75L5.21 5.21"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M3 3l18 18"
-                />
-              </svg>
-            ) : (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                className="h-5 w-5"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                />
-              </svg>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <div className="relative">
+            <input
+              type={showPassword ? 'text' : 'password'}
+              className={`input input-bordered w-full pr-10 ${errors.password ? 'border-red-500' : ''}`}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onBlur={handlePasswordBlur}
+              placeholder="Password"
+            />
+            <button
+              type="button"
+              className="absolute right-2 top-2"
+              onClick={() => setShowPassword(!showPassword)}
+            >
+              {showPassword ? (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  className="h-5 w-5"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.965 9.965 0 012.652-4.304m3.821-2.338A9.953 9.953 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.952 9.952 0 01-.46 1.08M15 12a3 3 0 11-6 0 3 3 0 016 0zm-1.259 4.75L5.21 5.21"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M3 3l18 18"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  className="h-5 w-5"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  />
+                </svg>
+              )}
+            </button>
+            <p className="text-sm text-gray-500">
+              Password must be at least 8 characters and include uppercase,
+              lowercase, number and special character
+            </p>
+            {errors.password && (
+              <p className="text-red-500 text-sm">{errors.password}</p>
             )}
-          </button>
-          <p className="text-sm text-gray-500">
-            Password must be at least 8 characters and include uppercase,
-            lowercase, number and special character
-          </p>
-          {errors.password && (
-            <p className="text-red-500 text-sm">{errors.password}</p>
-          )}
-        </div>
-        <div className="relative">
-          <input
-            type={showConfirm ? 'text' : 'password'}
-            className={`input input-bordered w-full pr-10 ${errors.confirm ? 'border-red-500' : ''}`}
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-            onBlur={handleConfirmBlur}
-            placeholder="Confirm Password"
-          />
-          <button
-            type="button"
-            className="absolute right-2 top-2"
-            onClick={() => setShowConfirm(!showConfirm)}
-          >
-            {showConfirm ? (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                className="h-5 w-5"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.965 9.965 0 012.652-4.304m3.821-2.338A9.953 9.953 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.952 9.952 0 01-.46 1.08M15 12a3 3 0 11-6 0 3 3 0 016 0zm-1.259 4.75L5.21 5.21"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M3 3l18 18"
-                />
-              </svg>
-            ) : (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                className="h-5 w-5"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                />
-              </svg>
+          </div>
+          <div className="relative">
+            <input
+              type={showConfirm ? 'text' : 'password'}
+              className={`input input-bordered w-full pr-10 ${errors.confirm ? 'border-red-500' : ''}`}
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              onBlur={handleConfirmBlur}
+              placeholder="Confirm Password"
+            />
+            <button
+              type="button"
+              className="absolute right-2 top-2"
+              onClick={() => setShowConfirm(!showConfirm)}
+            >
+              {showConfirm ? (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  className="h-5 w-5"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.965 9.965 0 012.652-4.304m3.821-2.338A9.953 9.953 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.952 9.952 0 01-.46 1.08M15 12a3 3 0 11-6 0 3 3 0 016 0zm-1.259 4.75L5.21 5.21"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M3 3l18 18"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  className="h-5 w-5"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  />
+                </svg>
+              )}
+            </button>
+            {errors.confirm && (
+              <p className="text-red-500 text-sm">{errors.confirm}</p>
             )}
-          </button>
-          {errors.confirm && (
-            <p className="text-red-500 text-sm">{errors.confirm}</p>
-          )}
+          </div>
         </div>
         <div>
           <select
@@ -354,26 +359,34 @@ export default function UserSignup() {
             placeholder="Address"
           />
         </div>
-        <div>
-          <input
-            className="input input-bordered w-full"
-            value={city}
-            onChange={(e) => setCity(e.target.value)}
-            placeholder="City"
-          />
-        </div>
-        <div>
-          <input
-            className="input input-bordered w-full"
-            value={country}
-            onChange={(e) => setCountry(e.target.value)}
-            placeholder="Country"
-          />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <div>
+            <input
+              className="input input-bordered w-full"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              placeholder="City"
+            />
+          </div>
+          <div>
+            <input
+              className="input input-bordered w-full"
+              value={country}
+              onChange={(e) => setCountry(e.target.value)}
+              placeholder="Country"
+            />
+          </div>
         </div>
         <button className="btn btn-primary w-full" type="submit">
           Sign Up
         </button>
       </form>
+      <p className="text-center mt-4">
+        Already have an account?{' '}
+        <Link href="/login" className="link">
+          Login
+        </Link>
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enlarge and inline social signup buttons
- arrange password/confirm plus city/country fields in grids
- show route-specific auth links below forms
- hide Login/Signup buttons in header when already on those routes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853e30c1360832f9d6c455396999f0c