### PR TITLE
Signup UI navigation & container tweaks

### DIFF
--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -184,8 +184,8 @@ export default function BrandSignup() {
   };
 
   return (
-    <div className="flex justify-center items-center min-h-screen">
-      <div className="w-full max-w-2xl px-4 sm:px-6 lg:px-8">
+    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <div className="max-w-md mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
       <div className="text-center mb-6">
         <h1 className="text-2xl font-bold">Brand Sign Up</h1>
       </div>
@@ -516,8 +516,8 @@ export default function BrandSignup() {
       </p>
       <p className="text-sm text-center mt-4 text-gray-600">
         Not a brand?{' '}
-        <Link href="/signup/user" className="text-blue-600 hover:underline">
-          Sign up as a user
+        <Link href="/users/signup" className="text-blue-600 hover:underline">
+          Sign up as a user instead
         </Link>
       </p>
       </div>

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -128,7 +128,7 @@ export default function UserSignup() {
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
-      <div className="w-full max-w-2xl -mt-8">
+      <div className="max-w-md mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
         <h1 className="text-2xl font-bold mb-4">User Sign Up</h1>
       <div className="flex flex-col gap-6 mb-4">
         <button
@@ -386,6 +386,12 @@ export default function UserSignup() {
         Already have an account?{' '}
         <Link href="/login" className="link">
           Login
+        </Link>
+      </p>
+      <p className="text-sm text-center mt-4 text-gray-600">
+        Want to sign up as a brand instead?{' '}
+        <Link href="/brands/signup" className="text-blue-600 hover:underline">
+          Sign up as a brand instead
         </Link>
       </p>
       </div>


### PR DESCRIPTION
## Summary
- tweak brand signup layout and link to user signup
- update user signup layout and add link to brand signup

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6854e77a439c832fba7eb7b9417721a7