### PR TITLE
Center auth forms

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -55,8 +55,8 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen flex">
-      <div className="w-full px-4 sm:px-6 lg:px-8">
+    <div className="flex justify-center items-center min-h-screen">
+      <div className="w-full max-w-md px-4 sm:px-6 lg:px-8">
         <h1 className="text-2xl font-bold mb-4">Login</h1>
         <button
           type="button"

--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -184,7 +184,8 @@ export default function BrandSignup() {
   };
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8 py-6 bg-slate-100 shadow-lg rounded-lg fade-in">
+    <div className="flex justify-center items-center min-h-screen">
+      <div className="w-full max-w-3xl px-4 sm:px-6 lg:px-8 py-6 bg-slate-100 shadow-lg rounded-lg fade-in">
       <div className="text-center mb-6">
         <h1 className="text-2xl font-bold">Brand Sign Up</h1>
       </div>
@@ -515,6 +516,7 @@ export default function BrandSignup() {
           Login
         </Link>
       </p>
+      </div>
     </div>
   );
 }

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -2,7 +2,8 @@ import Link from 'next/link';
 
 export default function Signup() {
   return (
-    <div className="w-full space-y-4 px-4 sm:px-6 lg:px-8">
+    <div className="flex justify-center items-center min-h-screen">
+      <div className="w-full max-w-md space-y-4 px-4 sm:px-6 lg:px-8">
       <h1 className="text-2xl font-bold mb-4">Choose Signup Type</h1>
       <Link href="/signup/user" className="btn btn-primary w-full">
         User Signup
@@ -10,6 +11,7 @@ export default function Signup() {
       <Link href="/signup/brand" className="btn btn-secondary w-full">
         Brand Signup
       </Link>
+      </div>
     </div>
   );
 }

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -127,8 +127,9 @@ export default function UserSignup() {
   };
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8">
-      <h1 className="text-2xl font-bold mb-4">User Sign Up</h1>
+    <div className="flex justify-center items-center min-h-screen">
+      <div className="w-full max-w-2xl px-4 sm:px-6 lg:px-8">
+        <h1 className="text-2xl font-bold mb-4">User Sign Up</h1>
       <div className="flex flex-col gap-6 mb-4">
         <button
           type="button"
@@ -387,6 +388,7 @@ export default function UserSignup() {
           Login
         </Link>
       </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- center login and signup pages vertically and horizontally
- set responsive max-widths to keep fields within viewport

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685450098c7c832fb0d4c0f572983df6