### PR TITLE
Fix category API and add NextAuth secret

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NEXTAUTH_SECRET=your_secure_random_string

--- a/__tests__/categories.api.test.ts
+++ b/__tests__/categories.api.test.ts
@@ -7,7 +7,7 @@ jest.mock('../lib/products', () => ({
 
 test('returns categories with subcategories', async () => {
   const data = [{ name: 'Electronics', subcategories: ['Phones'] }];
-  getCategoryTree.mockReturnValue(data);
+  getCategoryTree.mockResolvedValue(data);
   const json = jest.fn();
   const status = jest.fn(() => ({ json }));
   const req = { method: 'GET' };

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,9 @@
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { prisma } from './prisma';
 
 export default prisma;
+
+export function dbGetCategories() {
+  return prisma.category.findMany({
+    orderBy: { name: 'asc' },
+  });
+}

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -10,7 +10,7 @@ import {
   deleteProduct as dbDeleteProduct,
   getPendingFromDb,
   setProductStatus,
-  getCategories as dbGetCategories,
+  dbGetCategories,
   addCategory as dbAddCategory,
   updateCategory as dbUpdateCategory,
   deleteCategory as dbDeleteCategory,
@@ -306,8 +306,8 @@ export function getCategoriesFlat() {
   return dbGetCategories();
 }
 
-export function getCategoryTree() {
-  const flat = dbGetCategories();
+export async function getCategoryTree() {
+  const flat = await dbGetCategories();
   if (flat.length > 0) {
     const map = {};
     flat.forEach((c) => {

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -1,9 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '../../lib/products';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   if (req.method === 'GET') {
-    return res.status(200).json(getCategoryTree());
+    const data = await getCategoryTree();
+    return res.status(200).json(data);
   }
   return res.status(405).json({ message: 'Method Not Allowed' });
 }

--- a/pages/api/category-tree.ts
+++ b/pages/api/category-tree.ts
@@ -1,9 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '../../lib/products';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   if (req.method === 'GET') {
-    return res.status(200).json(getCategoryTree());
+    const data = await getCategoryTree();
+    return res.status(200).json(data);
   }
   return res.status(405).json({ message: 'Method Not Allowed' });
 }


### PR DESCRIPTION
## Summary
- fetch categories using Prisma
- make category tree builder asynchronous
- update API routes for async category tree
- update tests for async API behavior
- silence NextAuth secret warning by adding secret

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68544cfd5bc0832f951fb4477b4aae2b