### PR TITLE
Add search fallback

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -40,7 +40,9 @@ export function getDb() {
     const hasSlug = productInfo.some((c) => c.name === 'slug');
     if (!hasSlug) {
       db.exec('ALTER TABLE products ADD COLUMN slug TEXT');
-      db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_products_slug ON products(slug)');
+      db.exec(
+        'CREATE UNIQUE INDEX IF NOT EXISTS idx_products_slug ON products(slug)'
+      );
     }
     db.exec(
       'CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE, parent_id INTEGER, image TEXT, FOREIGN KEY(parent_id) REFERENCES categories(id))'
@@ -240,6 +242,16 @@ export function getProductBySlug(slug) {
   const db = getDb();
   const stmt = db.prepare('SELECT * FROM products WHERE slug = ?');
   return stmt.get(slug);
+}
+
+export function getProductsByIds(ids: string[]) {
+  if (!ids.length) return [];
+  const db = getDb();
+  const placeholders = ids.map(() => '?').join(',');
+  const stmt = db.prepare(
+    `SELECT * FROM products WHERE id IN (${placeholders})`
+  );
+  return stmt.all(...ids);
 }
 
 export function updateProductQuantity(id, quantity) {

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -1,4 +1,5 @@
-import { getDb } from './db';
+import { getDb, getProductById, getProductsByIds } from './db';
+import { mapDbRowToProduct } from './products';
 
 export function addOrder({
   user_email,
@@ -83,4 +84,21 @@ export function updateOrderStatus(id, status) {
   const db = getDb();
   const stmt = db.prepare('UPDATE orders SET status = ? WHERE id = ?');
   stmt.run(status, id);
+}
+
+export function getBestSellingProducts(limit = 8) {
+  const orders = getAllOrders();
+  const counts: Record<string, number> = {};
+  orders.forEach((o) => {
+    o.items.forEach((i: any) => {
+      const id = String(i.ID);
+      counts[id] = (counts[id] || 0) + (i.qty || 0);
+    });
+  });
+  const topIds = Object.entries(counts)
+    .sort((a, b) => (b[1] as number) - (a[1] as number))
+    .slice(0, limit)
+    .map(([id]) => id);
+  const rows = getProductsByIds(topIds);
+  return rows.map((r) => mapDbRowToProduct(r));
 }

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Typesense from 'typesense';
+import { getBestSellingProducts } from '../../lib/orders';
 
 const client = new Typesense.Client({
   nodes: [
@@ -85,6 +86,7 @@ export default async function handler(
         }
       }
     }
+    const fallback = result.found === 0 ? getBestSellingProducts(8) : [];
     return res.status(200).json({
       results: hits,
       total: result.found,
@@ -92,6 +94,7 @@ export default async function handler(
       totalPages,
       brands,
       categories,
+      fallback,
     });
   } catch (err) {
     console.error('Typesense search error', err);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,6 +19,7 @@ export default function Home() {
     useContext(AppContext);
   const [searchTerm, setSearchTerm] = useState('');
   const [products, setProducts] = useState<Product[]>([]);
+  const [fallbackProducts, setFallbackProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -97,6 +98,7 @@ export default function Home() {
 
     setLoading(true);
     setError(null);
+    setFallbackProducts([]);
 
     try {
       const params = new URLSearchParams();
@@ -126,6 +128,7 @@ export default function Home() {
 
       const data: any = await response.json();
       setProducts(data.results);
+      setFallbackProducts(data.fallback || []);
       setTotalPages(data.totalPages || 1);
       if (allVendors.length === 0 && Array.isArray(data.brands)) {
         setAllVendors(['All', ...data.brands]);
@@ -142,6 +145,7 @@ export default function Home() {
         console.error('Failed to fetch products:', e);
         setError('Failed to load products. Please try again.');
         setProducts([]);
+        setFallbackProducts([]);
       }
     } finally {
       // Only set loading to false if the request was not aborted
@@ -469,8 +473,106 @@ export default function Home() {
             )}
 
             {!loading && products.length === 0 && !error && (
-              <div className="alert shadow-sm">
-                No products found. Try a different search or clear filters.
+              <div className="mb-4">
+                <div className="alert shadow-sm mb-4">No results found.</div>
+                {fallbackProducts.length > 0 && (
+                  <>
+                    <h3 className="font-semibold mb-2">Popular Products</h3>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-4">
+                      {fallbackProducts.map((product) => (
+                        <div
+                          key={product.ID}
+                          className="card bg-base-100 border border-base-300 rounded-xl shadow hover:shadow-lg transition-all duration-200"
+                        >
+                          <Link href={`/product/${product.SLUG}`}>
+                            <ProductImageSlider
+                              images={
+                                product.IMAGES && product.IMAGES.length > 0
+                                  ? product.IMAGES
+                                  : product.FEATURED_IMAGE?.url
+                                    ? [product.FEATURED_IMAGE.url]
+                                    : []
+                              }
+                              placeholderSeed={Number(product.ID)}
+                              className="w-full h-40 bg-gray-200 overflow-hidden flex items-center justify-center"
+                              imgClass="w-full h-full"
+                            />
+                          </Link>
+
+                          <div className="card-body flex flex-col gap-1">
+                            <Link
+                              href={`/product/${product.SLUG}`}
+                              className="hover:underline transition-colors duration-200"
+                            >
+                              <h2
+                                className="text-lg font-semibold text-base-content line-clamp-2"
+                                title={product.TITLE}
+                              >
+                                {product.TITLE || 'Untitled Product'}
+                              </h2>
+                            </Link>
+                            <div className="flex flex-wrap gap-1 text-xs text-base-content">
+                              {product.VENDOR && (
+                                <span className="badge badge-ghost">
+                                  {product.VENDOR}
+                                </span>
+                              )}
+                              {product.PRODUCT_TYPE && (
+                                <span className="badge badge-ghost">
+                                  {product.PRODUCT_TYPE}
+                                </span>
+                              )}
+                            </div>
+                            <p className="text-md font-bold text-base-content">
+                              {product.CURRENCY} {product.MIN_PRICE.toFixed(2)}
+                              {product.MAX_PRICE > product.MIN_PRICE &&
+                                ` - ${product.MAX_PRICE.toFixed(2)}`}
+                            </p>
+                            <p className="text-sm text-base-content line-clamp-2">
+                              {product.DESCRIPTION_TEXT ||
+                                product.BODY_HTML_TEXT ||
+                                'No description available.'}
+                            </p>
+                            <div className="mt-auto flex justify-between items-center text-sm text-base-content">
+                              {product.SOLD_COUNT > 0 && (
+                                <span>Sold: {product.SOLD_COUNT}</span>
+                              )}
+                              {product.REVIEW_COUNT > 0 && (
+                                <span>
+                                  Reviews: {product.REVIEW_COUNT} (
+                                  {product.AVERAGE_RATING.toFixed(1)} avg)
+                                </span>
+                              )}
+                            </div>
+                            <div className="flex gap-2 mt-2">
+                              <button
+                                className="btn btn-sm btn-primary transition-all duration-200"
+                                onClick={() => addToCart(product)}
+                              >
+                                Add to Cart
+                              </button>
+                              {wishlist.some((w) => w.ID === product.ID) ? (
+                                <button
+                                  className="btn btn-sm transition-all duration-200"
+                                  onClick={() => removeFromWishlist(product.ID)}
+                                >
+                                  Remove Wishlist
+                                </button>
+                              ) : (
+                                <button
+                                  className="btn btn-sm transition-all duration-200"
+                                  onClick={() => addToWishlist(product)}
+                                >
+                                  Add Wishlist
+                                </button>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- add `getProductsByIds` helper
- expose `getBestSellingProducts`
- return best sellers when search yields no hits
- render fallback grid when no results are found

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68543bc31488832f9d6fe11d9b4bc6cc