### PR TITLE
Add product image slider and category image support

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -195,8 +195,12 @@ export default function Header() {
                             href={`/categories/${encodeURIComponent(cat.name)}`}
                             className="flex items-center font-semibold mb-1 hover:text-indigo-600"
                           >
-                            {iconMap[cat.name] || null}
-                            {cat.name}
+                          {cat.image ? (
+                            <img src={cat.image} alt="" className="w-4 h-4 mr-1 object-cover" />
+                          ) : (
+                            iconMap[cat.name] || null
+                          )}
+                          {cat.name}
                           </Link>
                           {cat.subcategories &&
                             cat.subcategories.length > 0 && (
@@ -437,7 +441,11 @@ export default function Header() {
                     categories.map((cat) => (
                       <li key={cat.name}>
                         <div className="flex items-center gap-1">
-                          {iconMap[cat.name] || null}
+                          {cat.image ? (
+                            <img src={cat.image} alt="" className="w-4 h-4 object-cover" />
+                          ) : (
+                            iconMap[cat.name] || null
+                          )}
                           <Link
                             href={`/categories/${encodeURIComponent(cat.name)}`}
                           >

--- a/components/ProductImageSlider.js
+++ b/components/ProductImageSlider.js
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+export default function ProductImageSlider({ images = [], className = '', imgClass = '' }) {
+  const [idx, setIdx] = useState(0);
+  if (!images || images.length === 0) {
+    return (
+      <img
+        src="https://placehold.co/600x400?text=No+Image"
+        alt="No image"
+        className={imgClass}
+      />
+    );
+  }
+  const next = () => setIdx((i) => (i + 1) % images.length);
+  const prev = () => setIdx((i) => (i - 1 + images.length) % images.length);
+  return (
+    <div className={`relative ${className}`}>
+      <img src={images[idx]} alt={`Image ${idx + 1}`} className={`object-cover ${imgClass}`} />
+      {images.length > 1 && (
+        <>
+          <button type="button" className="btn btn-xs absolute left-1 top-1/2 -translate-y-1/2" onClick={prev}>
+            Prev
+          </button>
+          <button type="button" className="btn btn-xs absolute right-1 top-1/2 -translate-y-1/2" onClick={next}>
+            Next
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/lib/db.js
+++ b/lib/db.js
@@ -37,12 +37,16 @@ export function getDb() {
       db.exec('ALTER TABLE products ADD COLUMN images TEXT');
     }
     db.exec(
-      'CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE, parent_id INTEGER, FOREIGN KEY(parent_id) REFERENCES categories(id))'
+      'CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE, parent_id INTEGER, image TEXT, FOREIGN KEY(parent_id) REFERENCES categories(id))'
     );
     const catInfo = db.prepare('PRAGMA table_info(categories)').all();
     const hasParent = catInfo.some((c) => c.name === 'parent_id');
     if (!hasParent) {
       db.exec('ALTER TABLE categories ADD COLUMN parent_id INTEGER');
+    }
+    const hasImage = catInfo.some((c) => c.name === 'image');
+    if (!hasImage) {
+      db.exec('ALTER TABLE categories ADD COLUMN image TEXT');
     }
     db.exec(`CREATE TABLE IF NOT EXISTS users (
       email TEXT PRIMARY KEY,
@@ -167,25 +171,25 @@ export function getCategories() {
   const db = getDb();
   return db
     .prepare(
-      'SELECT id, name, parent_id as parentId FROM categories ORDER BY name'
+      'SELECT id, name, parent_id as parentId, image FROM categories ORDER BY name'
     )
     .all();
 }
 
-export function addCategory(name, parentId = null) {
+export function addCategory(name, parentId = null, image = null) {
   const db = getDb();
   const stmt = db.prepare(
-    'INSERT OR IGNORE INTO categories (name, parent_id) VALUES (?, ?)'
+    'INSERT OR IGNORE INTO categories (name, parent_id, image) VALUES (?, ?, ?)'
   );
-  stmt.run(name, parentId);
+  stmt.run(name, parentId, image);
 }
 
-export function updateCategory(id, name, parentId = null) {
+export function updateCategory(id, name, parentId = null, image = null) {
   const db = getDb();
   const stmt = db.prepare(
-    'UPDATE categories SET name = ?, parent_id = ? WHERE id = ?'
+    'UPDATE categories SET name = ?, parent_id = ?, image = ? WHERE id = ?'
   );
-  stmt.run(name, parentId, id);
+  stmt.run(name, parentId, image, id);
 }
 
 export function deleteCategory(id) {
@@ -197,7 +201,7 @@ export function deleteCategory(id) {
 export function getCategoryById(id) {
   const db = getDb();
   const stmt = db.prepare(
-    'SELECT id, name, parent_id as parentId FROM categories WHERE id = ?'
+    'SELECT id, name, parent_id as parentId, image FROM categories WHERE id = ?'
   );
   return stmt.get(id);
 }
@@ -205,7 +209,7 @@ export function getCategoryById(id) {
 export function getCategoryByName(name) {
   const db = getDb();
   const stmt = db.prepare(
-    'SELECT id, name, parent_id as parentId FROM categories WHERE lower(name) = lower(?)'
+    'SELECT id, name, parent_id as parentId, image FROM categories WHERE lower(name) = lower(?)'
   );
   return stmt.get(name);
 }

--- a/lib/products.js
+++ b/lib/products.js
@@ -353,7 +353,7 @@ export function getCategoryTree() {
   if (flat.length > 0) {
     const map = {};
     flat.forEach((c) => {
-      map[c.id] = { name: c.name, subcategories: [] };
+      map[c.id] = { name: c.name, image: c.image, subcategories: [] };
     });
     flat.forEach((c) => {
       if (c.parentId) {
@@ -364,6 +364,7 @@ export function getCategoryTree() {
       .filter((c) => !c.parentId)
       .map((c) => ({
         name: c.name,
+        image: c.image,
         subcategories: map[c.id].subcategories.sort((a, b) =>
           a.localeCompare(b)
         ),
@@ -383,7 +384,7 @@ export function getCategoryTree() {
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function createCategory(name) {
+export function createCategory(name, parentId = null, image = null) {
   const existing = getCategoryByName(name);
   if (!existing) {
     if (parentId) {
@@ -392,12 +393,12 @@ export function createCategory(name) {
         throw new Error('depth');
       }
     }
-    dbAddCategory(name, parentId);
+    dbAddCategory(name, parentId, image);
   }
 }
 
-export function renameCategory(id, name, parentId = null) {
-  dbUpdateCategory(id, name, parentId);
+export function renameCategory(id, name, parentId = null, image = null) {
+  dbUpdateCategory(id, name, parentId, image);
 }
 
 export function removeCategory(id) {

--- a/pages/admin/categories.js
+++ b/pages/admin/categories.js
@@ -6,9 +6,11 @@ export default function Categories() {
   const [categories, setCategories] = useState([]);
   const [newCat, setNewCat] = useState('');
   const [newParent, setNewParent] = useState('');
+  const [newImage, setNewImage] = useState('');
   const [message, setMessage] = useState('');
   const [editing, setEditing] = useState(null);
   const [editName, setEditName] = useState('');
+  const [editImage, setEditImage] = useState('');
 
   const load = async () => {
     if (!user) return;
@@ -25,10 +27,11 @@ export default function Categories() {
     const res = await fetch('/api/admin/categories', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: newCat, parentId: newParent || null }),
+      body: JSON.stringify({ name: newCat, parentId: newParent || null, image: newImage || null }),
     });
     if (res.ok) {
       setNewCat('');
+      setNewImage('');
       setMessage('Category added');
       load();
     }
@@ -38,11 +41,12 @@ export default function Categories() {
     const res = await fetch('/api/admin/categories', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: editing, name: editName }),
+      body: JSON.stringify({ id: editing, name: editName, image: editImage || null }),
     });
     if (res.ok) {
       setEditing(null);
       setEditName('');
+      setEditImage('');
       setMessage('Category updated');
       load();
     }
@@ -72,6 +76,12 @@ export default function Categories() {
           value={newCat}
           onChange={(e) => setNewCat(e.target.value)}
           placeholder="New category"
+          className="input input-bordered flex-1"
+        />
+        <input
+          value={newImage}
+          onChange={(e) => setNewImage(e.target.value)}
+          placeholder="Image URL (optional)"
           className="input input-bordered flex-1"
         />
         <select
@@ -128,6 +138,12 @@ export default function Categories() {
                 value={editName}
                 onChange={(e) => setEditName(e.target.value)}
               />
+              <input
+                className="input input-bordered flex-1"
+                value={editImage}
+                onChange={(e) => setEditImage(e.target.value)}
+                placeholder="Image URL (optional)"
+              />
               <button onClick={update} className="btn btn-sm">
                 Save
               </button>
@@ -137,11 +153,17 @@ export default function Categories() {
             </>
           ) : (
             <>
-              <span className="flex-1">{cat.name}</span>
+              <span className="flex-1 flex items-center gap-2">
+                {cat.image && (
+                  <img src={cat.image} alt="" className="w-6 h-6 object-cover" />
+                )}
+                {cat.name}
+              </span>
               <button
                 onClick={() => {
                   setEditing(cat.id);
                   setEditName(cat.name);
+                  setEditImage(cat.image || '');
                 }}
                 className="btn btn-sm"
               >

--- a/pages/api/admin/categories.js
+++ b/pages/api/admin/categories.js
@@ -12,7 +12,7 @@ function handler(req, res) {
     return res.status(200).json(getCategoriesFlat());
   }
   if (req.method === 'POST') {
-    const { name, parentId } = req.body || {};
+    const { name, parentId, image } = req.body || {};
     if (!name) return res.status(400).json({ message: 'name required' });
     const exists = getCategoriesFlat().find(
       (c) => c.name.toLowerCase() === name.toLowerCase()
@@ -21,22 +21,22 @@ function handler(req, res) {
       return res.status(409).json({ message: 'category exists' });
     }
     try {
-      createCategory(name, parentId || null);
+      createCategory(name, parentId || null, image || null);
     } catch (e) {
       if (e.message === 'depth') {
         return res.status(400).json({ message: 'max depth exceeded' });
       }
       throw e;
     }
-    logAudit('create_category', { name, parentId });
+    logAudit('create_category', { name, parentId, image });
     return res.status(201).json({ message: 'category created' });
   }
   if (req.method === 'PUT') {
-    const { id, name, parentId } = req.body || {};
+    const { id, name, parentId, image } = req.body || {};
     if (!id || !name)
       return res.status(400).json({ message: 'id and name required' });
-    renameCategory(id, name, parentId || null);
-    logAudit('rename_category', { id, name, parentId });
+    renameCategory(id, name, parentId || null, image || null);
+    logAudit('rename_category', { id, name, parentId, image });
     return res.status(200).json({ message: 'category updated' });
   }
   if (req.method === 'DELETE') {

--- a/pages/categories/[name].js
+++ b/pages/categories/[name].js
@@ -10,6 +10,7 @@ export default function CategoryPage() {
   const { addToCart } = useContext(AppContext);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [catImage, setCatImage] = useState('');
 
   useEffect(() => {
     if (!name) return;
@@ -25,7 +26,16 @@ export default function CategoryPage() {
       }
       setLoading(false);
     }
+    async function loadCat() {
+      const res = await fetch('/api/categories');
+      if (res.ok) {
+        const cats = await res.json();
+        const found = cats.find((c) => c.name.toLowerCase() === name.toLowerCase());
+        if (found && found.image) setCatImage(found.image);
+      }
+    }
     load();
+    loadCat();
   }, [name, type]);
 
   if (!name) return <div className="p-4">Loading...</div>;
@@ -46,9 +56,12 @@ export default function CategoryPage() {
           }}
         />
       </Head>
-      <h1 className="text-2xl font-bold mb-4">
-        Category: {name}
-        {type && ` - ${type}`}
+      <h1 className="text-2xl font-bold mb-4 flex items-center gap-2">
+        {catImage && <img src={catImage} alt="" className="w-8 h-8 object-cover" />}
+        <span>
+          Category: {name}
+          {type && ` - ${type}`}
+        </span>
       </h1>
       {loading && <div>Loading...</div>}
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">

--- a/pages/categories/index.js
+++ b/pages/categories/index.js
@@ -12,9 +12,12 @@ export default function Categories() {
   return (
     <div className="p-4 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Categories</h1>
-      <ul className="list-disc pl-4 space-y-1">
+      <ul className="list-disc pl-4 space-y-2">
         {categories.map((c) => (
-          <li key={c.name}>
+          <li key={c.name} className="flex items-center gap-2">
+            {c.image && (
+              <img src={c.image} alt="" className="w-8 h-8 object-cover" />
+            )}
             <Link href={`/categories/${encodeURIComponent(c.name)}`}>{c.name}</Link>
           </li>
         ))}

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import Head from 'next/head';
 import { AppContext } from '../contexts/AppContext';
+import ProductImageSlider from '../components/ProductImageSlider';
 
 export default function Home({ theme, setTheme }) {
   const router = useRouter();
@@ -424,25 +425,15 @@ export default function Home({ theme, setTheme }) {
                   className="card bg-base-100 border border-gray-200 shadow-md transform hover:shadow-xl hover:scale-105 transition duration-200 ease-in-out"
                 >
                   <Link href={`/products/${product.ID}`}>
-                    <div className="w-full h-40 bg-gray-200 flex items-center justify-center overflow-hidden">
-                      {product.FEATURED_IMAGE?.url ? (
-                        <img
-                          src={product.FEATURED_IMAGE.url}
-                          alt={product.TITLE || 'Product Image'}
-                          className="object-cover w-full h-full"
-                          onError={(e) => {
-                            e.target.onerror = null;
-                            e.target.src = `https://placehold.co/400x300/e0e0e0/555555?text=No+Image`;
-                          }}
-                        />
-                      ) : (
-                        <img
-                          src={`https://placehold.co/400x300/e0e0e0/555555?text=No+Image`}
-                          alt="No Image Available"
-                          className="object-cover w-full h-full"
-                        />
-                      )}
-                    </div>
+                    <ProductImageSlider
+                      images={
+                        product.IMAGES && product.IMAGES.length > 0
+                          ? product.IMAGES
+                          : [product.FEATURED_IMAGE?.url]
+                      }
+                      className="w-full h-40 bg-gray-200 overflow-hidden flex items-center justify-center"
+                      imgClass="w-full h-full"
+                    />
                   </Link>
 
                   <div className="card-body flex flex-col gap-1">

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -3,6 +3,7 @@ import { useEffect, useState, useContext } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import Link from 'next/link';
 import Head from 'next/head';
+import ProductImageSlider from '../../components/ProductImageSlider';
 
 export default function ProductDetail() {
   const router = useRouter();
@@ -11,7 +12,6 @@ export default function ProductDetail() {
     useContext(AppContext);
   const [product, setProduct] = useState(null);
   const [error, setError] = useState(null);
-  const [currentImage, setCurrentImage] = useState(0);
   const [reviews, setReviews] = useState([]);
   const [averageRating, setAverageRating] = useState(0);
   const [reviewCount, setReviewCount] = useState(0);
@@ -75,40 +75,14 @@ export default function ProductDetail() {
       </Head>
       <h1 className="text-2xl font-bold mb-4">{product.TITLE}</h1>
       <div className="mb-4 w-full flex flex-col items-center">
-        <div className="relative">
-          <img
-            src={
-              product.IMAGES?.[currentImage] ||
-              product.FEATURED_IMAGE?.url ||
-              'https://placehold.co/600x400?text=No+Image'
-            }
-            alt={product.TITLE}
-            className="object-cover max-h-96 hover:scale-110 transition"
-          />
-        </div>
-        {product.IMAGES && product.IMAGES.length > 1 && (
-          <div className="flex gap-2 mt-2">
-            <button
-              className="btn btn-xs"
-              onClick={() =>
-                setCurrentImage(
-                  (currentImage - 1 + product.IMAGES.length) %
-                    product.IMAGES.length
-                )
-              }
-            >
-              Prev
-            </button>
-            <button
-              className="btn btn-xs"
-              onClick={() =>
-                setCurrentImage((currentImage + 1) % product.IMAGES.length)
-              }
-            >
-              Next
-            </button>
-          </div>
-        )}
+        <ProductImageSlider
+          images={
+            product.IMAGES && product.IMAGES.length > 0
+              ? product.IMAGES
+              : [product.FEATURED_IMAGE?.url]
+          }
+          imgClass="max-h-96 hover:scale-110 transition w-full"
+        />
       </div>
       <p className="mb-2">Vendor: {product.VENDOR}</p>
       <p className="mb-2">Type: {product.PRODUCT_TYPE}</p>

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -39,6 +39,7 @@ db.exec(`CREATE TABLE IF NOT EXISTS categories (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   name TEXT UNIQUE,
   parent_id INTEGER,
+  image TEXT,
   FOREIGN KEY(parent_id) REFERENCES categories(id)
 )`);
 
@@ -50,12 +51,12 @@ if (existingCount.c === 0) {
     { name: 'Fashion', subs: ['Men', 'Women'] },
   ];
   const insert = db.prepare(
-    'INSERT INTO categories (name, parent_id) VALUES (?, ?)'
+    'INSERT INTO categories (name, parent_id, image) VALUES (?, ?, ?)'
   );
   sample.forEach((cat) => {
-    const info = insert.run(cat.name, null);
+    const info = insert.run(cat.name, null, null);
     const parentId = info.lastInsertRowid;
-    cat.subs.forEach((sub) => insert.run(sub, parentId));
+    cat.subs.forEach((sub) => insert.run(sub, parentId, null));
   });
 }
 


### PR DESCRIPTION
## Summary
- add reusable `ProductImageSlider` component
- replace manual image logic with `ProductImageSlider`
- enable image field on categories and expose via APIs
- show category images in admin UI, dropdowns and listings
- update database and migration scripts for new column

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e5ebb2d0832f9f5ea236b974056e