### PR TITLE
UI tweaks for signup, header and checkout

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -178,7 +178,7 @@ export default function Header() {
               {menuOpen && (
                 <div
                   id="mega-menu"
-                  className="absolute left-0 top-full mt-2 z-20 p-4 bg-base-100 shadow-lg rounded w-screen max-w-3xl"
+                  className="absolute left-0 top-full mt-1 z-40 p-4 bg-base-100 shadow-lg rounded w-screen max-w-3xl"
                 >
                   <div
                     className="grid grid-cols-2 md:grid-cols-3 gap-4"

--- a/contexts/NotificationContext.js
+++ b/contexts/NotificationContext.js
@@ -24,7 +24,7 @@ export function NotificationProvider({ children }) {
     <NotificationContext.Provider value={{ addNotification }}>
       {children}
       <div className="fixed inset-0 pointer-events-none z-50">
-        <div className="absolute left-1/2 top-5 -translate-x-1/2 space-y-2">
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 space-y-2">
           {notifs
             .filter((n) => n.position === 'center')
             .map((n) => (

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -23,7 +23,7 @@ export default function Checkout() {
 
   if (!user)
     return (
-      <div className="h-64 flex flex-col items-center justify-center space-y-4">
+      <div className="min-h-screen flex flex-col items-center justify-center space-y-4">
         <p className="text-lg">Please log in to checkout.</p>
         <Link href="/login" className="btn btn-primary">
           Login

--- a/pages/signup/brand.js
+++ b/pages/signup/brand.js
@@ -187,10 +187,10 @@ export default function BrandSignup() {
       <div className="text-center mb-6">
         <h1 className="text-2xl font-bold">Brand Sign Up</h1>
       </div>
-      <div className="flex flex-row gap-6 mb-6 justify-center">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
         <button
           type="button"
-          className="btn btn-lg px-6 flex items-center justify-center gap-2 hover:bg-red-600 hover:text-white rounded-lg"
+          className="btn btn-lg w-full flex items-center justify-center gap-2 hover:bg-red-600 hover:text-white rounded-lg"
           onClick={() => signIn('google')}
         >
           <svg
@@ -207,7 +207,7 @@ export default function BrandSignup() {
         </button>
         <button
           type="button"
-          className="btn btn-lg px-6 flex items-center justify-center gap-2 hover:bg-gray-800 hover:text-white rounded-lg"
+          className="btn btn-lg w-full flex items-center justify-center gap-2 hover:bg-gray-800 hover:text-white rounded-lg"
           onClick={() => signIn('github')}
         >
           <svg
@@ -226,7 +226,7 @@ export default function BrandSignup() {
       {formError && <div className="text-red-500 mb-2">{formError}</div>}
       <form id="brand-signup-form" onSubmit={submit} className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="space-y-4">
+          <div className="space-y-5">
             <h2 className="text-xl font-semibold">Account Info</h2>
             <input
               name="firstName"
@@ -392,7 +392,7 @@ export default function BrandSignup() {
               </div>
             </div>
           </div>
-          <div className="space-y-4">
+          <div className="space-y-5">
             <h2 className="text-xl font-semibold">Business Info</h2>
             <input
               name="brandName"
@@ -453,7 +453,7 @@ export default function BrandSignup() {
           </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="space-y-4">
+          <div className="space-y-5">
             <input
               name="website"
               className="input input-bordered w-full rounded-lg focus:ring-2 focus:ring-indigo-500"
@@ -469,7 +469,7 @@ export default function BrandSignup() {
               placeholder="Tax ID"
             />
           </div>
-          <div className="space-y-4">
+          <div className="space-y-5">
             <textarea
               name="businessDescription"
               className="textarea textarea-bordered w-full rounded-lg focus:ring-2 focus:ring-indigo-500"
@@ -495,7 +495,7 @@ export default function BrandSignup() {
                 type="file"
                 accept="image/png,image/jpeg"
                 onChange={handleLogoChange}
-                className="file-input file-input-bordered w-full rounded-lg"
+                className="file-input file-input-bordered w-full rounded-lg mt-2"
               />
               {errors.logo && (
                 <p className="text-red-500 text-sm">{errors.logo}</p>
@@ -504,7 +504,7 @@ export default function BrandSignup() {
           </div>
         </div>
         <button
-          className="btn btn-primary w-full mt-6 rounded-lg hover:opacity-90"
+          className="btn btn-primary w-full mt-8 rounded-lg hover:opacity-90"
           type="submit"
           disabled={loading}
         >


### PR DESCRIPTION
## Summary
- tweak brand signup form spacing and file input
- adjust header dropdown stacking
- center notifications and checkout message

## Testing
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_6853ebfd8964832fb7fa933e8751adf3