### PR TITLE
Fix theme toggle to update html class

### DIFF
--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -20,9 +20,8 @@ export default function useTheme() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const html = document.documentElement;
-    const isDark = theme === 'dark';
-    html.setAttribute('data-theme', isDark ? 'dark' : 'cupcake');
-    html.classList.toggle('dark', isDark);
+    html.className = theme;
+    html.setAttribute('data-theme', theme);
     localStorage.setItem('theme', theme);
   }, [theme]);
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -19,9 +19,8 @@ export default function Document() {
       theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
     var html = document.documentElement;
-    var isDark = theme === 'dark';
-    html.setAttribute('data-theme', isDark ? 'dark' : 'cupcake');
-    if (isDark) html.classList.add('dark');
+    html.className = theme;
+    html.setAttribute('data-theme', theme);
   } catch (e) {}
 })();
             `,


### PR DESCRIPTION
## Summary
- apply theme by setting `<html>` className to `light` or `dark`
- do the same for initial script in `_document`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854e26ae5d0832f83bda80184cc8820