### PR TITLE
Update Typesense schema

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -12,9 +12,9 @@ function buildSort(sort?: string) {
     case 'price_desc':
       return 'price:desc';
     case 'date_desc':
-      return 'createdAt:desc';
     case 'date_asc':
-      return 'createdAt:asc';
+      // Deprecated: createdAt field not indexed in Typesense
+      return undefined;
     default:
       return undefined;
   }

--- a/scripts/initTypesense.ts
+++ b/scripts/initTypesense.ts
@@ -24,11 +24,13 @@ const schema = {
   name: 'products',
   fields: [
     { name: 'id', type: 'string' as const },
+    { name: 'title', type: 'string' as const },
     { name: 'name', type: 'string' as const },
     { name: 'slug', type: 'string' as const },
     { name: 'description', type: 'string' as const },
     { name: 'price', type: 'float' as const },
     { name: 'category', type: 'string' as const, facet: true },
+    { name: 'brand', type: 'string' as const, facet: true },
     { name: 'sold_count', type: 'int32' as const },
   ],
   default_sorting_field: 'sold_count',
@@ -36,8 +38,24 @@ const schema = {
 
 async function init() {
   try {
-    await client.collections('products').retrieve();
-    console.log('✅ Typesense collection "products" already exists.');
+    const existing = await client.collections('products').retrieve();
+    const fieldsMatch =
+      existing.fields?.length === schema.fields.length &&
+      existing.fields.every((f: any, i: number) => {
+        const s = schema.fields[i] as any;
+        return f.name === s.name && f.type === s.type && (!!f.facet === !!s.facet);
+      }) &&
+      existing.default_sorting_field === schema.default_sorting_field;
+
+    if (fieldsMatch) {
+      console.log('✅ Typesense collection "products" already up-to-date.');
+      return;
+    }
+
+    console.log('ℹ️  Schema mismatch detected. Recreating collection...');
+    await client.collections('products').delete();
+    await client.collections().create(schema);
+    console.log('✅ Recreated Typesense collection "products".');
   } catch (err: unknown) {
     if (err instanceof ObjectNotFound) {
       console.log('ℹ️  "products" collection not found. Creating new collection...');

--- a/scripts/typesense-schema.ts
+++ b/scripts/typesense-schema.ts
@@ -3,12 +3,13 @@ export const productsSchema = {
   fields: [
     { name: 'id', type: 'string' },
     { name: 'title', type: 'string' },
+    { name: 'name', type: 'string' },
+    { name: 'slug', type: 'string' },
     { name: 'description', type: 'string' },
+    { name: 'price', type: 'float' },
     { name: 'category', type: 'string', facet: true },
-    { name: 'price', type: 'float', facet: true },
     { name: 'brand', type: 'string', facet: true },
-    { name: 'status', type: 'string', facet: true },
-    { name: 'createdAt', type: 'int64' },
+    { name: 'sold_count', type: 'int32' },
   ],
-  default_sorting_field: 'price',
+  default_sorting_field: 'sold_count',
 };


### PR DESCRIPTION
## Summary
- update the init script with full product schema and auto re-create the collection when needed
- align `typesense-schema.ts` with the new schema
- adjust search API to ignore date sorting, matching new Typesense schema

## Testing
- `npx -y ts-node scripts/initTypesense.ts` *(fails: Cannot find module 'dotenv')*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find type definitions)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685460a7cec8832f9e5f5708f3b32803