### PR TITLE
Fix product images aspect ratio

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -33,8 +33,8 @@ export default function ProductCard({
               : []
           }
           placeholderSeed={Number(product.ID)}
-          className="w-full h-48 bg-gray-200 flex items-center justify-center"
-          imgClass="w-full h-full object-cover transition-transform duration-200 group-hover:scale-105"
+          className="w-full bg-gray-200 flex items-center justify-center aspect-[4/5]"
+          imgClass="transition-transform duration-200 group-hover:scale-105"
         />
       </Link>
       {(isNew || onSale || isOut) && (

--- a/components/ProductImageSlider.tsx
+++ b/components/ProductImageSlider.tsx
@@ -17,24 +17,24 @@ export default function ProductImageSlider({
   const [idx, setIdx] = useState(0);
   if (!images || images.length === 0) {
     return (
-      <Image
-        src={`https://source.unsplash.com/400x400/?product&sig=${placeholderSeed}`}
-        alt="Placeholder product"
-        width={400}
-        height={400}
-        className={imgClass}
-      />
+      <div className={`relative aspect-[4/5] ${className}`}>
+        <Image
+          src={`https://source.unsplash.com/400x400/?product&sig=${placeholderSeed}`}
+          alt="Placeholder product"
+          fill
+          className={`object-cover ${imgClass}`}
+        />
+      </div>
     );
   }
   const next = () => setIdx((i) => (i + 1) % images.length);
   const prev = () => setIdx((i) => (i - 1 + images.length) % images.length);
   return (
-    <div className={`relative ${className}`}>
+    <div className={`relative aspect-[4/5] ${className}`}>
       <Image
         src={images[idx]}
         alt={`Image ${idx + 1}`}
-        width={400}
-        height={400}
+        fill
         className={`object-cover ${imgClass}`}
       />
       {images.length > 1 && (

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -53,8 +53,9 @@ export default function ProductDetail({ product, initialReviews, initialAverage,
       <div className="flex flex-col md:flex-row gap-8">
         <div className="md:w-1/2 flex justify-center">
           <ProductImageSlider
+            className="w-full max-w-md aspect-[4/5]"
             images={product.IMAGES && product.IMAGES.length > 0 ? product.IMAGES : [product.FEATURED_IMAGE?.url]}
-            imgClass="max-h-96 hover:scale-110 transition w-full"
+            imgClass="hover:scale-110 transition"
           />
         </div>
         <div className="md:w-1/2">

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -86,12 +86,13 @@ export default function ProductDetail() {
       <h1 className="text-2xl font-bold mb-4">{product.TITLE || 'Product'}</h1>
       <div className="mb-4 w-full flex flex-col items-center">
         <ProductImageSlider
+          className="w-full max-w-md aspect-[4/5]"
           images={
             product.IMAGES && product.IMAGES.length > 0
               ? product.IMAGES
               : [product.FEATURED_IMAGE?.url || '/placeholder.png']
           }
-          imgClass="max-h-96 hover:scale-110 transition w-full"
+          imgClass="hover:scale-110 transition"
         />
       </div>
       <p className="mb-2">Vendor: {product.VENDOR}</p>


### PR DESCRIPTION
## Summary
- adjust `ProductImageSlider` to fill its container and keep a 4:5 aspect ratio
- give product card and product detail pages fixed aspect ratios

## Testing
- `npm install --ignore-scripts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545002b484832f9d9bb771481a766c