### PR TITLE
Add search logging analytics

### DIFF
--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -32,6 +32,9 @@ export default function AdminAnalytics() {
         <Link href="/admin/approvals" className="btn btn-sm">
           Approvals
         </Link>
+        <Link href="/admin/search-analytics" className="btn btn-sm">
+          Search Logs
+        </Link>
       </div>
       <p>Total Orders: {data.totalOrders}</p>
       <p>Total Revenue: £{data.totalRevenue.toFixed(2)}</p>
@@ -47,4 +50,3 @@ export default function AdminAnalytics() {
     </div>
   );
 }
-

--- a/pages/admin/search-analytics.tsx
+++ b/pages/admin/search-analytics.tsx
@@ -1,0 +1,52 @@
+import { useContext, useEffect, useState } from 'react';
+import { AppContext } from '../../contexts/AppContext';
+import Link from 'next/link';
+
+export default function SearchAnalytics() {
+  const { user } = useContext(AppContext);
+  const [data, setData] = useState<{
+    topSearches: any[];
+    failedSearches: any[];
+  } | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    fetch('/api/admin/search-analytics')
+      .then((res) => (res.ok ? res.json() : null))
+      .then(setData);
+  }, [user]);
+
+  if (!user) return <div className="p-4">Please log in to view analytics.</div>;
+  if (user.role !== 'super-admin')
+    return <div className="p-4">Admin access required.</div>;
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="w-full p-4 sm:p-6 lg:p-8">
+      <h1 className="text-2xl font-bold mb-4">Search Analytics</h1>
+      <div className="mb-4 space-x-2">
+        <Link href="/admin/analytics" className="btn btn-sm">
+          Back
+        </Link>
+      </div>
+      <h2 className="text-xl font-semibold mt-4 mb-2">Top Searches</h2>
+      <ul className="list-disc list-inside">
+        {data.topSearches.map((s) => (
+          <li key={s.query}>
+            {s.query} - {s.count}
+          </li>
+        ))}
+        {data.topSearches.length === 0 && <li>No searches yet.</li>}
+      </ul>
+      <h2 className="text-xl font-semibold mt-4 mb-2">No Result Searches</h2>
+      <ul className="list-disc list-inside">
+        {data.failedSearches.map((s) => (
+          <li key={s.query}>
+            {s.query} - {s.count}
+          </li>
+        ))}
+        {data.failedSearches.length === 0 && <li>None.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/pages/api/admin/search-analytics.ts
+++ b/pages/api/admin/search-analytics.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+import { withRole } from '../../../lib/withRole';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  const logs = await prisma.searchLog.findMany();
+  const counts: Record<string, number> = {};
+  const fails: Record<string, number> = {};
+  for (const log of logs) {
+    counts[log.query] = (counts[log.query] || 0) + 1;
+    if (log.noResults) {
+      fails[log.query] = (fails[log.query] || 0) + 1;
+    }
+  }
+  const topSearches = Object.entries(counts)
+    .sort((a, b) => (b[1] as number) - (a[1] as number))
+    .slice(0, 10)
+    .map(([query, count]) => ({ query, count }));
+  const failedSearches = Object.entries(fails)
+    .sort((a, b) => (b[1] as number) - (a[1] as number))
+    .slice(0, 10)
+    .map(([query, count]) => ({ query, count }));
+
+  return res.status(200).json({ topSearches, failedSearches });
+}
+
+export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,6 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Typesense from 'typesense';
 import { getBestSellingProducts } from '../../lib/orders';
+import { prisma } from '../../lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
 
 const client = new Typesense.Client({
   nodes: [
@@ -35,6 +38,16 @@ export default async function handler(
 ) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  let userId: number | null = null;
+  if (session?.user?.email) {
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+      select: { id: true },
+    });
+    if (user) userId = user.id;
   }
 
   const {
@@ -87,6 +100,17 @@ export default async function handler(
       }
     }
     const fallback = result.found === 0 ? getBestSellingProducts(8) : [];
+    try {
+      await prisma.searchLog.create({
+        data: {
+          query: String(q),
+          userId,
+          noResults: result.found === 0,
+        },
+      });
+    } catch (e) {
+      console.error('failed to log search', e);
+    }
     return res.status(200).json({
       results: hits,
       total: result.found,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,3 +100,12 @@ model DeletionRequest {
   updatedAt DateTime @updatedAt
 }
 
+model SearchLog {
+  id        Int      @id @default(autoincrement())
+  user      User?    @relation(fields: [userId], references: [id])
+  userId    Int?
+  query     String
+  noResults Boolean  @default(false)
+  createdAt DateTime @default(now())
+}
+


### PR DESCRIPTION
## Summary
- record searches with user and result info
- expose search log metrics for admins
- add dashboard link and admin page for search analytics

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68543e4e937c832f84289d5e5c4fb1ff