### PR TITLE
Apply min-h-screen to page containers

### DIFF
--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -109,7 +109,7 @@ export default function BrandDashboard() {
   }
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8 min-h-screen py-6">
       <h1 className="text-2xl font-bold mb-4">Brand Dashboard</h1>
       {lowStock.length > 0 && (
         <div className="alert alert-warning mb-4">

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -12,7 +12,7 @@ export default function Cart() {
   );
 
   return (
-    <div className="max-w-3xl mx-auto">
+    <div className="max-w-3xl mx-auto min-h-screen p-4">
       <h1 className="text-3xl font-bold mb-4">Summary</h1>
       {cart.length === 0 && <p>Your cart is empty.</p>}
       <ul className="space-y-2 mb-4">

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -43,7 +43,7 @@ export default function CategoryPage() {
   if (!name) return <div className="p-4">Loading...</div>;
 
   return (
-    <div className="max-w-screen-2xl mx-auto">
+    <div className="max-w-screen-2xl mx-auto min-h-screen p-4">
       <Head>
         <title>Category: {name}</title>
         <meta name="description" content={`Products for ${name}`} />

--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -11,7 +11,7 @@ export default function Categories() {
   }, []);
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="max-w-2xl mx-auto min-h-screen p-4">
       <h1 className="text-2xl font-bold mb-4">Categories</h1>
       <ul className="list-disc pl-4 space-y-2">
         {categories.map((c) => (

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -45,7 +45,7 @@ export default function ProductDetail({ product, initialReviews, initialAverage,
   }, [id]);
 
   return (
-    <div className="p-6 max-w-screen-2xl mx-auto bg-base-100 rounded-box shadow-md">
+    <div className="p-6 max-w-screen-2xl mx-auto bg-base-100 rounded-box shadow-md min-h-screen">
       <Head>
         <title>{product.TITLE} - Product</title>
         <meta name="description" content={product.DESCRIPTION_TEXT?.slice(0, 150)} />


### PR DESCRIPTION
## Summary
- ensure consistent page height via `min-h-screen`
- audit basic spacing on category, product, cart and dashboard pages

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm install` *(fails: binaries.prisma.sh 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685451aa49fc832fa15c49c3adf4a331