### PR TITLE
Switch search index to db file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ coverage/
 *.csv~
 *.bak
 *.tmp
+
+# Search index
+public/index.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛍️ Product Search App (Next.js + FlexSearch)
 
-A fast, scalable product search web app built with **Next.js**, **FlexSearch**, and **Vercel Blob Storage**. Product information is stored in a lightweight **SQLite** database instead of loading from CSV, and the data is indexed for fast searching.
+A fast, scalable product search web app built with **Next.js** and **FlexSearch**. Product information is stored in a lightweight **SQLite** database and indexed for fast searching.
 
 ---
 
@@ -10,7 +10,6 @@ A fast, scalable product search web app built with **Next.js**, **FlexSearch**, 
 - Extremely fast indexing via **FlexSearch.Document**
 - Manage products via a simple admin panel with a SQLite backend
 - Public search API: `/api/search?q=...`
-- Caches search index using **Vercel Blob Storage**
 - Optional `SKIP_INDEX_BUILD` flag to avoid rebuilding during deployment
 - Fully deployable on **Vercel** with CI/CD
 - Modern responsive UI built with **Tailwind CSS** and **DaisyUI**
@@ -38,8 +37,6 @@ This will also install **DaisyUI**, a Tailwind CSS component library used throug
 3. **Create `.env.local`**
 
 ```env
-BLOB_READ_WRITE_TOKEN=your-vercel-blob-token
-BLOB_BASE_URL=https://your-vercel-blob-url
 SKIP_INDEX_BUILD=false
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
@@ -50,12 +47,6 @@ NEXTAUTH_SECRET=random-secret
 
 ```bash
 npm run migrate
-```
-
-5. **Import products from Blob**
-
-```bash
-npm run migrate:blob
 ```
 
 6. **Place your product data**
@@ -85,7 +76,7 @@ This script will:
 
 - Load product data from the SQLite database
 - Build a FlexSearch index
-- Upload the index to Vercel Blob with the exact filename
+- Save the index to `public/index.json`
 
 ---
 
@@ -112,13 +103,11 @@ In the Vercel dashboard:
 
 | Key                     | Value                              |
 | ----------------------- | ---------------------------------- |
-| `BLOB_READ_WRITE_TOKEN` | your blob RW token                 |
-| `BLOB_BASE_URL`         | https://your-vercel-blob-url       |
 | `SKIP_INDEX_BUILD`      | `true` (to skip rebuild at deploy) |
 
 4. **Deploy**
 
-Vercel will auto-deploy. The frontend will fetch the search index from the uploaded blob.
+Vercel will auto-deploy. The frontend will fetch the search index from the generated index file.
 
 ---
 
@@ -158,8 +147,8 @@ Returns matching products in enriched format.
 - During CSV load:
   - HTML is stripped from body and description using `jsdom`
   - JSON fields are parsed safely
-- The index is serialized and uploaded as `flexsearch_index.json` to Blob
-- On next load, the app fetches and deserializes the pre-built index for faster boot
+- The index is serialized to `public/index.json`
+- on next load, the app reads and deserializes the pre-built index for faster boot
 
 ---
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ export default {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
-    '^next/link$': '<rootDir>/test-utils/NextLink.js'
+    '^next/link$': '<rootDir>/test-utils/NextLink.tsx'
   },
   transform: {
     '^.+\\.[jt]sx?$': 'babel-jest'

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -2,7 +2,7 @@ import { JSDOM } from 'jsdom';
 import FlexSearch from 'flexsearch';
 const { Document } = FlexSearch;
 import path from 'path';
-import { put, list } from '@vercel/blob';
+import fs from 'fs';
 import {
   getAllFromDb,
   addProduct as dbAddProduct,
@@ -23,7 +23,7 @@ let products = [];
 let productIndex = null;
 let isDataLoaded = false;
 
-const BLOB_FILE_NAME = 'flexsearch_index.json';
+const INDEX_FILE_PATH = path.join(process.cwd(), 'public', 'index.json');
 
 const stripHtml = (html) => {
   if (!html) return '';
@@ -171,92 +171,51 @@ export async function loadAndIndexProducts() {
     return { products, productIndex };
   }
 
-  console.log('Attempting to load pre-built index from Vercel Blob...');
+  console.log('Attempting to load pre-built index from file...');
 
-  productIndex = new Document({
-    document: {
-      id: 'ID',
-      index: [
-        'TITLE',
-        'VENDOR',
-        'DESCRIPTION_TEXT',
-        'BODY_HTML_TEXT',
-        'TAGS',
-        'PRODUCT_TYPE',
-        'CATEGORY',
-        'METAFIELDS.my_fields_ingredients.value',
-      ],
-      store: true,
-    },
-    preset: 'match',
-    tokenize: 'forward',
-    resolution: 9,
-  });
+  productIndex = createFlexDoc();
 
   try {
-    const { blobs } = await list();
-    const targetBlob = blobs.find((blob) => blob.pathname === BLOB_FILE_NAME);
-
-    if (targetBlob && targetBlob.downloadUrl) {
-      console.log(`Downloaded index from Blob URL: ${targetBlob.downloadUrl}`);
-      const response = await fetch(targetBlob.downloadUrl);
-      if (!response.ok) {
-        throw new Error(
-          `Failed to fetch blob from URL: ${response.statusText}`
-        );
-      }
-      const indexData = await response.json();
-
+    if (fs.existsSync(INDEX_FILE_PATH)) {
+      const indexData = JSON.parse(fs.readFileSync(INDEX_FILE_PATH, 'utf8'));
       const { serializedIndex, loadedProducts } = indexData;
 
       if (loadedProducts && loadedProducts.length > 0) {
-        console.log(
-          'Loaded products from pre-built Blob data. Rebuilding index manually...'
-        );
         products = loadedProducts;
 
-        products.forEach((product) => {
-          productIndex.add(product);
+        Object.keys(serializedIndex).forEach((key) => {
+          productIndex.import(key, serializedIndex[key]);
         });
 
-        console.log('Index rebuilt from serialized product data from Blob.');
+        console.log('Index loaded from file.');
         isDataLoaded = true;
         return { products, productIndex };
       } else {
-        console.warn(
-          'Pre-built products data from Blob is empty or invalid. Building from CSV.'
-        );
-        products = [];
+        console.warn('Index file missing product data. Rebuilding from database.');
       }
     } else {
-      console.warn(
-        'No pre-built index found in Vercel Blob. Building from source data.'
-      );
-      products = [];
+      console.warn('No index file found. Building from database.');
     }
   } catch (e) {
-    console.error(
-      'Failed to load pre-built index from Vercel Blob, building from source:',
-      e
-    );
-    products = [];
+    console.error('Failed to load index file, rebuilding from database:', e);
   }
 
-  console.log('Building index from provided data source...');
+  console.log('Building index from database...');
   products = [];
-  await forceBuildAndSaveIndexToBlob();
+  await forceBuildAndSaveIndexToFile();
   return { products, productIndex };
 }
 
-export async function forceBuildAndSaveIndexToBlob() {
-  console.log('Building index from data source and uploading to Blob...');
+export async function forceBuildAndSaveIndexToFile() {
+  console.log('Building index from data source and writing to file...');
   try {
     products = await loadProductsData();
+    products = products.filter((p) => p.TOTAL_INVENTORY > 0);
     productIndex = createFlexDoc();
     products.forEach((p) => productIndex.add(p));
     console.log('Products indexed with FlexSearch.');
     isDataLoaded = true;
-    await saveIndexToBlob(productIndex, products);
+    await saveIndexToFile(productIndex, products);
   } catch (error) {
     console.error('Failed to load product data:', error);
     isDataLoaded = false;
@@ -264,9 +223,9 @@ export async function forceBuildAndSaveIndexToBlob() {
   }
 }
 
-async function saveIndexToBlob(indexToSave, productsToSave) {
+async function saveIndexToFile(indexToSave, productsToSave) {
   if (!indexToSave || productsToSave.length === 0) {
-    console.warn('No index or products to save to Blob.');
+    console.warn('No index or products to save.');
     return;
   }
 
@@ -280,18 +239,12 @@ async function saveIndexToBlob(indexToSave, productsToSave) {
     loadedProducts: productsToSave,
   };
 
-  console.log('Uploading FlexSearch index to Vercel Blob...');
+  console.log('Writing FlexSearch index to file...');
   try {
-    const blob = await put(BLOB_FILE_NAME, JSON.stringify(dataToSave), {
-      access: 'public',
-      contentType: 'application/json',
-      addRandomSuffix: false,
-    });
-    console.log(
-      `FlexSearch index saved successfully to Vercel Blob: ${blob.url}`
-    );
+    fs.writeFileSync(INDEX_FILE_PATH, JSON.stringify(dataToSave, null, 2));
+    console.log(`FlexSearch index saved to ${INDEX_FILE_PATH}`);
   } catch (e) {
-    console.error('Failed to save FlexSearch index to Vercel Blob:', e);
+    console.error('Failed to save FlexSearch index to file:', e);
     throw e;
   }
 }

--- a/scripts/generate-search-index.mjs
+++ b/scripts/generate-search-index.mjs
@@ -1,14 +1,70 @@
-import { forceBuildAndSaveIndexToBlob } from '../lib/products.js'; // Import the new function
+import fs from 'fs';
+import path from 'path';
+import FlexSearch from 'flexsearch';
+const { Document } = FlexSearch;
+import { getAllFromDb } from '../lib/db.js';
+import { mapDbRowToProduct } from '../lib/products.js';
 
-async function generateIndex() {
-  console.log('Starting index generation script...');
-  try {
-    await forceBuildAndSaveIndexToBlob(); // Call the function that only builds and uploads
-    console.log('Index generation complete.');
-  } catch (error) {
-    console.error('Error during index generation:', error);
-    process.exit(1);
-  }
+const OUTPUT_FILE = path.join(process.cwd(), 'public', 'index.json');
+
+function createFlexDoc() {
+  return new Document({
+    document: {
+      id: 'ID',
+      index: [
+        'TITLE',
+        'VENDOR',
+        'DESCRIPTION_TEXT',
+        'BODY_HTML_TEXT',
+        'TAGS',
+        'PRODUCT_TYPE',
+        'CATEGORY',
+        'METAFIELDS.my_fields_ingredients.value'
+      ],
+      store: true
+    },
+    preset: 'match',
+    tokenize: 'forward',
+    resolution: 9
+  });
 }
 
-generateIndex();
+function loadActiveProducts() {
+  return getAllFromDb('approved')
+    .filter((row) => row.quantity > 0)
+    .map(mapDbRowToProduct);
+}
+
+async function buildAndSave() {
+  const products = loadActiveProducts();
+  const index = createFlexDoc();
+  products.forEach((p) => index.add(p));
+
+  const serializedIndex = {};
+  await index.export((key, data) => {
+    serializedIndex[key] = data;
+  });
+
+  fs.writeFileSync(
+    OUTPUT_FILE,
+    JSON.stringify({ serializedIndex, loadedProducts: products }, null, 2)
+  );
+}
+
+async function generateIndex() {
+  const rebuild = process.argv.includes('--rebuild');
+
+  if (!rebuild && fs.existsSync(OUTPUT_FILE)) {
+    console.log('Search index already exists. Use --rebuild to regenerate.');
+    return;
+  }
+
+  console.log('Building search index...');
+  await buildAndSave();
+  console.log(`Index written to ${OUTPUT_FILE}`);
+}
+
+generateIndex().catch((err) => {
+  console.error('Error during index generation:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- index generation now loads data from the database
- store generated search index locally in `public/index.json`
- add `--rebuild` CLI flag to avoid duplicate indexing
- drop Vercel Blob references from code and docs
- fix Jest config path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540b68de68832fb481034cf6a2d315