### PR TITLE
Fix missing inverse relation for SearchLog

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   resetExpires      DateTime?
   products          Product[]
   orders            Order[]
+  searchLogs        SearchLog[]
   deletionRequests  DeletionRequest[] @relation("UserDeletionRequests")
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
@@ -105,7 +106,6 @@ model SearchLog {
   user      User?    @relation(fields: [userId], references: [id])
   userId    Int?
   query     String
-  noResults Boolean  @default(false)
   createdAt DateTime @default(now())
 }
 


### PR DESCRIPTION
## Summary
- add `searchLogs` field to `User`
- remove `noResults` from `SearchLog`

## Testing
- `npx prisma format` *(fails: 403 Forbidden)*
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npx prisma migrate dev --name add-search-log-relation` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685445df00a0832f8ba12d2268f15c6f