### PR TITLE
Ignore autogenerated next-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Build output
 .next/
 out/
+next-env.d.ts
 
 # Logs
 npm-debug.log*
@@ -16,6 +17,8 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.env*
+*.local
 
 # OS-specific files
 .DS_Store
@@ -36,3 +39,9 @@ coverage/
 # Search index
 public/index.json
 tsconfig.tsbuildinfo
+
+# Prisma
+prisma/dev.db
+prisma/dev.db-journal
+prisma/*.sqlite
+prisma/*.sqlite-journal

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="react" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
## Summary
- ignore autogenerated files from Next.js and Prisma
- remove tracked `next-env.d.ts`

## Testing
- `npm test` *(fails: jest not found before install)*
- `npm install` *(fails to download prisma engines due to 403 Forbidden)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68544c2f60c8832f8b1edf681751c5c4