### PR TITLE
Improve home page design

### DIFF
--- a/__tests__/Header.test.js
+++ b/__tests__/Header.test.js
@@ -40,7 +40,7 @@ const renderWithContext = (
 
 test('shows login and signup when unauthenticated', () => {
   mockUseSession.mockReturnValue({ data: null });
-  renderWithContext(<Header />);
+  renderWithContext(<Header theme="light" setTheme={() => {}} />);
   expect(screen.getAllByText('Login').length).toBeGreaterThan(0);
   expect(screen.getAllByText('Signup').length).toBeGreaterThan(0);
 });
@@ -49,7 +49,7 @@ test('shows admin and cart count when authenticated as admin', () => {
   const user = { role: 'super-admin', firstName: 'Alice', email: 'a@a.com' };
   const cart = [{ ID: 1, qty: 2 }];
   mockUseSession.mockReturnValue({ data: { user } });
-  renderWithContext(<Header />, { cart });
+  renderWithContext(<Header theme="light" setTheme={() => {}} />, { cart });
   expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
   expect(screen.getAllByText('2').length).toBeGreaterThan(0);
 });
@@ -57,7 +57,7 @@ test('shows admin and cart count when authenticated as admin', () => {
 test('shows orders link when authenticated as customer', () => {
   const user = { role: 'customer', firstName: 'Bob', email: 'b@b.com' };
   mockUseSession.mockReturnValue({ data: { user } });
-  renderWithContext(<Header />);
+  renderWithContext(<Header theme="light" setTheme={() => {}} />);
   expect(screen.getAllByText('Orders').length).toBeGreaterThan(0);
   expect(screen.getAllByText('Wishlist').length).toBeGreaterThan(0);
 });
@@ -66,10 +66,11 @@ test('renders categories from API', async () => {
   global.fetch = jest.fn(() =>
     Promise.resolve({
       ok: true,
-      json: () => Promise.resolve([{ name: 'Electronics', subcategories: ['Phones'] }]),
+      json: () =>
+        Promise.resolve([{ name: 'Electronics', subcategories: ['Phones'] }]),
     })
   );
-  renderWithContext(<Header />);
+  renderWithContext(<Header theme="light" setTheme={() => {}} />);
   // open the menu to render categories
   const button = screen.getByRole('button', { name: /categories/i });
   button.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
@@ -81,7 +82,7 @@ test('shows fallback when no categories are available', async () => {
   global.fetch = jest.fn(() =>
     Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
   );
-  renderWithContext(<Header />);
+  renderWithContext(<Header theme="light" setTheme={() => {}} />);
   const button = screen.getByRole('button', { name: /categories/i });
   button.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
   expect(await screen.findByText('No categories found')).toBeInTheDocument();

--- a/components/Header.js
+++ b/components/Header.js
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import { useSession, signOut } from 'next-auth/react';
 import { AppContext } from '../contexts/AppContext';
 
-export default function Header() {
+export default function Header({ theme = 'light', setTheme }) {
   const router = useRouter();
   const { data: session } = useSession();
   const { cart } = useContext(AppContext);
@@ -195,12 +195,16 @@ export default function Header() {
                             href={`/categories/${encodeURIComponent(cat.name)}`}
                             className="flex items-center font-semibold mb-1 hover:text-indigo-600"
                           >
-                          {cat.image ? (
-                            <img src={cat.image} alt="" className="w-4 h-4 mr-1 object-cover" />
-                          ) : (
-                            iconMap[cat.name] || null
-                          )}
-                          {cat.name}
+                            {cat.image ? (
+                              <img
+                                src={cat.image}
+                                alt=""
+                                className="w-4 h-4 mr-1 object-cover"
+                              />
+                            ) : (
+                              iconMap[cat.name] || null
+                            )}
+                            {cat.name}
                           </Link>
                           {cat.subcategories &&
                             cat.subcategories.length > 0 && (
@@ -293,8 +297,8 @@ export default function Header() {
           )}
         </form>
       </div>
-      <nav className="hidden md:flex flex-none ml-auto">
-        <ul className="menu menu-horizontal gap-2">
+      <nav className="hidden md:flex flex-none ml-auto items-center">
+        <ul className="menu menu-horizontal gap-2 items-center">
           <li className="relative mr-1">
             <Link
               href="/cart"
@@ -321,6 +325,15 @@ export default function Header() {
                 </span>
               )}
             </Link>
+          </li>
+          <li className="flex items-center">
+            <input
+              type="checkbox"
+              className="toggle toggle-sm"
+              checked={theme === 'dark'}
+              onChange={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+              aria-label="Toggle Dark Mode"
+            />
           </li>
           {user ? (
             <>
@@ -433,6 +446,15 @@ export default function Header() {
                 </span>
               )}
             </li>
+            <li className="flex items-center px-2">
+              <input
+                type="checkbox"
+                className="toggle toggle-sm"
+                checked={theme === 'dark'}
+                onChange={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+                aria-label="Toggle Dark Mode"
+              />
+            </li>
             <li>
               <details>
                 <summary>Categories</summary>
@@ -442,7 +464,11 @@ export default function Header() {
                       <li key={cat.name}>
                         <div className="flex items-center gap-1">
                           {cat.image ? (
-                            <img src={cat.image} alt="" className="w-4 h-4 object-cover" />
+                            <img
+                              src={cat.image}
+                              alt=""
+                              className="w-4 h-4 object-cover"
+                            />
                           ) : (
                             iconMap[cat.name] || null
                           )}
@@ -468,7 +494,9 @@ export default function Header() {
                       </li>
                     ))
                   ) : (
-                    <li className="text-gray-500 px-2 py-1">No categories found</li>
+                    <li className="text-gray-500 px-2 py-1">
+                      No categories found
+                    </li>
                   )}
                 </ul>
               </details>

--- a/components/HeroSlider.js
+++ b/components/HeroSlider.js
@@ -1,5 +1,11 @@
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { Navigation, Pagination, Autoplay, A11y, EffectFade } from 'swiper/modules';
+import {
+  Navigation,
+  Pagination,
+  Autoplay,
+  A11y,
+  EffectFade,
+} from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
@@ -7,19 +13,22 @@ import 'swiper/css/effect-fade';
 
 const slides = [
   {
-    image: 'https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=1350&q=80',
+    image:
+      'https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=1350&q=80',
     headline: 'Discover New Arrivals',
     tagline: 'Fresh styles just landed',
     href: '/products',
   },
   {
-    image: 'https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=1350&q=80',
+    image:
+      'https://images.unsplash.com/photo-1511707171634-5f897ff02aa9?auto=format&fit=crop&w=1350&q=80',
     headline: 'Upgrade Your Tech',
     tagline: 'Latest gadgets at great prices',
     href: '/products?type=Electronics',
   },
   {
-    image: 'https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=1350&q=80',
+    image:
+      'https://images.unsplash.com/photo-1491553895911-0055eca6402d?auto=format&fit=crop&w=1350&q=80',
     headline: 'Step Up Your Style',
     tagline: 'Trendy fashion for everyone',
     href: '/products?type=Fashion',
@@ -46,9 +55,15 @@ export default function HeroSlider() {
               className="absolute inset-0 w-full h-full object-cover"
             />
             <div className="relative z-10 flex flex-col items-center justify-center h-full bg-black/40 text-center text-white px-4">
-              <h2 className="text-3xl md:text-5xl font-bold mb-2">{slide.headline}</h2>
-              <p className="mb-4 md:text-lg">{slide.tagline}</p>
-              <a href={slide.href} className="btn btn-primary">Shop Now</a>
+              <h2 className="text-4xl md:text-6xl font-extrabold mb-2">
+                {slide.headline}
+              </h2>
+              <p className="mb-6 text-lg md:text-2xl font-semibold">
+                {slide.tagline}
+              </p>
+              <a href={slide.href} className="btn btn-primary btn-lg">
+                Shop Now
+              </a>
             </div>
           </SwiperSlide>
         ))}

--- a/components/ProductImageSlider.js
+++ b/components/ProductImageSlider.js
@@ -4,13 +4,13 @@ export default function ProductImageSlider({
   images = [],
   className = '',
   imgClass = '',
+  placeholderSeed = 1,
 }) {
   const [idx, setIdx] = useState(0);
   if (!images || images.length === 0) {
-    // Placeholder photo from Unsplash, replace before production
     return (
       <img
-        src="https://images.unsplash.com/photo-1606813909275-63941d602ae2?auto=format&fit=crop&w=600&q=80"
+        src={`https://source.unsplash.com/400x400/?product&sig=${placeholderSeed}`}
         alt="Placeholder product"
         className={imgClass}
       />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -30,7 +30,7 @@ export default function App({
     <SessionProvider session={session}>
       <NotificationProvider>
         <AppProvider>
-          <Header />
+          <Header theme={theme} setTheme={setTheme} />
           <Component {...pageProps} theme={theme} setTheme={setTheme} />
         </AppProvider>
       </NotificationProvider>

--- a/pages/index.js
+++ b/pages/index.js
@@ -209,19 +209,9 @@ export default function Home({ theme, setTheme }) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className="w-full max-w-screen-2xl bg-base-100 p-8 rounded-box shadow-xl">
+      <main className="w-full max-w-screen-2xl bg-base-100 p-8 rounded-box shadow-xl space-y-6">
         <HeroSlider />
-        <div className="flex justify-end mb-6">
-          <label className="flex items-center cursor-pointer gap-2">
-            <span className="text-sm">Dark Mode</span>
-            <input
-              type="checkbox"
-              className="toggle"
-              checked={theme === 'dark'}
-              onChange={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-            />
-          </label>
-        </div>
+        {/* Theme toggle moved to header */}
 
         {allProductTypes.length > 0 && (
           <div className="flex flex-wrap justify-center mb-6">
@@ -424,8 +414,11 @@ export default function Home({ theme, setTheme }) {
                       images={
                         product.IMAGES && product.IMAGES.length > 0
                           ? product.IMAGES
-                          : [product.FEATURED_IMAGE?.url]
+                          : product.FEATURED_IMAGE?.url
+                            ? [product.FEATURED_IMAGE.url]
+                            : []
                       }
+                      placeholderSeed={product.ID}
                       className="w-full h-40 bg-gray-200 overflow-hidden flex items-center justify-center"
                       imgClass="w-full h-full"
                     />


### PR DESCRIPTION
## Summary
- move theme toggle to header and pass theme props
- style hero slider with large fonts and new images
- add random unsplash placeholders to product cards
- tweak homepage layout spacing
- update tests for header props

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f6e358d8832f8a0c2b111acb70c0