### PR TITLE
Improve signup layouts

### DIFF
--- a/pages/signup/brand.js
+++ b/pages/signup/brand.js
@@ -187,10 +187,10 @@ export default function BrandSignup() {
       <div className="text-center mb-6">
         <h1 className="text-2xl font-bold">Brand Sign Up</h1>
       </div>
-      <div className="flex flex-row gap-4 mb-4 justify-center">
+      <div className="flex flex-row gap-6 mb-6 justify-center">
         <button
           type="button"
-          className="btn btn-lg flex-1 hover:bg-red-600 hover:text-white flex items-center justify-center gap-2 rounded-lg"
+          className="btn btn-lg px-6 flex items-center justify-center gap-2 hover:bg-red-600 hover:text-white rounded-lg"
           onClick={() => signIn('google')}
         >
           <svg
@@ -207,7 +207,7 @@ export default function BrandSignup() {
         </button>
         <button
           type="button"
-          className="btn btn-lg flex-1 hover:bg-gray-800 hover:text-white flex items-center justify-center gap-2 rounded-lg"
+          className="btn btn-lg px-6 flex items-center justify-center gap-2 hover:bg-gray-800 hover:text-white rounded-lg"
           onClick={() => signIn('github')}
         >
           <svg
@@ -259,7 +259,7 @@ export default function BrandSignup() {
             {errors.email && (
               <p className="text-red-500 text-sm">{errors.email}</p>
             )}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-2 gap-4">
               <div className="relative">
                 <input
                   name="password"
@@ -424,7 +424,7 @@ export default function BrandSignup() {
             {errors.businessAddress && (
               <p className="text-red-500 text-sm">{errors.businessAddress}</p>
             )}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-2 gap-4">
               <div>
                 <input
                   name="city"

--- a/pages/signup/index.js
+++ b/pages/signup/index.js
@@ -7,7 +7,7 @@ export default function Signup() {
       <Link href="/signup/user" className="btn btn-primary w-full">
         User Signup
       </Link>
-      <Link href="/signup/brand" className="btn btn-secondary w-full">
+      <Link href="/signup/brand" className="btn btn-secondary">
         Brand Signup
       </Link>
     </div>

--- a/pages/signup/user.js
+++ b/pages/signup/user.js
@@ -127,12 +127,12 @@ export default function UserSignup() {
   };
 
   return (
-    <div className="p-4 max-w-sm mx-auto">
+    <div className="p-4 max-w-lg mx-auto">
       <h1 className="text-2xl font-bold mb-4">User Sign Up</h1>
-      <div className="flex gap-2 mb-2">
+      <div className="flex gap-4 mb-4 justify-center">
         <button
           type="button"
-          className="btn btn-lg flex-1 hover:bg-red-600 hover:text-white flex items-center justify-center gap-2"
+          className="btn btn-lg px-6 flex items-center justify-center gap-2 hover:bg-red-600 hover:text-white"
           onClick={() => signIn('google')}
         >
           <svg
@@ -149,7 +149,7 @@ export default function UserSignup() {
         </button>
         <button
           type="button"
-          className="btn btn-lg flex-1 hover:bg-gray-800 hover:text-white flex items-center justify-center gap-2"
+          className="btn btn-lg px-6 flex items-center justify-center gap-2 hover:bg-gray-800 hover:text-white"
           onClick={() => signIn('github')}
         >
           <svg
@@ -201,7 +201,7 @@ export default function UserSignup() {
             <p className="text-red-500 text-sm">{errors.email}</p>
           )}
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <div className="grid grid-cols-2 gap-2">
           <div className="relative">
             <input
               type={showPassword ? 'text' : 'password'}
@@ -359,7 +359,7 @@ export default function UserSignup() {
             placeholder="Address"
           />
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <div className="grid grid-cols-2 gap-2">
           <div>
             <input
               className="input input-bordered w-full"


### PR DESCRIPTION
## Summary
- tweak user signup widths, show password & city fields in two columns
- enlarge social login buttons on user and brand signup pages
- make brand signup button smaller on signup type page

## Testing
- `npx jest` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6853e6df9fcc832fb5b84b3b7ffbc7c6