### PR TITLE
Fix DB import usage

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,6 @@
 import { prisma } from './prisma';
 
+export const getDb = () => prisma;
 export default prisma;
 
 export function dbGetCategories() {

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -16,8 +16,8 @@ import {
   getCategoryByName,
   getCategoryById,
   countProductsForCategory,
+  getDb,
 } from './db';
-import { prisma } from './prisma';
 
 let products = [];
 let productIndex = null;
@@ -91,8 +91,9 @@ function processProductRow(row) {
 }
 
 async function loadProductsData() {
+  const db = getDb();
   try {
-    const rows = await prisma.product.findMany({
+    const rows = await db.product.findMany({
       where: { status: 'approved' },
       include: { category: true, vendor: true },
     });
@@ -339,7 +340,8 @@ export async function getCategoryTree() {
       .sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  const rows = await prisma.product.findMany({ include: { category: true } });
+  const db = getDb();
+  const rows = await db.product.findMany({ include: { category: true } });
   const map = {} as Record<string, Set<string>>;
   for (const row of rows) {
     const categoryName = row.category?.name;

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,4 +1,6 @@
-import { prisma } from './prisma';
+import { getDb } from './db';
+
+const prisma = getDb();
 
 export async function addUser({
   email,

--- a/pages/api/admin/search-analytics.ts
+++ b/pages/api/admin/search-analytics.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { prisma } from '../../../lib/prisma';
+import { getDb } from '../../../lib/db';
 import { withRole } from '../../../lib/withRole';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -7,7 +7,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
 
-  const logs = await prisma.searchLog.findMany();
+  const db = getDb();
+  const logs = await db.searchLog.findMany();
   const counts: Record<string, number> = {};
   const fails: Record<string, number> = {};
   for (const log of logs) {

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getBestSellingProducts } from '../../lib/orders';
-import { prisma } from '../../lib/prisma';
+import { getDb } from '../../lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import client from '../../lib/typesenseClient';
@@ -28,10 +28,11 @@ export default async function handler(
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
 
+  const db = getDb();
   const session = await getServerSession(req, res, authOptions);
   let userId: number | null = null;
   if (session?.user?.email) {
-    const user = await prisma.user.findUnique({
+    const user = await db.user.findUnique({
       where: { email: session.user.email },
       select: { id: true },
     });
@@ -96,7 +97,7 @@ export default async function handler(
     }
     const fallback = result.found === 0 ? getBestSellingProducts(8) : [];
     try {
-      await prisma.searchLog.create({
+      await db.searchLog.create({
         data: {
           query: String(q),
           userId,


### PR DESCRIPTION
## Summary
- provide `getDb()` named export for prisma
- use `getDb()` in product and user utilities
- use `getDb()` in search APIs

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_685463e02d74832f9617801e422d014f