### PR TITLE
Add InputField UI component

### DIFF
--- a/components/ui/InputField.tsx
+++ b/components/ui/InputField.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+export type InputFieldProps = {
+  label?: string;
+  name: string;
+  type?: string;
+  id?: string;
+  placeholder?: string;
+  value?: string | number;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+  required?: boolean;
+  error?: string;
+  hint?: string;
+  className?: string;
+} & React.InputHTMLAttributes<HTMLInputElement>;
+
+export const InputField: React.FC<InputFieldProps> = ({
+  label,
+  name,
+  type = 'text',
+  id,
+  placeholder,
+  value,
+  onChange,
+  onBlur,
+  disabled = false,
+  required = false,
+  error,
+  hint,
+  className = '',
+  ...rest
+}) => {
+  const inputId = id || name;
+
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 mb-1">
+          {label} {required && <span className="text-red-500">*</span>}
+        </label>
+      )}
+      <input
+        id={inputId}
+        name={name}
+        type={type}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        disabled={disabled}
+        required={required}
+        className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+          error ? 'border-red-500' : 'border-gray-300'
+        } ${className}`}
+        {...rest}
+      />
+      {hint && !error && <p className="text-sm text-gray-500 mt-1">{hint}</p>}
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default InputField;


### PR DESCRIPTION
## Summary
- implement a reusable `InputField` component with TypeScript

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854f2eb5a64832f85166e4b1d7b725e