### PR TITLE
Improve dark mode toggle

### DIFF
--- a/__tests__/ThemeToggle.test.tsx
+++ b/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Layout from '../components/Layout';
+import { AppContext } from '../contexts/AppContext';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('next-auth/react', () => ({
+  __esModule: true,
+  useSession: () => ({ data: null }),
+  signOut: jest.fn(),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }) => <a href={href}>{children}</a>,
+}));
+
+const renderWithContext = (ui: React.ReactElement) => {
+  const value = { cart: [] } as any;
+  return render(<AppContext.Provider value={value}>{ui}</AppContext.Provider>);
+};
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    })),
+  });
+  localStorage.clear();
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+  );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('toggle adds and removes dark class on html', () => {
+  renderWithContext(
+    <Layout>
+      <div>Content</div>
+    </Layout>
+  );
+  const [checkbox] = screen.getAllByRole('checkbox', { name: /toggle dark mode/i });
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
+  fireEvent.click(checkbox);
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
+  expect(localStorage.getItem('theme')).toBe('dark');
+  fireEvent.click(checkbox);
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
+  expect(localStorage.getItem('theme')).toBe('light');
+});

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -3,17 +3,27 @@ import Header from './Header';
 import Footer from './Footer';
 
 export default function Layout({ children }) {
-  const [theme, setTheme] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem('theme') || 'light';
-    }
-    return 'light';
-  });
+  const [theme, setTheme] = useState('light');
 
+  // Load stored theme preference on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('theme');
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+
+  // Apply theme changes to the DOM and persist them
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const t = theme === 'dark' ? 'dark' : 'cupcake';
-      document.documentElement.setAttribute('data-theme', t);
+      const html = document.documentElement;
+      const isDark = theme === 'dark';
+      const t = isDark ? 'dark' : 'cupcake';
+      html.setAttribute('data-theme', t);
+      html.classList.toggle('dark', isDark);
       localStorage.setItem('theme', theme);
     }
   }, [theme]);

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -9,6 +9,24 @@ export default function Document() {
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet" />
       </Head>
       <body className="font-sans">
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+(function() {
+  try {
+    var theme = localStorage.getItem('theme');
+    if (!theme) {
+      theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    var html = document.documentElement;
+    var isDark = theme === 'dark';
+    html.setAttribute('data-theme', isDark ? 'dark' : 'cupcake');
+    if (isDark) html.classList.add('dark');
+  } catch (e) {}
+})();
+            `,
+          }}
+        />
         <Main />
         <NextScript />
       </body>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  @apply transition-colors duration-300;
+}
+
 body {
   @apply font-sans bg-base-200 text-base-content;
 }


### PR DESCRIPTION
## Summary
- handle dark mode via DOM class and DaisyUI theme
- initialize theme on page load with script in `_document.tsx`
- add transition styling for theme changes
- test dark mode toggle logic

## Testing
- `npm test`
- `npm run type-check` *(fails: numerous TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685432af3c88832fb1592e41e467de91