### PR TITLE
Fix categories dropdown and add API tests

### DIFF
--- a/__tests__/Header.test.js
+++ b/__tests__/Header.test.js
@@ -22,6 +22,13 @@ jest.mock('next/link', () => ({
 beforeEach(() => {
   mockUseSession.mockReset();
   mockUseSession.mockReturnValue({ data: null });
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+  );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
 });
 const renderWithContext = (
   ui,
@@ -53,4 +60,30 @@ test('shows orders link when authenticated as customer', () => {
   renderWithContext(<Header />);
   expect(screen.getAllByText('Orders').length).toBeGreaterThan(0);
   expect(screen.getAllByText('Wishlist').length).toBeGreaterThan(0);
+});
+
+test('renders categories from API', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve([{ name: 'Electronics', subcategories: ['Phones'] }]),
+    })
+  );
+  renderWithContext(<Header />);
+  // open the menu to render categories
+  const button = screen.getByRole('button', { name: /categories/i });
+  button.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+  expect(await screen.findByText('Electronics')).toBeInTheDocument();
+  global.fetch.mockRestore();
+});
+
+test('shows fallback when no categories are available', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+  );
+  renderWithContext(<Header />);
+  const button = screen.getByRole('button', { name: /categories/i });
+  button.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+  expect(await screen.findByText('No categories found')).toBeInTheDocument();
+  global.fetch.mockRestore();
 });

--- a/__tests__/categories.api.test.js
+++ b/__tests__/categories.api.test.js
@@ -1,0 +1,18 @@
+import handler from '../pages/api/categories';
+import { getCategoryTree } from '../lib/products';
+
+jest.mock('../lib/products', () => ({
+  getCategoryTree: jest.fn(),
+}));
+
+test('returns categories with subcategories', async () => {
+  const data = [{ name: 'Electronics', subcategories: ['Phones'] }];
+  getCategoryTree.mockReturnValue(data);
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const req = { method: 'GET' };
+  const res = { status };
+  await handler(req, res);
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith(data);
+});

--- a/components/Header.js
+++ b/components/Header.js
@@ -213,7 +213,7 @@ export default function Header() {
                         </div>
                       ))
                     ) : (
-                      <p className="text-gray-500">No categories</p>
+                      <p className="text-gray-500">No categories found</p>
                     )}
                   </div>
                 </div>
@@ -450,7 +450,7 @@ export default function Header() {
                       </li>
                     ))
                   ) : (
-                    <li className="text-gray-500 px-2 py-1">No categories</li>
+                    <li className="text-gray-500 px-2 py-1">No categories found</li>
                   )}
                 </ul>
               </details>


### PR DESCRIPTION
## Summary
- update category menu fallback text
- test API handler for categories
- mock fetch in header tests and cover category rendering and empty state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e46228b4832f8f2aaf815993f833