### PR TITLE
Add Typesense init script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "type-check": "tsc --noEmit",
     "setup-env": "node scripts/setupEnv.js",
-    "postinstall": "npm run setup-env && node scripts/setupPrisma.js && prisma generate"
+    "postinstall": "npm run setup-env && node scripts/setupPrisma.js && prisma generate",
+    "init:typesense": "ts-node scripts/initTypesense.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",

--- a/scripts/initTypesense.ts
+++ b/scripts/initTypesense.ts
@@ -1,0 +1,33 @@
+import * as dotenv from 'dotenv';
+import Typesense from 'typesense';
+import { productsSchema } from './typesense-schema';
+
+dotenv.config();
+
+const host = process.env.TYPESENSE_HOST || 'localhost';
+const port = Number(process.env.TYPESENSE_PORT || 8108);
+const protocol = process.env.TYPESENSE_PROTOCOL || 'http';
+const apiKey = process.env.TYPESENSE_API_KEY || '';
+
+const client = new Typesense.Client({
+  nodes: [{ host, port, protocol }],
+  apiKey,
+  connectionTimeoutSeconds: 5,
+});
+
+async function init() {
+  try {
+    await client.collections('products').retrieve();
+    console.log('Typesense collection "products" already exists, skipping');
+  } catch (err: any) {
+    if (err?.httpStatus === 404) {
+      await client.collections().create(productsSchema as any);
+      console.log('Created Typesense collection "products"');
+    } else {
+      console.error('Failed to initialize Typesense:', err);
+      process.exit(1);
+    }
+  }
+}
+
+void init();


### PR DESCRIPTION
## Summary
- add script to create a `products` collection if missing
- expose `init:typesense` npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545bb96dd8832f8d4f0fa0813bc5e3