### PR TITLE
Fix theme toggle persistence

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,32 +1,9 @@
-import { useState, useEffect } from 'react';
+import useTheme from '../hooks/useTheme';
 import Header from './Header';
 import Footer from './Footer';
 
 export default function Layout({ children }) {
-  const [theme, setTheme] = useState('light');
-
-  // Load stored theme preference on mount
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const stored = localStorage.getItem('theme');
-    if (stored) {
-      setTheme(stored);
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      setTheme('dark');
-    }
-  }, []);
-
-  // Apply theme changes to the DOM and persist them
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const html = document.documentElement;
-      const isDark = theme === 'dark';
-      const t = isDark ? 'dark' : 'cupcake';
-      html.setAttribute('data-theme', t);
-      html.classList.toggle('dark', isDark);
-      localStorage.setItem('theme', theme);
-    }
-  }, [theme]);
+  const [theme, setTheme] = useTheme();
 
   return (
     <div className="flex flex-col min-h-screen">

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+export default function useTheme() {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  // Determine initial theme on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+
+  // Apply theme class and persist preference
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const html = document.documentElement;
+    const isDark = theme === 'dark';
+    html.setAttribute('data-theme', isDark ? 'dark' : 'cupcake');
+    html.classList.toggle('dark', isDark);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return [theme, setTheme] as const;
+}


### PR DESCRIPTION
## Summary
- add `useTheme` hook for shared theme logic
- simplify `Layout` to use the hook

## Testing
- `npm test --silent`
- `npm run type-check --silent` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685452cb547c832f95b492008ca1f450