### PR TITLE
Fix Prisma relation for deletion requests

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   resetExpires      DateTime?
   products          Product[]
   orders            Order[]
+  deletionRequests  DeletionRequest[] @relation("UserDeletionRequests")
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 }
@@ -90,7 +91,7 @@ model DeletionRequest {
   id        Int       @id @default(autoincrement())
   category  Category  @relation(fields: [categoryId], references: [id])
   categoryId Int
-  brand     User      @relation(fields: [brandId], references: [id])
+  brand     User      @relation("UserDeletionRequests", fields: [brandId], references: [id])
   brandId   Int
   reason    String?
   status    String   @default("pending")


### PR DESCRIPTION
## Summary
- add user inverse relation for deletion requests

## Testing
- `npx prisma format` *(fails: Failed to fetch sha256 checksum - binaries.prisma.sh 403)*
- `npx prisma generate` *(fails: Failed to fetch sha256 checksum - binaries.prisma.sh 403)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ea18ff48832fb7d3ff3b0bec526d