### PR TITLE
Improve mobile filters and layout

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -29,7 +29,7 @@ export default function Layout({ children }) {
   }, [theme]);
 
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex flex-col min-h-screen overflow-x-hidden">
       <Header theme={theme} setTheme={setTheme} />
       <main className="container mx-auto flex-1 px-4 sm:px-6 lg:px-8 py-6">
         {children}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,6 +31,7 @@ export default function Home() {
   const [inStock, setInStock] = useState(false);
   const [minPrice, setMinPrice] = useState('');
   const [maxPrice, setMaxPrice] = useState('');
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [totalPages, setTotalPages] = useState<number>(1);
@@ -298,10 +299,18 @@ export default function Home() {
           </div>
         )}
         <div className="md:flex">
-          <form
-            onSubmit={handleSearch}
-            className="md:w-60 md:mr-8 mb-8 flex flex-col gap-4"
-          >
+          <div className="md:w-60 md:mr-8 mb-8">
+            <button
+              type="button"
+              className="btn btn-outline w-full mb-4 md:hidden"
+              onClick={() => setFiltersOpen((o) => !o)}
+            >
+              {filtersOpen ? 'Hide Filters' : 'Show Filters'}
+            </button>
+            <form
+              onSubmit={handleSearch}
+              className={`flex flex-col gap-4 ${filtersOpen ? '' : 'hidden'} md:flex`}
+            >
             {allVendors.length > 0 && (
               <div>
                 <label
@@ -466,6 +475,7 @@ export default function Home() {
               </button>
             </div>
           </form>
+          </div>
           <div className="flex-1">
             {activeFilters.length > 0 && (
               <div className="mb-4 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- hide horizontal overflow in layout
- collapse product filters on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685451a180c8832fae8fde31a13d4adf