### PR TITLE
Create generic form field components

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Link your GitHub project.
 
 In the Vercel dashboard:
 
-| Key                     | Value                              |
-| ----------------------- | ---------------------------------- |
-| `SKIP_INDEX_BUILD`      | `true` (to skip rebuild at deploy) |
+| Key                | Value                              |
+| ------------------ | ---------------------------------- |
+| `SKIP_INDEX_BUILD` | `true` (to skip rebuild at deploy) |
 
 4. **Deploy**
 
@@ -147,6 +147,19 @@ Returns matching products in enriched format.
 │       └── search.ts
 ├── .env.local
 └── package.json
+```
+
+## 🧩 Form Field Components
+
+Reusable form elements live in `/components/form-fields` and accept common props like `label`, `value` and `onChange`.
+
+Available components: `TextInput`, `EmailInput`, `PasswordInput`, `Textarea`, `SelectDropdown`, `Checkbox`, `RadioGroup`, `DatePicker` and `FileUpload`.
+
+```tsx
+import { TextInput, PasswordInput } from "@/components/form-fields";
+
+<TextInput label="First Name" name="firstName" value={firstName} onChange={e => setFirstName(e.target.value)} />
+<PasswordInput label="Password" name="password" value={password} onChange={e => setPassword(e.target.value)} />
 ```
 
 ---

--- a/components/form-fields/Checkbox.tsx
+++ b/components/form-fields/Checkbox.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+export interface CheckboxProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  name: string;
+  checked?: boolean;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+const Checkbox: React.FC<CheckboxProps> = ({
+  label,
+  name,
+  checked,
+  onChange,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+  ...rest
+}) => {
+  const inputId = rest.id || name;
+  return (
+    <div className="mb-4 w-full">
+      <div className="flex items-center">
+        <input
+          type="checkbox"
+          id={inputId}
+          name={name}
+          checked={checked}
+          onChange={onChange}
+          disabled={disabled}
+          required={required}
+          className={`mr-2 border rounded text-blue-600 focus:ring-blue-500 ${className}`}
+          {...rest}
+        />
+        {label && (
+          <label htmlFor={inputId} className="text-sm text-gray-700">
+            {label}
+          </label>
+        )}
+      </div>
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default Checkbox;

--- a/components/form-fields/DatePicker.tsx
+++ b/components/form-fields/DatePicker.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+export interface DatePickerProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  name: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+const DatePicker: React.FC<DatePickerProps> = ({
+  label,
+  name,
+  value,
+  onChange,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+  ...rest
+}) => {
+  const inputId = rest.id || name;
+
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {label} {required && <span className="text-red-500">*</span>}
+        </label>
+      )}
+      <input
+        type="date"
+        id={inputId}
+        name={name}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        required={required}
+        className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+          error ? 'border-red-500' : 'border-gray-300'
+        } ${className}`}
+        {...rest}
+      />
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default DatePicker;

--- a/components/form-fields/EmailInput.tsx
+++ b/components/form-fields/EmailInput.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+export interface EmailInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  name: string;
+  placeholder?: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+  leftAddon?: React.ReactNode;
+  rightAddon?: React.ReactNode;
+}
+
+const EmailInput: React.FC<EmailInputProps> = ({
+  label,
+  name,
+  placeholder,
+  value,
+  onChange,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+  leftAddon,
+  rightAddon,
+  ...rest
+}) => {
+  const inputId = rest.id || name;
+
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {label} {required && <span className="text-red-500">*</span>}
+        </label>
+      )}
+      <div className="relative flex items-stretch w-full">
+        {leftAddon && (
+          <span className="inline-flex items-center px-3 text-gray-500">
+            {leftAddon}
+          </span>
+        )}
+        <input
+          type="email"
+          id={inputId}
+          name={name}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          required={required}
+          className={`flex-1 px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+            error ? 'border-red-500' : 'border-gray-300'
+          } ${leftAddon ? 'rounded-l-none' : ''} ${rightAddon ? 'rounded-r-none' : ''} ${className}`}
+          {...rest}
+        />
+        {rightAddon && (
+          <span className="inline-flex items-center px-3 text-gray-500">
+            {rightAddon}
+          </span>
+        )}
+      </div>
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default EmailInput;

--- a/components/form-fields/FileUpload.tsx
+++ b/components/form-fields/FileUpload.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+export interface FileUploadProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  name: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+const FileUpload: React.FC<FileUploadProps> = ({
+  label,
+  name,
+  onChange,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+  ...rest
+}) => {
+  const inputId = rest.id || name;
+
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {label} {required && <span className="text-red-500">*</span>}
+        </label>
+      )}
+      <input
+        type="file"
+        id={inputId}
+        name={name}
+        onChange={onChange}
+        disabled={disabled}
+        required={required}
+        className={`w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 ${className}`}
+        {...rest}
+      />
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default FileUpload;

--- a/components/form-fields/PasswordInput.tsx
+++ b/components/form-fields/PasswordInput.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+
+export interface PasswordInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  name: string;
+  placeholder?: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+  leftAddon?: React.ReactNode;
+}
+
+const PasswordInput: React.FC<PasswordInputProps> = ({
+  label,
+  name,
+  placeholder,
+  value,
+  onChange,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+  leftAddon,
+  ...rest
+}) => {
+  const [show, setShow] = useState(false);
+  const inputId = rest.id || name;
+  const toggle = () => setShow(!show);
+
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {label} {required && <span className="text-red-500">*</span>}
+        </label>
+      )}
+      <div className="relative flex items-stretch w-full">
+        {leftAddon && (
+          <span className="inline-flex items-center px-3 text-gray-500">
+            {leftAddon}
+          </span>
+        )}
+        <input
+          type={show ? 'text' : 'password'}
+          id={inputId}
+          name={name}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          required={required}
+          className={`flex-1 px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+            error ? 'border-red-500' : 'border-gray-300'
+          } ${leftAddon ? 'rounded-l-none' : ''} rounded-r-none ${className}`}
+          {...rest}
+        />
+        <button
+          type="button"
+          onClick={toggle}
+          className="inline-flex items-center px-3 border border-l-0 rounded-r-md bg-gray-100 hover:bg-gray-200"
+        >
+          {show ? 'Hide' : 'Show'}
+        </button>
+      </div>
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default PasswordInput;

--- a/components/form-fields/RadioGroup.tsx
+++ b/components/form-fields/RadioGroup.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+export interface RadioOption {
+  label: string;
+  value: string;
+}
+
+export interface RadioGroupProps {
+  label?: string;
+  name: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  options: RadioOption[];
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+const RadioGroup: React.FC<RadioGroupProps> = ({
+  label,
+  name,
+  value,
+  onChange,
+  options,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+}) => {
+  const groupName = name;
+
+  return (
+    <div className={`mb-4 w-full ${className}`}>
+      {label && (
+        <p className="block text-sm font-medium text-gray-700 mb-1">{label}</p>
+      )}
+      <div className="space-y-2">
+        {options.map((opt) => (
+          <label key={opt.value} className="flex items-center">
+            <input
+              type="radio"
+              name={groupName}
+              value={opt.value}
+              checked={value === opt.value}
+              onChange={onChange}
+              disabled={disabled}
+              required={required}
+              className="mr-2 text-blue-600 focus:ring-blue-500"
+            />
+            <span>{opt.label}</span>
+          </label>
+        ))}
+      </div>
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default RadioGroup;

--- a/components/form-fields/SelectDropdown.tsx
+++ b/components/form-fields/SelectDropdown.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+export interface SelectOption {
+  label: string;
+  value: string;
+}
+
+export interface SelectDropdownProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  label?: string;
+  name: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  options: SelectOption[];
+  placeholder?: string;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+const SelectDropdown: React.FC<SelectDropdownProps> = ({
+  label,
+  name,
+  value,
+  onChange,
+  options,
+  placeholder,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+  ...rest
+}) => {
+  const inputId = rest.id || name;
+
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {label} {required && <span className="text-red-500">*</span>}
+        </label>
+      )}
+      <select
+        id={inputId}
+        name={name}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        required={required}
+        className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+          error ? 'border-red-500' : 'border-gray-300'
+        } ${className}`}
+        {...rest}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default SelectDropdown;

--- a/components/form-fields/TextInput.tsx
+++ b/components/form-fields/TextInput.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+export interface TextInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  name: string;
+  placeholder?: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+  leftAddon?: React.ReactNode;
+  rightAddon?: React.ReactNode;
+}
+
+const TextInput: React.FC<TextInputProps> = ({
+  label,
+  name,
+  placeholder,
+  value,
+  onChange,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+  leftAddon,
+  rightAddon,
+  ...rest
+}) => {
+  const inputId = rest.id || name;
+
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {label} {required && <span className="text-red-500">*</span>}
+        </label>
+      )}
+      <div className="relative flex items-stretch w-full">
+        {leftAddon && (
+          <span className="inline-flex items-center px-3 text-gray-500">
+            {leftAddon}
+          </span>
+        )}
+        <input
+          type="text"
+          id={inputId}
+          name={name}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          required={required}
+          className={`flex-1 px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+            error ? 'border-red-500' : 'border-gray-300'
+          } ${leftAddon ? 'rounded-l-none' : ''} ${rightAddon ? 'rounded-r-none' : ''} ${className}`}
+          {...rest}
+        />
+        {rightAddon && (
+          <span className="inline-flex items-center px-3 text-gray-500">
+            {rightAddon}
+          </span>
+        )}
+      </div>
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default TextInput;

--- a/components/form-fields/Textarea.tsx
+++ b/components/form-fields/Textarea.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: string;
+  name: string;
+  placeholder?: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+const Textarea: React.FC<TextareaProps> = ({
+  label,
+  name,
+  placeholder,
+  value,
+  onChange,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+  ...rest
+}) => {
+  const inputId = rest.id || name;
+
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {label} {required && <span className="text-red-500">*</span>}
+        </label>
+      )}
+      <textarea
+        id={inputId}
+        name={name}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        required={required}
+        className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+          error ? 'border-red-500' : 'border-gray-300'
+        } ${className}`}
+        {...rest}
+      />
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default Textarea;

--- a/components/form-fields/index.ts
+++ b/components/form-fields/index.ts
@@ -1,0 +1,9 @@
+export { default as TextInput } from './TextInput';
+export { default as EmailInput } from './EmailInput';
+export { default as PasswordInput } from './PasswordInput';
+export { default as Textarea } from './Textarea';
+export { default as SelectDropdown } from './SelectDropdown';
+export { default as Checkbox } from './Checkbox';
+export { default as RadioGroup } from './RadioGroup';
+export { default as DatePicker } from './DatePicker';
+export { default as FileUpload } from './FileUpload';


### PR DESCRIPTION
## Summary
- add TextInput, EmailInput, PasswordInput, Textarea, SelectDropdown
- add Checkbox, RadioGroup, DatePicker, FileUpload and barrel file
- document usage of form field components in README

## Testing
- `npm test`
- `npm run type-check` *(fails: many TS errors in repo)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854f5a93578832fbf1658e401aee179