### PR TITLE
Improve TypeScript coverage

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="react" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@testing-library/react": "^14.1.0",
     "@types/node": "^24.0.3",
     "@types/react": "^18.3.23",
+    "@types/jest": "^29.5.10",
+    "ts-jest": "^29.1.1",
     "autoprefixer": "^10.4.19",
     "babel-jest": "^30.0.0-beta.3",
     "daisyui": "^4.12.24",

--- a/pages/api/admin/analytics.ts
+++ b/pages/api/admin/analytics.ts
@@ -1,7 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getAllOrders } from '../../../lib/orders';
 import { withRole } from '../../../lib/withRole';
 
-function handler(req, res) {
+function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import {
   getCategoriesFlat,
   createCategory,
@@ -7,7 +8,7 @@ import {
 import { withRole } from '../../../lib/withRole';
 import { logAudit } from '../../../lib/audit';
 
-function handler(req, res) {
+function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     return res.status(200).json(getCategoriesFlat());
   }

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import {
   addProduct,
   updateProduct,
@@ -36,7 +37,7 @@ function parseForm(req) {
   });
 }
 
-async function handler(req, res) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST' || req.method === 'PUT') {
     const { fields, files } = await parseForm(req);
     const {

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import {
   getAllUsers,
   updateUserRole,
@@ -7,7 +8,7 @@ import {
 } from '../../../lib/users';
 import { withRole } from '../../../lib/withRole';
 
-async function handler(req, res) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     return res.status(200).json(await getAllUsers());
   }

--- a/pages/api/admin/vendor-products.ts
+++ b/pages/api/admin/vendor-products.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import {
   getPendingProducts,
   approveProduct,
@@ -5,7 +6,7 @@ import {
 } from '../../../lib/products';
 import { withRole } from '../../../lib/withRole';
 
-function handler(req, res) {
+function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     return res.status(200).json(getPendingProducts());
   }

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import NextAuth from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 import GitHubProvider from 'next-auth/providers/github';

--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -1,6 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
 
-export default function handler(req, res) {
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -1,6 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoriesFlat, createCategory } from '../../../lib/products';
 
-export default function handler(req, res) {
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/brand/low-stock.ts
+++ b/pages/api/brand/low-stock.ts
@@ -1,6 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { loadAndIndexProducts } from '../../../lib/products';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { vendor } = req.query;
   if (!vendor) return res.status(400).json({ message: 'vendor required' });
   const { products } = await loadAndIndexProducts();

--- a/pages/api/brand/orders.ts
+++ b/pages/api/brand/orders.ts
@@ -1,6 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
 
-export default function handler(req, res) {
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/brand/products/[id].ts
+++ b/pages/api/brand/products/[id].ts
@@ -1,8 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateProduct, deleteProduct, loadAndIndexProducts } from '../../../../lib/products';
 import { getProductById } from '../../../../lib/db';
 import { hasOrdersForProduct } from '../../../../lib/orders';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { id } = req.query;
   if (!id) return res.status(400).json({ message: 'id required' });
 

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { addProduct, loadAndIndexProducts } from '../../../../lib/products';
 
 function slugify(text) {
@@ -9,7 +10,7 @@ function slugify(text) {
     .replace(/-+/g, '-');
 }
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     const { vendor } = req.query;
     if (!vendor) return res.status(400).json({ message: 'vendor required' });

--- a/pages/api/brand/profile.ts
+++ b/pages/api/brand/profile.ts
@@ -1,8 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateUserProfile, findUser } from '../../../lib/users';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
   if (!session?.user) {
     return res.status(401).json({ message: 'Unauthorized' });

--- a/pages/api/cart.ts
+++ b/pages/api/cart.ts
@@ -1,8 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCart, setCart } from '../../lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
   if (!session?.user) {
     return res.status(401).json({ message: 'Unauthorized' });

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -1,6 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '../../lib/products';
 
-export default function handler(req, res) {
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     return res.status(200).json(getCategoryTree());
   }

--- a/pages/api/category-tree.ts
+++ b/pages/api/category-tree.ts
@@ -1,6 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '../../lib/products';
 
-export default function handler(req, res) {
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     return res.status(200).json(getCategoryTree());
   }

--- a/pages/api/check-email.ts
+++ b/pages/api/check-email.ts
@@ -1,6 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser } from '../../lib/users';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { email } = req.query;
   if (!email) {
     return res.status(400).json({ message: 'email required' });

--- a/pages/api/checkout/complete.ts
+++ b/pages/api/checkout/complete.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
 import { addOrder } from '../../../lib/orders';
 import { sendOrderConfirmation } from '../../../lib/email';
@@ -6,7 +7,7 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2023-10-16',
 });
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/checkout/create-session.ts
+++ b/pages/api/checkout/create-session.ts
@@ -1,10 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2023-10-16',
 });
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/coupons/[code].ts
+++ b/pages/api/coupons/[code].ts
@@ -1,9 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 const coupons = {
   SAVE10: { percent: 10 },
   SAVE20: { percent: 20 },
 };
 
-export default function handler(req, res) {
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { code } = req.query;
   const coupon = coupons[code?.toUpperCase()];
   if (!coupon) return res.status(404).json({ message: 'Invalid code' });

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -1,7 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser } from '../../lib/users';
 import bcrypt from 'bcryptjs';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import {
   addOrder,
   getOrdersForUser,
@@ -13,7 +14,7 @@ import {
 import { withRole } from '../../lib/withRole';
 import { sendOrderConfirmation } from '../../lib/email';
 
-async function handler(req, res) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
     const { email, items, total, shippingName, shippingAddress } = req.body;
     if (!email || !items) {

--- a/pages/api/orders/[id].ts
+++ b/pages/api/orders/[id].ts
@@ -1,9 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrderById } from '../../../lib/orders';
 import { updateOrderStatus } from '../../../lib/orders';
 import { sendOrderStatusUpdate } from '../../../lib/email';
 import { withRole } from '../../../lib/withRole';
 
-async function handler(req, res) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { id } = req.query;
   if (!id) {
     return res.status(400).json({ message: 'id required' });

--- a/pages/api/request-reset.ts
+++ b/pages/api/request-reset.ts
@@ -1,7 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser, setResetToken } from '../../lib/users';
 import crypto from 'crypto';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST')
     return res.status(405).json({ message: 'Method Not Allowed' });
   const { email } = req.body;

--- a/pages/api/reset-password.ts
+++ b/pages/api/reset-password.ts
@@ -1,6 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { resetPassword } from '../../lib/users';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST')
     return res.status(405).json({ message: 'Method Not Allowed' });
   const { token, password } = req.body;

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -1,8 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { addUser, findUser } from '../../lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/signup/brand.ts
+++ b/pages/api/signup/brand.ts
@@ -1,8 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { addUser, findUser } from '../../../lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/signup/user.ts
+++ b/pages/api/signup/user.ts
@@ -1,8 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { addUser, findUser } from '../../../lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/user/orders.ts
+++ b/pages/api/user/orders.ts
@@ -1,8 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForUser } from '../../../lib/orders';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
   if (!session?.user) {
     return res.status(401).json({ message: 'Unauthorized' });

--- a/pages/api/user/profile.ts
+++ b/pages/api/user/profile.ts
@@ -1,8 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateUserProfile, findUser } from '../../../lib/users';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
   if (!session?.user) {
     return res.status(401).json({ message: 'Unauthorized' });

--- a/pages/api/vendor/orders.ts
+++ b/pages/api/vendor/orders.ts
@@ -1,7 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
 import { withRole } from '../../../lib/withRole';
 
-function handler(req, res) {
+function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/verify-email.ts
+++ b/pages/api/verify-email.ts
@@ -1,6 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { verifyUser } from '../../lib/users';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { token } = req.query;
   if (!token) return res.status(400).json({ message: 'token required' });
   try {

--- a/pages/api/wishlist.ts
+++ b/pages/api/wishlist.ts
@@ -1,8 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getWishlist, setWishlist } from '../../lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 
-export default async function handler(req, res) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
   if (!session?.user) {
     return res.status(401).json({ message: 'Unauthorized' });

--- a/pages/vendor/index.tsx
+++ b/pages/vendor/index.tsx
@@ -1,9 +1,30 @@
-import { useState, useEffect, useContext, useCallback } from 'react';
+import {
+  useState,
+  useEffect,
+  useContext,
+  useCallback,
+  ChangeEvent,
+  FormEvent,
+} from 'react';
 import { AppContext } from '../../contexts/AppContext';
+import type { Product } from '../../types';
 
 export default function VendorDashboard() {
   const { user } = useContext(AppContext);
-  const emptyForm = {
+  interface FormState {
+    id: string;
+    title: string;
+    vendor: string;
+    description: string;
+    product_type: string;
+    tags: string;
+    category: string;
+    quantity: number;
+    min_price: number;
+    max_price: number;
+    currency: string;
+  }
+  const emptyForm: FormState = {
     id: '',
     title: '',
     vendor: '',
@@ -16,12 +37,12 @@ export default function VendorDashboard() {
     max_price: 0,
     currency: 'USD',
   };
-  const [form, setForm] = useState(emptyForm);
-  const [products, setProducts] = useState([]);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [products, setProducts] = useState<Product[]>([]);
   const [message, setMessage] = useState('');
-  const [editingId, setEditingId] = useState(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
 
-  const fetchProducts = useCallback(async () => {
+  const fetchProducts = useCallback(async (): Promise<void> => {
     if (!user) return;
     const res = await fetch(
       `/api/admin/products?vendor=${encodeURIComponent(user.brandName || '')}`
@@ -35,11 +56,11 @@ export default function VendorDashboard() {
     fetchProducts();
   }, [fetchProducts]);
 
-  const handleChange = (e) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
-  const submit = async (e) => {
+  const submit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const res = await fetch('/api/admin/products', {
       method: editingId ? 'PUT' : 'POST',
@@ -57,7 +78,7 @@ export default function VendorDashboard() {
     }
   };
 
-  const handleEdit = (p) => {
+  const handleEdit = (p: Product) => {
     setForm({
       id: p.ID,
       title: p.TITLE || '',
@@ -79,7 +100,7 @@ export default function VendorDashboard() {
     setForm(emptyForm);
   };
 
-  const handleDelete = async (id) => {
+  const handleDelete = async (id: string): Promise<void> => {
     if (!confirm('Delete this product?')) return;
     const res = await fetch(
       `/api/admin/products?id=${encodeURIComponent(id)}`,

--- a/pages/vendor/orders.tsx
+++ b/pages/vendor/orders.tsx
@@ -1,15 +1,21 @@
-import { useContext, useEffect, useState, useCallback } from 'react';
+import {
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+} from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import { NotificationContext } from '../../contexts/NotificationContext';
+import type { Order } from '../../types';
 
 export default function VendorOrders() {
   const { user } = useContext(AppContext);
-  const [orders, setOrders] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
   const { addNotification } = useContext(NotificationContext);
 
-  const fetchOrders = useCallback(() => {
+  const fetchOrders = useCallback((): void => {
     if (!user) return;
     setLoading(true);
     fetch(
@@ -28,7 +34,7 @@ export default function VendorOrders() {
     fetchOrders();
   }, [fetchOrders]);
 
-  const updateStatus = async (id, status) => {
+  const updateStatus = async (id: number, status: string): Promise<void> => {
     const res = await fetch(`/api/orders/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },

--- a/test-utils/NextLink.tsx
+++ b/test-utils/NextLink.tsx
@@ -1,3 +1,9 @@
-export default function Link({ href, children }) {
+import type { PropsWithChildren } from 'react';
+
+interface LinkProps {
+  href: string;
+}
+
+export default function Link({ href, children }: PropsWithChildren<LinkProps>) {
   return <a href={href}>{children}</a>;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node", "jest"],
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,5 @@
+export * from './product';
+export * from './category';
+export * from './user';
+export * from './order';
+export * from './review';


### PR DESCRIPTION
## Summary
- add shared type exports
- type vendor pages and Next.js API handlers
- add Jest/Node types to tsconfig
- tweak test utilities

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'jest' and 'node')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542b3f38dc832fa3504abff2707385