### PR TITLE
Add search suggestions API

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -17,7 +17,7 @@ export default function Header({ theme = 'light', setTheme }) {
   const [categories, setCategories] = useState([]);
   const [menuOpen, setMenuOpen] = useState(false);
   const [search, setSearch] = useState('');
-  const [suggestions, setSuggestions] = useState([]);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
   const [activeIdx, setActiveIdx] = useState(-1);
   const searchRef = useRef(null);
   const iconMap = {
@@ -101,12 +101,12 @@ export default function Header({ theme = 'light', setTheme }) {
     const t = setTimeout(async () => {
       try {
         const res = await fetch(
-          `/api/search?q=${encodeURIComponent(search)}&perPage=5`,
+          `/api/suggest?q=${encodeURIComponent(search)}`,
           { signal: controller.signal }
         );
         if (res.ok) {
           const data = await res.json();
-          setSuggestions(data.results || []);
+          setSuggestions(data.suggestions || []);
           setActiveIdx(-1);
         }
       } catch (_) {
@@ -126,10 +126,10 @@ export default function Header({ theme = 'light', setTheme }) {
     setSuggestions([]);
   };
 
-  const selectSuggestion = (p) => {
-    router.push(`/products/${p.ID}`);
+  const selectSuggestion = (text) => {
+    router.push(`/?q=${encodeURIComponent(text)}`);
     setSuggestions([]);
-    setSearch('');
+    setSearch(text);
   };
 
   const renderCat = (cat) => (
@@ -290,7 +290,7 @@ export default function Header({ theme = 'light', setTheme }) {
                 className="absolute z-10 bg-white shadow rounded mt-1 w-full max-h-60 overflow-auto"
               >
                 {suggestions.map((s, idx) => (
-                  <li key={s.ID}>
+                  <li key={s}>
                     <button
                       type="button"
                       role="option"
@@ -299,7 +299,7 @@ export default function Header({ theme = 'light', setTheme }) {
                       onMouseEnter={() => setActiveIdx(idx)}
                       onClick={() => selectSuggestion(s)}
                     >
-                      {s.TITLE}
+                      {s}
                     </button>
                   </li>
                 ))}

--- a/pages/api/suggest.ts
+++ b/pages/api/suggest.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  const { q = '' } = req.query as { q?: string };
+  const query = Array.isArray(q) ? q[0] : q;
+
+  if (!query.trim()) {
+    return res.status(200).json({ suggestions: [] });
+  }
+
+  const host = process.env.TYPESENSE_HOST || 'localhost';
+  const port = process.env.TYPESENSE_PORT || '8108';
+  const protocol = process.env.TYPESENSE_PROTOCOL || 'http';
+  const apiKey = process.env.TYPESENSE_API_KEY || '';
+  const url = `${protocol}://${host}:${port}/collections/products/documents/suggest?q=${encodeURIComponent(query)}&query_by=title,description&num_suggestions=5`;
+
+  try {
+    const resp = await fetch(url, {
+      headers: { 'X-TYPESENSE-API-KEY': apiKey },
+    });
+    if (!resp.ok) {
+      throw new Error(`HTTP ${resp.status}`);
+    }
+    const data = await resp.json();
+    return res.status(200).json(data);
+  } catch (err) {
+    console.error('Typesense suggest error', err);
+    return res.status(500).json({ message: 'Suggest failed' });
+  }
+}


### PR DESCRIPTION
## Summary
- add API route for Typesense suggestions
- query suggestions from the header search field
- run search when a suggestion is chosen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68543bae1f2c832faeaf493490bbac47