### PR TITLE
Improve postinstall for Prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # PostgreSQL connection string
-DATABASE_URL="postgresql://username:password@localhost:5432/ecommerce_platform"
+DATABASE_URL=postgresql://user:password@localhost:5432/ecommerce_platform
 # Stripe credentials
 STRIPE_SECRET_KEY="sk_test_yourkey"
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_yourkey"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ cd product-search-app
 npm install
 ```
 
-This will also install **DaisyUI**, a Tailwind CSS component library used throughout the app, and run `prisma generate` to build the Prisma client.
+This will also install **DaisyUI**, load your `.env` file and run `prisma generate` to build the Prisma client.
+
+During postinstall your environment variables are read automatically so the database and Prisma client are ready without additional steps.
 
 3. **Configure environment variables**
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "jest",
     "type-check": "tsc --noEmit",
     "setup-env": "node scripts/setupEnv.js",
-    "postinstall": "npm run setup-env && prisma generate"
+    "postinstall": "node scripts/setupEnv.js && prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",

--- a/scripts/setupEnv.js
+++ b/scripts/setupEnv.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const dotenv = require('dotenv');
 
 const envPath = path.join(process.cwd(), '.env');
 const examplePath = path.join(process.cwd(), '.env.example');
@@ -14,8 +15,8 @@ if (!fs.existsSync(envPath)) {
     process.exit(0);
   }
 }
+dotenv.config({ path: envPath });
 
-const envContent = fs.readFileSync(envPath, 'utf8');
-if (!/DATABASE_URL\s*=/.test(envContent)) {
+if (!process.env.DATABASE_URL) {
   console.warn('DATABASE_URL is missing in .env. Please set it for local development.');
 }


### PR DESCRIPTION
## Summary
- load env vars automatically in postinstall script
- copy `.env.example` to `.env` with sample database URL
- ensure Prisma client is generated via `node scripts/setupEnv.js`
- document automatic setup in README

## Testing
- `npm install` *(fails: Error: Failed to fetch sha256 checksum at https://binaries.prisma.sh)*
- `npm test`
- `npm run lint`
- `npm run type-check` *(fails: implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68544aed0fdc832fa80dcf861c1826cb