### PR TITLE
Add global API error handling

### DIFF
--- a/lib/utils/handleApiError.ts
+++ b/lib/utils/handleApiError.ts
@@ -1,0 +1,7 @@
+export function handleApiError(res: any, error: unknown, defaultMessage = 'Unexpected server error') {
+  console.error('API Error:', error);
+  if (error instanceof Error && 'code' in error) {
+    return res.status(400).json({ error: (error as Error).message });
+  }
+  return res.status(500).json({ error: defaultMessage });
+}

--- a/pages/api/admin/analytics.ts
+++ b/pages/api/admin/analytics.ts
@@ -1,29 +1,34 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getAllOrders } from '../../../lib/orders';
 import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
-function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
-  const orders = getAllOrders();
-  const summary = {
-    totalOrders: orders.length,
-    totalRevenue: 0,
-    topProducts: [],
-  };
-  const counts = {};
-  orders.forEach((o) => {
-    summary.totalRevenue += o.total || 0;
-    o.items.forEach((i) => {
-      counts[i.ID] = (counts[i.ID] || 0) + i.qty;
+  try {
+    const orders = await getAllOrders();
+    const summary = {
+      totalOrders: orders.length,
+      totalRevenue: 0,
+      topProducts: [],
+    };
+    const counts: Record<string, number> = {};
+    orders.forEach((o) => {
+      summary.totalRevenue += o.total || 0;
+      o.items.forEach((i) => {
+        counts[i.ID] = (counts[i.ID] || 0) + i.qty;
+      });
     });
-  });
-  summary.topProducts = Object.entries(counts)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 5)
-    .map(([id, qty]) => ({ id, qty }));
-  return res.status(200).json(summary);
+    summary.topProducts = Object.entries(counts)
+      .sort((a, b) => (b[1] as number) - (a[1] as number))
+      .slice(0, 5)
+      .map(([id, qty]) => ({ id, qty }));
+    return res.status(200).json(summary);
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load analytics');
+  }
 }
 
 export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -7,56 +7,61 @@ import {
 } from '../../../lib/products';
 import { withRole } from '../../../lib/withRole';
 import { logAudit } from '../../../lib/audit';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
-function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === 'GET') {
-    return res.status(200).json(getCategoriesFlat());
-  }
-  if (req.method === 'POST') {
-    const { name, parentId, image } = req.body || {};
-    if (!name) return res.status(400).json({ message: 'name required' });
-    const exists = getCategoriesFlat().find(
-      (c) => c.name.toLowerCase() === name.toLowerCase()
-    );
-    if (exists) {
-      return res.status(409).json({ message: 'category exists' });
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method === 'GET') {
+      return res.status(200).json(getCategoriesFlat());
     }
-    try {
-      createCategory(name, parentId || null, image || null);
-    } catch (e) {
-      if (e.message === 'depth') {
-        return res.status(400).json({ message: 'max depth exceeded' });
+    if (req.method === 'POST') {
+      const { name, parentId, image } = req.body || {};
+      if (!name) return res.status(400).json({ message: 'name required' });
+      const exists = getCategoriesFlat().find(
+        (c) => c.name.toLowerCase() === name.toLowerCase()
+      );
+      if (exists) {
+        return res.status(409).json({ message: 'category exists' });
       }
-      throw e;
-    }
-    logAudit('create_category', { name, parentId, image });
-    return res.status(201).json({ message: 'category created' });
-  }
-  if (req.method === 'PUT') {
-    const { id, name, parentId, image } = req.body || {};
-    if (!id || !name)
-      return res.status(400).json({ message: 'id and name required' });
-    renameCategory(id, name, parentId || null, image || null);
-    logAudit('rename_category', { id, name, parentId, image });
-    return res.status(200).json({ message: 'category updated' });
-  }
-  if (req.method === 'DELETE') {
-    const { id } = req.query;
-    if (!id) return res.status(400).json({ message: 'id required' });
-    try {
-      removeCategory(id);
-      logAudit('delete_category', { id });
-      return res.status(200).json({ message: 'category deleted' });
-    } catch (e) {
-      if (e.message === 'category in use') {
-        return res
-          .status(400)
-          .json({ message: 'cannot delete category with products' });
+      try {
+        createCategory(name, parentId || null, image || null);
+      } catch (e: any) {
+        if (e.message === 'depth') {
+          return res.status(400).json({ message: 'max depth exceeded' });
+        }
+        throw e;
       }
-      throw e;
+      logAudit('create_category', { name, parentId, image });
+      return res.status(201).json({ message: 'category created' });
     }
+    if (req.method === 'PUT') {
+      const { id, name, parentId, image } = req.body || {};
+      if (!id || !name)
+        return res.status(400).json({ message: 'id and name required' });
+      renameCategory(id, name, parentId || null, image || null);
+      logAudit('rename_category', { id, name, parentId, image });
+      return res.status(200).json({ message: 'category updated' });
+    }
+    if (req.method === 'DELETE') {
+      const { id } = req.query;
+      if (!id) return res.status(400).json({ message: 'id required' });
+      try {
+        removeCategory(id);
+        logAudit('delete_category', { id });
+        return res.status(200).json({ message: 'category deleted' });
+      } catch (e: any) {
+        if (e.message === 'category in use') {
+          return res
+            .status(400)
+            .json({ message: 'cannot delete category with products' });
+        }
+        throw e;
+      }
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage categories');
   }
-  return res.status(405).json({ message: 'Method Not Allowed' });
 }
 
 export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -11,6 +11,7 @@ import formidable from 'formidable';
 import fs from 'fs';
 import path from 'path';
 import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 function slugify(text) {
   return text
@@ -38,8 +39,9 @@ function parseForm(req) {
 }
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === 'POST' || req.method === 'PUT') {
-    const { fields, files } = await parseForm(req);
+  try {
+    if (req.method === 'POST' || req.method === 'PUT') {
+      const { fields, files } = await parseForm(req);
     const {
       id,
       title,
@@ -134,7 +136,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(200).json(filtered);
   }
 
-  return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to process product');
+  }
 }
 
 

--- a/pages/api/admin/search-analytics.ts
+++ b/pages/api/admin/search-analytics.ts
@@ -1,32 +1,37 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getDb } from '../../../lib/db';
 import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'GET') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
-  }
-
-  const db = getDb();
-  const logs = await db.searchLog.findMany();
-  const counts: Record<string, number> = {};
-  const fails: Record<string, number> = {};
-  for (const log of logs) {
-    counts[log.query] = (counts[log.query] || 0) + 1;
-    if (log.noResults) {
-      fails[log.query] = (fails[log.query] || 0) + 1;
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
     }
-  }
-  const topSearches = Object.entries(counts)
-    .sort((a, b) => (b[1] as number) - (a[1] as number))
-    .slice(0, 10)
-    .map(([query, count]) => ({ query, count }));
-  const failedSearches = Object.entries(fails)
-    .sort((a, b) => (b[1] as number) - (a[1] as number))
-    .slice(0, 10)
-    .map(([query, count]) => ({ query, count }));
 
-  return res.status(200).json({ topSearches, failedSearches });
+    const db = getDb();
+    const logs = await db.searchLog.findMany();
+    const counts: Record<string, number> = {};
+    const fails: Record<string, number> = {};
+    for (const log of logs) {
+      counts[log.query] = (counts[log.query] || 0) + 1;
+      if (log.noResults) {
+        fails[log.query] = (fails[log.query] || 0) + 1;
+      }
+    }
+    const topSearches = Object.entries(counts)
+      .sort((a, b) => (b[1] as number) - (a[1] as number))
+      .slice(0, 10)
+      .map(([query, count]) => ({ query, count }));
+    const failedSearches = Object.entries(fails)
+      .sort((a, b) => (b[1] as number) - (a[1] as number))
+      .slice(0, 10)
+      .map(([query, count]) => ({ query, count }));
+
+    return res.status(200).json({ topSearches, failedSearches });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load analytics');
+  }
 }
 
 export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -7,49 +7,54 @@ import {
   setUserDisabled,
 } from '../../../lib/users';
 import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === 'GET') {
-    return res.status(200).json(await getAllUsers());
-  }
-  if (req.method === 'PUT') {
-    const { email, role } = req.body || {};
-    if (!email || !role)
-      return res.status(400).json({ message: 'email and role required' });
-    await updateUserRole(email, role);
-    return res.status(200).json({ message: 'role updated' });
-  }
-  if (req.method === 'PATCH') {
-    const { email, disabled } = req.body || {};
-    if (typeof disabled !== 'boolean' || !email)
-      return res.status(400).json({ message: 'email and disabled required' });
-    await setUserDisabled(email, disabled);
-    return res.status(200).json({ message: 'status updated' });
-  }
-  if (req.method === 'DELETE') {
-    const { email } = req.query;
-    if (!email) return res.status(400).json({ message: 'email required' });
-    await deleteUser(email);
-    return res.status(200).json({ message: 'user deleted' });
-  }
-  if (req.method === 'POST') {
-    const { email, password, firstName, lastName, brandName, gender, role } =
-      req.body || {};
-    if (!email || !password || !firstName || !lastName || !gender) {
-      return res.status(400).json({ message: 'missing required fields' });
+  try {
+    if (req.method === 'GET') {
+      return res.status(200).json(await getAllUsers());
     }
-    await addUser({
-      email,
-      password,
-      first_name: firstName,
-      last_name: lastName,
-      brand_name: brandName,
-      gender,
-      role: role || 'USER',
-    });
-    return res.status(201).json({ message: 'user created' });
+    if (req.method === 'PUT') {
+      const { email, role } = req.body || {};
+      if (!email || !role)
+        return res.status(400).json({ message: 'email and role required' });
+      await updateUserRole(email, role);
+      return res.status(200).json({ message: 'role updated' });
+    }
+    if (req.method === 'PATCH') {
+      const { email, disabled } = req.body || {};
+      if (typeof disabled !== 'boolean' || !email)
+        return res.status(400).json({ message: 'email and disabled required' });
+      await setUserDisabled(email, disabled);
+      return res.status(200).json({ message: 'status updated' });
+    }
+    if (req.method === 'DELETE') {
+      const { email } = req.query;
+      if (!email) return res.status(400).json({ message: 'email required' });
+      await deleteUser(email);
+      return res.status(200).json({ message: 'user deleted' });
+    }
+    if (req.method === 'POST') {
+      const { email, password, firstName, lastName, brandName, gender, role } =
+        req.body || {};
+      if (!email || !password || !firstName || !lastName || !gender) {
+        return res.status(400).json({ message: 'missing required fields' });
+      }
+      await addUser({
+        email,
+        password,
+        first_name: firstName,
+        last_name: lastName,
+        brand_name: brandName,
+        gender,
+        role: role || 'USER',
+      });
+      return res.status(201).json({ message: 'user created' });
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage users');
   }
-  return res.status(405).json({ message: 'Method Not Allowed' });
 }
 
 export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/admin/vendor-products.ts
+++ b/pages/api/admin/vendor-products.ts
@@ -5,26 +5,31 @@ import {
   rejectProduct,
 } from '../../../lib/products';
 import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
-function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === 'GET') {
-    return res.status(200).json(getPendingProducts());
-  }
-  if (req.method === 'PUT') {
-    const { id, action } = req.body || {};
-    if (!id || !action)
-      return res.status(400).json({ message: 'id and action required' });
-    if (action === 'approve') {
-      approveProduct(id);
-      return res.status(200).json({ message: 'approved' });
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method === 'GET') {
+      return res.status(200).json(getPendingProducts());
     }
-    if (action === 'reject') {
-      rejectProduct(id);
-      return res.status(200).json({ message: 'rejected' });
+    if (req.method === 'PUT') {
+      const { id, action } = req.body || {};
+      if (!id || !action)
+        return res.status(400).json({ message: 'id and action required' });
+      if (action === 'approve') {
+        approveProduct(id);
+        return res.status(200).json({ message: 'approved' });
+      }
+      if (action === 'reject') {
+        rejectProduct(id);
+        return res.status(200).json({ message: 'rejected' });
+      }
+      return res.status(400).json({ message: 'invalid action' });
     }
-    return res.status(400).json({ message: 'invalid action' });
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to process vendor products');
   }
-  return res.status(405).json({ message: 'Method Not Allowed' });
 }
 
 

--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -1,33 +1,38 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'GET') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const { vendor } = req.query;
+    if (!vendor) {
+      return res.status(400).json({ message: 'vendor required' });
+    }
+    const orders = await getOrdersForVendor(vendor as string);
+    const summary = {
+      totalOrders: orders.length,
+      totalRevenue: 0,
+      topProducts: [],
+    };
+    const counts: Record<string, number> = {};
+    orders.forEach((o) => {
+      summary.totalRevenue += o.total || 0;
+      o.items
+        .filter((i) => i.VENDOR === vendor)
+        .forEach((i) => {
+          counts[i.ID] = (counts[i.ID] || 0) + i.qty;
+        });
+    });
+    summary.topProducts = Object.entries(counts)
+      .sort((a, b) => (b[1] as number) - (a[1] as number))
+      .slice(0, 5)
+      .map(([id, qty]) => ({ id, qty }));
+    return res.status(200).json(summary);
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load analytics');
   }
-  const { vendor } = req.query;
-  if (!vendor) {
-    return res.status(400).json({ message: 'vendor required' });
-  }
-  const orders = await getOrdersForVendor(vendor as string);
-  const summary = {
-    totalOrders: orders.length,
-    totalRevenue: 0,
-    topProducts: [],
-  };
-  const counts = {};
-  orders.forEach((o) => {
-    summary.totalRevenue += o.total || 0;
-    o.items
-      .filter((i) => i.VENDOR === vendor)
-      .forEach((i) => {
-        counts[i.ID] = (counts[i.ID] || 0) + i.qty;
-      });
-  });
-  summary.topProducts = Object.entries(counts)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 5)
-    .map(([id, qty]) => ({ id, qty }));
-  return res.status(200).json(summary);
 }
 

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -1,24 +1,29 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoriesFlat, createCategory } from '../../../lib/products';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
-  }
-  const { name, parentId } = req.body || {};
-  if (!name) return res.status(400).json({ message: 'name required' });
-  const exists = getCategoriesFlat().find(
-    (c) => c.name.toLowerCase() === name.toLowerCase()
-  );
-  if (!exists) {
-    try {
-      createCategory(name, parentId || null);
-    } catch (e) {
-      if (e.message === 'depth') {
-        return res.status(400).json({ message: 'max depth exceeded' });
-      }
-      throw e;
+  try {
+    if (req.method !== 'POST') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
     }
+    const { name, parentId } = req.body || {};
+    if (!name) return res.status(400).json({ message: 'name required' });
+    const exists = getCategoriesFlat().find(
+      (c) => c.name.toLowerCase() === name.toLowerCase()
+    );
+    if (!exists) {
+      try {
+        createCategory(name, parentId || null);
+      } catch (e: any) {
+        if (e.message === 'depth') {
+          return res.status(400).json({ message: 'max depth exceeded' });
+        }
+        throw e;
+      }
+    }
+    return res.status(201).json({ message: 'ok' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to create category');
   }
-  return res.status(201).json({ message: 'ok' });
 }

--- a/pages/api/brand/low-stock.ts
+++ b/pages/api/brand/low-stock.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { loadAndIndexProducts } from '../../../lib/products';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { vendor } = req.query;
-  if (!vendor) return res.status(400).json({ message: 'vendor required' });
-  const { products } = await loadAndIndexProducts();
-  const low = products.filter(
-    (p) => p.VENDOR === vendor && p.TOTAL_INVENTORY <= 5
-  );
-  res.status(200).json(low);
+  try {
+    const { vendor } = req.query;
+    if (!vendor) return res.status(400).json({ message: 'vendor required' });
+    const { products } = await loadAndIndexProducts();
+    const low = products.filter(
+      (p) => p.VENDOR === vendor && p.TOTAL_INVENTORY <= 5
+    );
+    res.status(200).json(low);
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to fetch low stock products');
+  }
 }

--- a/pages/api/brand/orders.ts
+++ b/pages/api/brand/orders.ts
@@ -1,14 +1,19 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'GET') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const { vendor } = req.query;
+    if (!vendor) {
+      return res.status(400).json({ message: 'vendor required' });
+    }
+    const orders = await getOrdersForVendor(vendor as string);
+    return res.status(200).json(orders);
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to get orders');
   }
-  const { vendor } = req.query;
-  if (!vendor) {
-    return res.status(400).json({ message: 'vendor required' });
-  }
-  const orders = await getOrdersForVendor(vendor as string);
-  return res.status(200).json(orders);
 }

--- a/pages/api/brand/products/[id].ts
+++ b/pages/api/brand/products/[id].ts
@@ -2,19 +2,21 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateProduct, deleteProduct, loadAndIndexProducts } from '../../../../lib/products';
 import { getProductById } from '../../../../lib/db';
 import { hasOrdersForProduct } from '../../../../lib/orders';
+import { handleApiError } from '../../../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { id } = req.query;
-  if (!id) return res.status(400).json({ message: 'id required' });
+  try {
+    const { id } = req.query;
+    if (!id) return res.status(400).json({ message: 'id required' });
 
-  if (req.method === 'PUT') {
-    const existing = await getProductById(String(id));
-    if (!existing) return res.status(404).json({ message: 'Not found' });
-    const {
-      title,
-      vendor,
-      description,
-      product_type,
+    if (req.method === 'PUT') {
+      const existing = await getProductById(String(id));
+      if (!existing) return res.status(404).json({ message: 'Not found' });
+      const {
+        title,
+        vendor,
+        description,
+        product_type,
       tags,
       category,
       quantity,
@@ -38,20 +40,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       status: existing.status,
       images: existing.images,
     });
-    await loadAndIndexProducts();
-    return res.status(200).json({ message: 'product updated' });
-  }
-
-  if (req.method === 'DELETE') {
-    const existing = await getProductById(String(id));
-    if (!existing) return res.status(404).json({ message: 'Not found' });
-    if (existing.quantity > 0 || hasOrdersForProduct(String(id))) {
-      return res.status(400).json({ message: 'cannot delete product with stock or orders' });
+      await loadAndIndexProducts();
+      return res.status(200).json({ message: 'product updated' });
     }
-    await deleteProduct(String(id));
-    await loadAndIndexProducts();
-    return res.status(200).json({ message: 'product deleted' });
-  }
 
-  return res.status(405).json({ message: 'Method Not Allowed' });
+    if (req.method === 'DELETE') {
+      const existing = await getProductById(String(id));
+      if (!existing) return res.status(404).json({ message: 'Not found' });
+      if (existing.quantity > 0 || hasOrdersForProduct(String(id))) {
+        return res.status(400).json({ message: 'cannot delete product with stock or orders' });
+      }
+      await deleteProduct(String(id));
+      await loadAndIndexProducts();
+      return res.status(200).json({ message: 'product deleted' });
+    }
+
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to process product');
+  }
 }

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { addProduct, loadAndIndexProducts } from '../../../../lib/products';
+import { handleApiError } from '../../../../lib/utils/handleApiError';
 
 function slugify(text) {
   return text
@@ -11,20 +12,21 @@ function slugify(text) {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === 'GET') {
-    const { vendor } = req.query;
-    if (!vendor) return res.status(400).json({ message: 'vendor required' });
-    const { products } = await loadAndIndexProducts();
-    const filtered = products.filter((p) => p.VENDOR === vendor);
-    return res.status(200).json(filtered);
-  }
+  try {
+    if (req.method === 'GET') {
+      const { vendor } = req.query;
+      if (!vendor) return res.status(400).json({ message: 'vendor required' });
+      const { products } = await loadAndIndexProducts();
+      const filtered = products.filter((p) => p.VENDOR === vendor);
+      return res.status(200).json(filtered);
+    }
 
-  if (req.method === 'POST') {
-    const {
-      id,
-      title,
-      vendor,
-      description,
+    if (req.method === 'POST') {
+      const {
+        id,
+        title,
+        vendor,
+        description,
       product_type,
       tags,
       category,
@@ -51,10 +53,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       currency: currency || 'USD',
       status: 'approved',
       images: JSON.stringify([]),
-    });
-    await loadAndIndexProducts();
-    return res.status(201).json({ message: 'product created' });
-  }
+      });
+      await loadAndIndexProducts();
+      return res.status(201).json({ message: 'product created' });
+    }
 
-  return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage products');
+  }
 }

--- a/pages/api/brand/profile.ts
+++ b/pages/api/brand/profile.ts
@@ -2,40 +2,45 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateUserProfile, findUser } from '../../../lib/users';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getServerSession(req, res, authOptions);
-  if (!session?.user) {
-    return res.status(401).json({ message: 'Unauthorized' });
-  }
-  if (req.method === 'GET') {
-    const userData = await findUser(session.user.email);
-    return res.status(200).json(userData);
-  }
-  if (req.method === 'PUT') {
-    const {
-      brandName,
-      phoneNumber,
-      businessAddress,
-      city,
-      country,
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    if (req.method === 'GET') {
+      const userData = await findUser(session.user.email);
+      return res.status(200).json(userData);
+    }
+    if (req.method === 'PUT') {
+      const {
+        brandName,
+        phoneNumber,
+        businessAddress,
+        city,
+        country,
       website,
       businessDescription,
       logo,
       taxId,
     } = req.body;
-    await updateUserProfile(session.user.email, {
-      brandName,
-      phoneNumber,
-      businessAddress,
-      city,
-      country,
-      website,
-      businessDescription,
-      logo,
-      taxId,
-    });
-    return res.status(200).json({ message: 'updated' });
+      await updateUserProfile(session.user.email, {
+        brandName,
+        phoneNumber,
+        businessAddress,
+        city,
+        country,
+        website,
+        businessDescription,
+        logo,
+        taxId,
+      });
+      return res.status(200).json({ message: 'updated' });
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage profile');
   }
-  return res.status(405).json({ message: 'Method Not Allowed' });
 }

--- a/pages/api/cart.ts
+++ b/pages/api/cart.ts
@@ -2,24 +2,29 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCart, setCart } from '../../lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getServerSession(req, res, authOptions);
-  if (!session?.user) {
-    return res.status(401).json({ message: 'Unauthorized' });
-  }
-  const email = session.user.email;
-  if (req.method === 'GET') {
-    const items = getCart(email);
-    return res.status(200).json(items);
-  }
-  if (req.method === 'POST') {
-    const { items } = req.body || {};
-    if (!Array.isArray(items)) {
-      return res.status(400).json({ message: 'items required' });
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
     }
-    setCart(email, items);
-    return res.status(200).json({ message: 'saved' });
+    const email = session.user.email;
+    if (req.method === 'GET') {
+      const items = getCart(email);
+      return res.status(200).json(items);
+    }
+    if (req.method === 'POST') {
+      const { items } = req.body || {};
+      if (!Array.isArray(items)) {
+        return res.status(400).json({ message: 'items required' });
+      }
+      setCart(email, items);
+      return res.status(200).json({ message: 'saved' });
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage cart');
   }
-  return res.status(405).json({ message: 'Method Not Allowed' });
 }

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -1,13 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '../../lib/products';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  if (req.method === 'GET') {
-    const data = await getCategoryTree();
-    return res.status(200).json(data);
+  try {
+    if (req.method === 'GET') {
+      const data = await getCategoryTree();
+      return res.status(200).json(data);
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load categories');
   }
-  return res.status(405).json({ message: 'Method Not Allowed' });
 }

--- a/pages/api/category-tree.ts
+++ b/pages/api/category-tree.ts
@@ -1,13 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '../../lib/products';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  if (req.method === 'GET') {
-    const data = await getCategoryTree();
-    return res.status(200).json(data);
+  try {
+    if (req.method === 'GET') {
+      const data = await getCategoryTree();
+      return res.status(200).json(data);
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load categories');
   }
-  return res.status(405).json({ message: 'Method Not Allowed' });
 }

--- a/pages/api/check-email.ts
+++ b/pages/api/check-email.ts
@@ -1,11 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser } from '../../lib/users';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { email } = req.query;
-  if (!email) {
-    return res.status(400).json({ message: 'email required' });
+  try {
+    const { email } = req.query;
+    if (!email) {
+      return res.status(400).json({ message: 'email required' });
+    }
+    const user = await findUser(email);
+    return res.status(200).json({ exists: !!user });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to check email');
   }
-  const user = await findUser(email);
-  return res.status(200).json({ exists: !!user });
 }

--- a/pages/api/checkout/complete.ts
+++ b/pages/api/checkout/complete.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
 import { addOrder } from '../../../lib/orders';
 import { sendOrderConfirmation } from '../../../lib/email';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2023-10-16',
@@ -30,7 +31,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await sendOrderConfirmation(metadata.email, { id: orderId });
     return res.status(200).json({ id: orderId });
   } catch (e) {
-    console.error(e);
-    return res.status(500).json({ message: 'stripe error' });
+    return handleApiError(res, e, 'stripe error');
   }
 }

--- a/pages/api/checkout/create-session.ts
+++ b/pages/api/checkout/create-session.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2023-10-16',
@@ -36,7 +37,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
     return res.status(200).json({ url: session.url, id: session.id });
   } catch (e) {
-    console.error(e);
-    return res.status(500).json({ message: 'stripe error' });
+    return handleApiError(res, e, 'stripe error');
   }
 }

--- a/pages/api/coupons/[code].ts
+++ b/pages/api/coupons/[code].ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 const coupons = {
   SAVE10: { percent: 10 },
   SAVE20: { percent: 20 },
 };
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { code } = req.query;
-  const coupon = coupons[code?.toUpperCase()];
-  if (!coupon) return res.status(404).json({ message: 'Invalid code' });
-  res.status(200).json(coupon);
+  try {
+    const { code } = req.query;
+    const coupon = coupons[code?.toUpperCase() as string];
+    if (!coupon) return res.status(404).json({ message: 'Invalid code' });
+    res.status(200).json(coupon);
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to validate coupon');
+  }
 }

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -1,33 +1,38 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser } from '../../lib/users';
 import bcrypt from 'bcryptjs';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+  try {
+    if (req.method !== 'POST') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ message: 'email and password required' });
+    }
+    const user = await findUser(email);
+    if (
+      !user ||
+      user.disabled ||
+      !(await bcrypt.compare(password, user.password))
+    ) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const { firstName, lastName, brandName, gender, role } = user;
+    return res.status(200).json({
+      message: 'Login successful',
+      user: {
+        email,
+        firstName,
+        lastName,
+        brandName,
+        gender,
+        role,
+      },
+    });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to login');
   }
-  const { email, password } = req.body;
-  if (!email || !password) {
-    return res.status(400).json({ message: 'email and password required' });
-  }
-  const user = await findUser(email);
-  if (
-    !user ||
-    user.disabled ||
-    !(await bcrypt.compare(password, user.password))
-  ) {
-    return res.status(401).json({ message: 'Invalid credentials' });
-  }
-  const { firstName, lastName, brandName, gender, role } = user;
-  return res.status(200).json({
-    message: 'Login successful',
-    user: {
-      email,
-      firstName,
-      lastName,
-      brandName,
-      gender,
-      role,
-    },
-  });
 }

--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -13,10 +13,12 @@ import {
 } from '../../lib/db';
 import { withRole } from '../../lib/withRole';
 import { sendOrderConfirmation } from '../../lib/email';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === 'POST') {
-    const { email, items, total, shippingName, shippingAddress } = req.body;
+  try {
+    if (req.method === 'POST') {
+      const { email, items, total, shippingName, shippingAddress } = req.body;
     if (!email || !items) {
       return res.status(400).json({ message: 'email and items required' });
     }
@@ -63,7 +65,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(200).json(await getOrdersForUser(email));
   }
 
-  return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to process orders');
+  }
 }
 
 export default withRole(['USER', 'BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/api/orders/[id].ts
+++ b/pages/api/orders/[id].ts
@@ -3,31 +3,36 @@ import { getOrderById } from '../../../lib/orders';
 import { updateOrderStatus } from '../../../lib/orders';
 import { sendOrderStatusUpdate } from '../../../lib/email';
 import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { id } = req.query;
-  if (!id) {
-    return res.status(400).json({ message: 'id required' });
-  }
-
-  if (req.method === 'GET') {
-    const order = await getOrderById(String(id));
-    if (!order) return res.status(404).json({ message: 'Not found' });
-    return res.status(200).json(order);
-  }
-
-  if (req.method === 'PATCH') {
-    const { status } = req.body || {};
-    if (!status || !['pending', 'shipped', 'completed'].includes(status)) {
-      return res.status(400).json({ message: 'invalid status' });
+  try {
+    const { id } = req.query;
+    if (!id) {
+      return res.status(400).json({ message: 'id required' });
     }
-    await updateOrderStatus(String(id), status);
-    const order = await getOrderById(String(id));
-    await sendOrderStatusUpdate(order.user_email, order);
-    return res.status(200).json(order);
-  }
 
-  return res.status(405).json({ message: 'Method Not Allowed' });
+    if (req.method === 'GET') {
+      const order = await getOrderById(String(id));
+      if (!order) return res.status(404).json({ message: 'Not found' });
+      return res.status(200).json(order);
+    }
+
+    if (req.method === 'PATCH') {
+      const { status } = req.body || {};
+      if (!status || !['pending', 'shipped', 'completed'].includes(status)) {
+        return res.status(400).json({ message: 'invalid status' });
+      }
+      await updateOrderStatus(String(id), status);
+      const order = await getOrderById(String(id));
+      await sendOrderStatusUpdate(order.user_email, order);
+      return res.status(200).json(order);
+    }
+
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage order');
+  }
 }
 
 export default withRole(['BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/api/products/[id].ts
+++ b/pages/api/products/[id].ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getProductById, getAverageRating } from '../../../lib/db.js';
 import { mapDbRowToProduct } from '../../../lib/products.js';
 import { Product } from '../../../types/product';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export type ProductResponse = Product & {
   AVERAGE_RATING: number;
@@ -29,6 +30,6 @@ export default async function handler(
       REVIEW_COUNT: stats.count,
     });
   } catch (e) {
-    res.status(500).json({ message: 'Failed to load product' });
+    return handleApiError(res, e, 'Failed to load product');
   }
 }

--- a/pages/api/products/[id]/reviews.ts
+++ b/pages/api/products/[id]/reviews.ts
@@ -5,6 +5,7 @@ import {
   getReviewsForProduct,
   getAverageRating,
 } from '../../../../lib/db.js';
+import { handleApiError } from '../../../../lib/utils/handleApiError';
 import type { Review, ReviewsResponse, ReviewAddedResponse } from '../../../../types/review';
 
 export default async function handler(
@@ -15,44 +16,48 @@ export default async function handler(
     query: { id },
     method,
   } = req;
-  if (!id) return res.status(400).json({ message: 'id required' });
+  try {
+    if (!id) return res.status(400).json({ message: 'id required' });
 
-  if (method === 'GET') {
-    const reviews = getReviewsForProduct(String(id)) as Review[];
-    const stats = getAverageRating(String(id));
-    return res.status(200).json({
-      reviews,
-      averageRating: stats.average,
-      reviewCount: stats.count,
-    });
-  }
-
-  if (method === 'POST') {
-    const session = await getSession({ req });
-    if (!session?.user) {
-      return res.status(401).json({ message: 'auth required' });
+    if (method === 'GET') {
+      const reviews = getReviewsForProduct(String(id)) as Review[];
+      const stats = getAverageRating(String(id));
+      return res.status(200).json({
+        reviews,
+        averageRating: stats.average,
+        reviewCount: stats.count,
+      });
     }
-    const { rating, comment = '' } = (req.body || {}) as {
-      rating?: number | string;
-      comment?: string;
-    };
-    const r = parseInt(String(rating), 10);
-    if (!r || r < 1 || r > 5) {
-      return res.status(400).json({ message: 'rating 1-5 required' });
-    }
-    addReview({
-      productId: String(id),
-      userEmail: session.user.email!,
-      rating: r,
-      comment,
-    });
-    const stats = getAverageRating(String(id));
-    return res.status(201).json({
-      message: 'review added',
-      averageRating: stats.average,
-      reviewCount: stats.count,
-    });
-  }
 
-  return res.status(405).json({ message: 'Method Not Allowed' });
+    if (method === 'POST') {
+      const session = await getSession({ req });
+      if (!session?.user) {
+        return res.status(401).json({ message: 'auth required' });
+      }
+      const { rating, comment = '' } = (req.body || {}) as {
+        rating?: number | string;
+        comment?: string;
+      };
+      const r = parseInt(String(rating), 10);
+      if (!r || r < 1 || r > 5) {
+        return res.status(400).json({ message: 'rating 1-5 required' });
+      }
+      addReview({
+        productId: String(id),
+        userEmail: session.user.email!,
+        rating: r,
+        comment,
+      });
+      const stats = getAverageRating(String(id));
+      return res.status(201).json({
+        message: 'review added',
+        averageRating: stats.average,
+        reviewCount: stats.count,
+      });
+    }
+
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to handle review');
+  }
 }

--- a/pages/api/request-reset.ts
+++ b/pages/api/request-reset.ts
@@ -1,16 +1,21 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser, setResetToken } from '../../lib/users';
 import crypto from 'crypto';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST')
-    return res.status(405).json({ message: 'Method Not Allowed' });
-  const { email } = req.body;
-  if (!email) return res.status(400).json({ message: 'email required' });
-  const user = await findUser(email);
-  if (!user) return res.status(404).json({ message: 'User not found' });
-  const token = crypto.randomBytes(20).toString('hex');
-  const expires = Date.now() + 3600 * 1000; // 1 hour
-  await setResetToken(email, token, expires);
-  return res.status(200).json({ message: 'Reset email sent', token });
+  try {
+    if (req.method !== 'POST')
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    const { email } = req.body;
+    if (!email) return res.status(400).json({ message: 'email required' });
+    const user = await findUser(email);
+    if (!user) return res.status(404).json({ message: 'User not found' });
+    const token = crypto.randomBytes(20).toString('hex');
+    const expires = Date.now() + 3600 * 1000; // 1 hour
+    await setResetToken(email, token, expires);
+    return res.status(200).json({ message: 'Reset email sent', token });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to request reset');
+  }
 }

--- a/pages/api/reset-password.ts
+++ b/pages/api/reset-password.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { resetPassword } from '../../lib/users';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST')
@@ -11,6 +12,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await resetPassword(token, password);
     return res.status(200).json({ message: 'Password reset' });
   } catch (e) {
-    return res.status(500).json({ message: 'Error resetting password' });
+    return handleApiError(res, e, 'Error resetting password');
   }
 }

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -4,6 +4,7 @@ import { getDb } from '../../lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import client from '../../lib/typesenseClient';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 function buildSort(sort?: string) {
   switch (sort) {
@@ -118,6 +119,6 @@ export default async function handler(
     });
   } catch (err) {
     console.error('Typesense search error', err);
-    return res.status(500).json({ message: 'Search failed' });
+    return handleApiError(res, err, 'Search failed');
   }
 }

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { addUser, findUser } from '../../lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -41,6 +42,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       token,
     });
   } catch (e) {
-    return res.status(500).json({ message: 'Error creating user' });
+    return handleApiError(res, e, 'Error creating user');
   }
 }

--- a/pages/api/signup/brand.ts
+++ b/pages/api/signup/brand.ts
@@ -2,17 +2,19 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { addUser, findUser } from '../../../lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
-  }
-  const {
-    email,
-    password,
-    firstName,
-    lastName,
-    brandName,
+  try {
+    if (req.method !== 'POST') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const {
+      email,
+      password,
+      firstName,
+      lastName,
+      brandName,
     phoneNumber,
     businessAddress,
     city,
@@ -21,12 +23,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     businessDescription,
     taxId,
   } = req.body;
-  if (
-    !email ||
-    !password ||
-    !firstName ||
-    !lastName ||
-    !brandName ||
+    } = req.body;
+    if (
+      !email ||
+      !password ||
+      !firstName ||
+      !lastName ||
+      !brandName ||
     !phoneNumber ||
     !businessAddress ||
     !city ||
@@ -34,17 +37,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   ) {
     return res.status(400).json({ message: 'missing required fields' });
   }
-  if (await findUser(email)) {
-    return res.status(409).json({ message: 'User exists' });
-  }
-  const hashed = await bcrypt.hash(password, 10);
-  const token = crypto.randomBytes(20).toString('hex');
-  await addUser({
-    email,
-    password: hashed,
-    first_name: firstName,
-    last_name: lastName,
-    brand_name: brandName,
+    ) {
+      return res.status(400).json({ message: 'missing required fields' });
+    }
+    if (await findUser(email)) {
+      return res.status(409).json({ message: 'User exists' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const token = crypto.randomBytes(20).toString('hex');
+    await addUser({
+      email,
+      password: hashed,
+      first_name: firstName,
+      last_name: lastName,
+      brand_name: brandName,
     phone_number: phoneNumber,
     business_address: businessAddress,
     city,
@@ -53,7 +59,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     business_description: businessDescription || null,
     tax_id: taxId || null,
     role: 'BRAND',
-    verification_token: token,
-  });
-  return res.status(201).json({ token });
+      verification_token: token,
+    });
+    return res.status(201).json({ token });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to sign up brand');
+  }
 }

--- a/pages/api/signup/user.ts
+++ b/pages/api/signup/user.ts
@@ -2,42 +2,47 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { addUser, findUser } from '../../../lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
-  }
-  const {
-    email,
-    password,
-    firstName,
-    lastName,
-    gender,
+  try {
+    if (req.method !== 'POST') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const {
+      email,
+      password,
+      firstName,
+      lastName,
+      gender,
     phoneNumber,
     address,
     city,
     country,
-  } = req.body;
-  if (!email || !password || !firstName || !lastName) {
-    return res.status(400).json({ message: 'missing required fields' });
-  }
-  if (await findUser(email)) {
-    return res.status(409).json({ message: 'User exists' });
-  }
-  const hashed = await bcrypt.hash(password, 10);
-  const token = crypto.randomBytes(20).toString('hex');
-  await addUser({
-    email,
-    password: hashed,
-    first_name: firstName,
-    last_name: lastName,
-    gender: gender || '',
+    } = req.body;
+    if (!email || !password || !firstName || !lastName) {
+      return res.status(400).json({ message: 'missing required fields' });
+    }
+    if (await findUser(email)) {
+      return res.status(409).json({ message: 'User exists' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const token = crypto.randomBytes(20).toString('hex');
+    await addUser({
+      email,
+      password: hashed,
+      first_name: firstName,
+      last_name: lastName,
+      gender: gender || '',
     phone_number: phoneNumber || null,
     address: address || null,
     city: city || null,
     country: country || null,
     role: 'USER',
-    verification_token: token,
-  });
-  return res.status(201).json({ token });
+      verification_token: token,
+    });
+    return res.status(201).json({ token });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to sign up user');
+  }
 }

--- a/pages/api/suggest.ts
+++ b/pages/api/suggest.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { host, port, protocol, apiKey } from '../../lib/typesenseClient';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -26,6 +27,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(200).json(data);
   } catch (err) {
     console.error('Typesense suggest error', err);
-    return res.status(500).json({ message: 'Suggest failed' });
+    return handleApiError(res, err, 'Suggest failed');
   }
 }

--- a/pages/api/trending.ts
+++ b/pages/api/trending.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 const trendingKeywords = [
   'iPhone 14',
@@ -12,8 +13,12 @@ export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<{ keywords: string[] }>
 ) {
-  if (req.method !== 'GET') {
-    return res.status(405).json({ keywords: [] });
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ keywords: [] });
+    }
+    res.status(200).json({ keywords: trendingKeywords });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load trending keywords');
   }
-  res.status(200).json({ keywords: trendingKeywords });
 }

--- a/pages/api/user/orders.ts
+++ b/pages/api/user/orders.ts
@@ -2,15 +2,20 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForUser } from '../../../lib/orders';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getServerSession(req, res, authOptions);
-  if (!session?.user) {
-    return res.status(401).json({ message: 'Unauthorized' });
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const orders = await getOrdersForUser(session.user.email);
+    return res.status(200).json(orders);
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to get orders');
   }
-  if (req.method !== 'GET') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
-  }
-  const orders = await getOrdersForUser(session.user.email);
-  return res.status(200).json(orders);
 }

--- a/pages/api/user/profile.ts
+++ b/pages/api/user/profile.ts
@@ -2,25 +2,30 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateUserProfile, findUser } from '../../../lib/users';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getServerSession(req, res, authOptions);
-  if (!session?.user) {
-    return res.status(401).json({ message: 'Unauthorized' });
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    if (req.method === 'GET') {
+      const userData = await findUser(session.user.email);
+      return res.status(200).json(userData);
+    }
+    if (req.method === 'PUT') {
+      const { phoneNumber, address, city, country } = req.body;
+      await updateUserProfile(session.user.email, {
+        phoneNumber,
+        address,
+        city,
+        country,
+      });
+      return res.status(200).json({ message: 'updated' });
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to update profile');
   }
-  if (req.method === 'GET') {
-    const userData = await findUser(session.user.email);
-    return res.status(200).json(userData);
-  }
-  if (req.method === 'PUT') {
-    const { phoneNumber, address, city, country } = req.body;
-    await updateUserProfile(session.user.email, {
-      phoneNumber,
-      address,
-      city,
-      country,
-    });
-    return res.status(200).json({ message: 'updated' });
-  }
-  return res.status(405).json({ message: 'Method Not Allowed' });
 }

--- a/pages/api/vendor/orders.ts
+++ b/pages/api/vendor/orders.ts
@@ -1,17 +1,22 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
 import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'GET') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const { vendor } = req.query;
+    if (!vendor) {
+      return res.status(400).json({ message: 'vendor required' });
+    }
+    const orders = await getOrdersForVendor(vendor as string);
+    return res.status(200).json(orders);
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to get orders');
   }
-  const { vendor } = req.query;
-  if (!vendor) {
-    return res.status(400).json({ message: 'vendor required' });
-  }
-  const orders = await getOrdersForVendor(vendor as string);
-  return res.status(200).json(orders);
 }
 
 export default withRole(['BRAND'])(handler);

--- a/pages/api/verify-email.ts
+++ b/pages/api/verify-email.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { verifyUser } from '../../lib/users';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { token } = req.query;
@@ -8,6 +9,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await verifyUser(token);
     return res.status(200).json({ message: 'Email verified' });
   } catch (e) {
-    return res.status(500).json({ message: 'Error verifying email' });
+    return handleApiError(res, e, 'Error verifying email');
   }
 }

--- a/pages/api/wishlist.ts
+++ b/pages/api/wishlist.ts
@@ -2,24 +2,29 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getWishlist, setWishlist } from '../../lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
+import { handleApiError } from '../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getServerSession(req, res, authOptions);
-  if (!session?.user) {
-    return res.status(401).json({ message: 'Unauthorized' });
-  }
-  const email = session.user.email;
-  if (req.method === 'GET') {
-    const items = getWishlist(email);
-    return res.status(200).json(items);
-  }
-  if (req.method === 'POST') {
-    const { items } = req.body || {};
-    if (!Array.isArray(items)) {
-      return res.status(400).json({ message: 'items required' });
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
     }
-    setWishlist(email, items);
-    return res.status(200).json({ message: 'saved' });
+    const email = session.user.email;
+    if (req.method === 'GET') {
+      const items = getWishlist(email);
+      return res.status(200).json(items);
+    }
+    if (req.method === 'POST') {
+      const { items } = req.body || {};
+      if (!Array.isArray(items)) {
+        return res.status(400).json({ message: 'items required' });
+      }
+      setWishlist(email, items);
+      return res.status(200).json({ message: 'saved' });
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage wishlist');
   }
-  return res.status(405).json({ message: 'Method Not Allowed' });
 }


### PR DESCRIPTION
## Summary
- add `handleApiError` utility
- wrap API routes with try/catch and use the new handler

## Testing
- `npm install` *(fails: binaries.prisma.sh blocked)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854db9d00a4832fa64feecd71441eae