### PR TITLE
Apply Inter font globally

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,7 +6,7 @@ export default function Document() {
       <Head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
       </Head>
       <body className="font-sans">
         <script

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -272,7 +272,7 @@ export default function Home() {
     });
 
   return (
-    <div className="min-h-screen bg-base-200 flex flex-col items-center py-10 font-inter">
+    <div className="min-h-screen bg-base-200 flex flex-col items-center py-10 font-sans">
       <Head>
         <title>Product Search App</title>
         <meta name="description" content="Search products from CSV data" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,8 +7,7 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        inter: ['Inter', 'sans-serif'],
-        sans: ['Poppins', 'Inter', 'sans-serif'],
+        sans: ['Inter', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- update Tailwind theme to use Inter for `font-sans`
- load Inter from Google Fonts in `_document`
- use `font-sans` class on the home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854de3c3aa8832faa51ca02f97d84e9