### PR TITLE
Add env setup and Prisma check

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ npm install
 
 This will also install **DaisyUI**, a Tailwind CSS component library used throughout the app, and run `prisma generate` to build the Prisma client.
 
-3. **Create `.env.local`**
+3. **Configure environment variables**
+
+`npm install` will copy `.env.example` to `.env` if it does not exist. Edit this file and set `DATABASE_URL` to point to your local PostgreSQL instance.
+
+Next.js runtime variables go in `.env.local`:
 
 ```env
 SKIP_INDEX_BUILD=false

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,4 +1,13 @@
 import { PrismaClient } from '@prisma/client';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+if (!process.env.DATABASE_URL) {
+  throw new Error(
+    'DATABASE_URL is not set. Please copy `.env.example` to `.env` and set your database connection string.'
+  );
+}
 
 const globalForPrisma = globalThis;
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "test": "jest",
     "type-check": "tsc --noEmit",
-    "postinstall": "prisma generate"
+    "setup-env": "node scripts/setupEnv.js",
+    "postinstall": "npm run setup-env && prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",

--- a/scripts/setupEnv.js
+++ b/scripts/setupEnv.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const envPath = path.join(process.cwd(), '.env');
+const examplePath = path.join(process.cwd(), '.env.example');
+
+if (!fs.existsSync(envPath)) {
+  if (fs.existsSync(examplePath)) {
+    fs.copyFileSync(examplePath, envPath);
+    console.log('Created .env from .env.example');
+  } else {
+    console.warn('No .env file found and .env.example is missing.');
+    console.warn('Please create a .env file with a valid DATABASE_URL.');
+    process.exit(0);
+  }
+}
+
+const envContent = fs.readFileSync(envPath, 'utf8');
+if (!/DATABASE_URL\s*=/.test(envContent)) {
+  console.warn('DATABASE_URL is missing in .env. Please set it for local development.');
+}


### PR DESCRIPTION
## Summary
- add an automatic `.env` setup script
- validate `DATABASE_URL` at Prisma client initialization
- run env setup during postinstall
- mention DATABASE_URL requirement in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854336699b4832fb2c143bd6bca9357