### PR TITLE
Fix auth page layout

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -55,8 +55,8 @@ export default function Login() {
   };
 
   return (
-    <div className="flex justify-center items-center min-h-screen">
-      <div className="w-full max-w-md px-4 sm:px-6 lg:px-8">
+    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <div className="w-full max-w-md space-y-4 -mt-8">
         <h1 className="text-2xl font-bold mb-4">Login</h1>
         <button
           type="button"

--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -184,8 +184,8 @@ export default function BrandSignup() {
   };
 
   return (
-    <div className="flex justify-center items-center min-h-screen">
-      <div className="w-full max-w-3xl px-4 sm:px-6 lg:px-8 py-6 bg-slate-100 shadow-lg rounded-lg fade-in">
+    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <div className="w-full max-w-3xl -mt-8 px-4 sm:px-6 lg:px-8 py-6 bg-slate-100 shadow-lg rounded-lg fade-in">
       <div className="text-center mb-6">
         <h1 className="text-2xl font-bold">Brand Sign Up</h1>
       </div>

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 
 export default function Signup() {
   return (
-    <div className="flex justify-center items-center min-h-screen">
-      <div className="w-full max-w-md space-y-4 px-4 sm:px-6 lg:px-8">
+    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <div className="w-full max-w-md space-y-4 -mt-8">
       <h1 className="text-2xl font-bold mb-4">Choose Signup Type</h1>
       <Link href="/signup/user" className="btn btn-primary w-full">
         User Signup

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -127,8 +127,8 @@ export default function UserSignup() {
   };
 
   return (
-    <div className="flex justify-center items-center min-h-screen">
-      <div className="w-full max-w-2xl px-4 sm:px-6 lg:px-8">
+    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <div className="w-full max-w-2xl -mt-8">
         <h1 className="text-2xl font-bold mb-4">User Sign Up</h1>
       <div className="flex flex-col gap-6 mb-4">
         <button


### PR DESCRIPTION
## Summary
- adjust sign-in and sign-up containers to avoid scroll
- lift forms slightly for better balance

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6854da6e60f8832f8f8f066cd9f08f13