### PR TITLE
Fix Prisma missing error for NextAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cd product-search-app
 npm install
 ```
 
-This will also install **DaisyUI**, a Tailwind CSS component library used throughout the app.
+This will also install **DaisyUI**, a Tailwind CSS component library used throughout the app, and run `prisma generate` to build the Prisma client.
 
 3. **Create `.env.local`**
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "migrate": "node scripts/migrate.mjs",
     "migrate:blob": "node scripts/migrate-from-blob.mjs",
     "format": "prettier --write .",
-    "test": "jest"
+    "test": "jest",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -5,6 +5,13 @@ import CredentialsProvider from 'next-auth/providers/credentials';
 import bcrypt from 'bcryptjs';
 import { findUser, addUser } from '../../../lib/users.js';
 
+if (!process.env.NEXTAUTH_SECRET) {
+  console.error('NEXTAUTH_SECRET environment variable is not set');
+}
+if (!process.env.NEXTAUTH_URL) {
+  console.error('NEXTAUTH_URL environment variable is not set');
+}
+
 export const authOptions = {
   providers: [
     GoogleProvider({


### PR DESCRIPTION
## Summary
- warn if critical NextAuth env vars are not set
- run `prisma generate` on install so the client exists
- note that install will generate the Prisma client in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e7a8a030832fad62a7d31d462a85