### PR TITLE
Fix Typesense connection issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ RESEND_API_KEY=""
 RESEND_FROM="orders@example.com"
 
 # Typesense configuration
-TYPESENSE_API_KEY=your_key
+TYPESENSE_API_KEY=xyz
 TYPESENSE_HOST=localhost
 TYPESENSE_PORT=8108
 TYPESENSE_PROTOCOL=http

--- a/README.md
+++ b/README.md
@@ -55,6 +55,29 @@ NEXTAUTH_SECRET=random-secret
 npm run migrate
 ```
 
+5. **Run Typesense**
+
+```bash
+docker run -d \
+  -p 8108:8108 \
+  -v/tmp/typesense-data:/data \
+  typesense/typesense:0.25.1 \
+  --data-dir /data \
+  --api-key=xyz \
+  --enable-cors
+```
+
+Ensure `.env` contains:
+
+```env
+TYPESENSE_HOST=localhost
+TYPESENSE_PORT=8108
+TYPESENSE_PROTOCOL=http
+TYPESENSE_API_KEY=xyz
+```
+
+Visit [http://localhost:8108/health](http://localhost:8108/health) to verify the server is running.
+
 6. **Place your product data**
 
 Either put your `products.csv` inside the `/data/` directory **or** specify a

--- a/lib/typesenseClient.ts
+++ b/lib/typesenseClient.ts
@@ -1,0 +1,30 @@
+import Typesense from 'typesense';
+
+export const host = process.env.TYPESENSE_HOST || 'localhost';
+export const port = Number(process.env.TYPESENSE_PORT || 8108);
+export const protocol = process.env.TYPESENSE_PROTOCOL || 'http';
+export const apiKey = process.env.TYPESENSE_API_KEY || '';
+
+const client = new Typesense.Client({
+  nodes: [{ host, port, protocol }],
+  apiKey,
+  connectionTimeoutSeconds: 5,
+});
+
+async function healthCheck() {
+  const url = `${protocol}://${host}:${port}/health`;
+  try {
+    const resp = await fetch(url, { headers: { 'X-TYPESENSE-API-KEY': apiKey } });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const data = await resp.json();
+    if (!data.ok) {
+      console.warn('Typesense health check failed', data);
+    }
+  } catch (err) {
+    console.warn(`Warning: Typesense server not reachable at ${url}`);
+  }
+}
+
+void healthCheck();
+
+export default client;

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,21 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import Typesense from 'typesense';
 import { getBestSellingProducts } from '../../lib/orders';
 import { prisma } from '../../lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
-
-const client = new Typesense.Client({
-  nodes: [
-    {
-      host: process.env.TYPESENSE_HOST || 'localhost',
-      port: Number(process.env.TYPESENSE_PORT || 8108),
-      protocol: process.env.TYPESENSE_PROTOCOL || 'http',
-    },
-  ],
-  apiKey: process.env.TYPESENSE_API_KEY || '',
-  connectionTimeoutSeconds: 5,
-});
+import client from '../../lib/typesenseClient';
 
 function buildSort(sort?: string) {
   switch (sort) {

--- a/pages/api/suggest.ts
+++ b/pages/api/suggest.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { host, port, protocol, apiKey } from '../../lib/typesenseClient';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -12,10 +13,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(200).json({ suggestions: [] });
   }
 
-  const host = process.env.TYPESENSE_HOST || 'localhost';
-  const port = process.env.TYPESENSE_PORT || '8108';
-  const protocol = process.env.TYPESENSE_PROTOCOL || 'http';
-  const apiKey = process.env.TYPESENSE_API_KEY || '';
   const url = `${protocol}://${host}:${port}/collections/products/documents/suggest?q=${encodeURIComponent(query)}&query_by=title,description&num_suggestions=5`;
 
   try {

--- a/scripts/setupEnv.js
+++ b/scripts/setupEnv.js
@@ -20,3 +20,22 @@ dotenv.config({ path: envPath });
 if (!process.env.DATABASE_URL) {
   console.warn('DATABASE_URL is missing in .env. Please set it for local development.');
 }
+
+if (!process.env.TYPESENSE_API_KEY) {
+  console.warn('TYPESENSE_API_KEY is missing in .env. Searches will fail without a running Typesense server.');
+}
+
+const host = process.env.TYPESENSE_HOST || 'localhost';
+const port = process.env.TYPESENSE_PORT || '8108';
+const protocol = process.env.TYPESENSE_PROTOCOL || 'http';
+const healthUrl = `${protocol}://${host}:${port}/health`;
+
+fetch(healthUrl)
+  .then(res => {
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+  })
+  .catch(() => {
+    console.warn(`Warning: Typesense server not reachable at ${healthUrl}.`);
+  });


### PR DESCRIPTION
## Summary
- add Typesense health check on startup and warn when unreachable
- centralize Typesense client setup
- update API routes to use shared client
- document how to run Typesense locally
- include Typesense variables in `.env.example`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685455b151a4832fbdb043806a4c7b9a