### PR TITLE
Add browsing history recommendations

### DIFF
--- a/components/RecommendedProducts.tsx
+++ b/components/RecommendedProducts.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import ProductImageSlider from './ProductImageSlider';
+import { Product } from '../types/product';
+
+interface RecommendedProductsProps {
+  category?: string;
+  excludeId?: string;
+  title?: string;
+}
+
+export default function RecommendedProducts({ category, excludeId, title = 'You may also like' }: RecommendedProductsProps) {
+  const [products, setProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    if (!category) return;
+    fetch(`/api/search?category=${encodeURIComponent(category)}&perPage=4`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data && Array.isArray(data.results)) {
+          const filtered = data.results.filter((p: Product) => p.ID !== excludeId);
+          setProducts(filtered);
+        }
+      })
+      .catch(() => {});
+  }, [category, excludeId]);
+
+  if (!products.length) return null;
+
+  return (
+    <div className="mt-8">
+      <h3 className="font-semibold mb-4">{title}</h3>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {products.map((p) => (
+          <Link href={`/product/${p.SLUG}`} key={p.ID} className="card bg-base-100 border border-base-300 rounded-xl shadow hover:shadow-lg transition-all duration-200">
+            <ProductImageSlider
+              images={p.IMAGES && p.IMAGES.length > 0 ? p.IMAGES : [p.FEATURED_IMAGE?.url]}
+              placeholderSeed={Number(p.ID)}
+              className="w-full h-32 bg-gray-200 overflow-hidden flex items-center justify-center"
+              imgClass="w-full h-full object-cover"
+            />
+            <div className="p-2 text-sm line-clamp-2">{p.TITLE}</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,6 +12,7 @@ import { AppContext } from '../contexts/AppContext';
 import ProductImageSlider from '../components/ProductImageSlider';
 import Hero from '../components/Hero';
 import { Product } from '../types/product';
+import RecommendedProducts from '../components/RecommendedProducts';
 
 export default function Home() {
   const router = useRouter();
@@ -37,6 +38,7 @@ export default function Home() {
   const [allVendors, setAllVendors] = useState<string[]>([]);
   const [allProductTypes, setAllProductTypes] = useState<string[]>([]);
   const [allCategories, setAllCategories] = useState<string[]>([]);
+  const [historyInfo, setHistoryInfo] = useState<{ category?: string; id?: string } | null>(null);
 
   // useRef to store the AbortController instance
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -85,6 +87,24 @@ export default function Home() {
       }
     }
     loadCats();
+  }, []);
+
+  useEffect(() => {
+    try {
+      const hist = JSON.parse(localStorage.getItem('browse-history') || '[]');
+      if (hist.length > 0) {
+        fetch(`/api/products/${hist[0]}`)
+          .then((res) => (res.ok ? res.json() : null))
+          .then((data) => {
+            if (data && data.CATEGORY) {
+              setHistoryInfo({ category: data.CATEGORY, id: hist[0] });
+            }
+          })
+          .catch(() => {});
+      }
+    } catch {
+      // ignore
+    }
   }, []);
 
   const fetchProducts = useCallback(async (): Promise<void> => {
@@ -591,6 +611,12 @@ export default function Home() {
             )}
           </div>
         </div>
+        {historyInfo?.category && (
+          <RecommendedProducts
+            category={historyInfo.category}
+            excludeId={historyInfo.id}
+          />
+        )}
       </main>
     </div>
   );

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -1,8 +1,9 @@
-import { useContext, useState } from 'react';
+import { useContext, useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
 import ProductImageSlider from '../../components/ProductImageSlider';
+import RecommendedProducts from '../../components/RecommendedProducts';
 import { getProductBySlug, getReviewsForProduct, getAverageRating } from '../../lib/db';
 import { mapDbRowToProduct } from '../../lib/products';
 
@@ -32,6 +33,16 @@ export default function ProductDetail({ product, initialReviews, initialAverage,
   const [myRating, setMyRating] = useState(5);
   const [comment, setComment] = useState('');
   const id = product.ID;
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('browse-history') || '[]');
+      const updated = [id, ...stored.filter((v: string) => v !== id)];
+      localStorage.setItem('browse-history', JSON.stringify(updated.slice(0, 20)));
+    } catch {
+      // ignore
+    }
+  }, [id]);
 
   return (
     <div className="p-6 max-w-screen-2xl mx-auto bg-base-100 rounded-box shadow-md">
@@ -109,6 +120,7 @@ export default function ProductDetail({ product, initialReviews, initialAverage,
           </form>
         )}
       </div>
+      <RecommendedProducts category={product.CATEGORY} excludeId={product.ID} />
       <div className="mt-4">
         <Link href="/">&larr; Back to products</Link>
       </div>


### PR DESCRIPTION
## Summary
- add a component for fetching related products
- track product views and show recommendations on product page
- surface recommendations on the home page if history exists

## Testing
- `npm test`
- `npm run type-check` *(fails: Parameter implicitly has an 'any' type and other TS errors)*
- `npm run lint` *(fails: next command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543bdbec70832f9b82e935e0579683