### PR TITLE
Show password rules only when field focused or invalid

### DIFF
--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -56,6 +56,7 @@ export default function BrandSignup() {
   const [loading, setLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [passwordFocused, setPasswordFocused] = useState(false);
   const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
   const countryOptions = useMemo(() => countryList().getData(), []);
@@ -99,7 +100,12 @@ export default function BrandSignup() {
     }
   };
 
+  const handlePasswordFocus = () => {
+    setPasswordFocused(true);
+  };
+
   const handlePasswordBlur = () => {
+    setPasswordFocused(false);
     setErrors((prev) => {
       const next = { ...prev };
       if (password && !passwordRegex.test(password)) {
@@ -211,6 +217,9 @@ export default function BrandSignup() {
     }
   };
 
+  const showPasswordHint =
+    passwordFocused || (password !== '' && !passwordRegex.test(password));
+
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
       <div className="max-w-3xl mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
@@ -297,7 +306,9 @@ export default function BrandSignup() {
                   className={`input input-bordered w-full pr-10 rounded-lg focus:ring-2 focus:ring-indigo-500 ${errors.password ? 'border-red-500' : ''}`}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
+                  onFocus={handlePasswordFocus}
                   onBlur={handlePasswordBlur}
+                  aria-describedby="password-help"
                   placeholder="Password"
                 />
                 <button
@@ -349,10 +360,12 @@ export default function BrandSignup() {
                     </svg>
                   )}
                 </button>
-                <p className="text-sm text-gray-500">
-                  Password must be at least 8 characters and include uppercase,
-                  lowercase, number and special character
-                </p>
+                {showPasswordHint && (
+                  <p id="password-help" className="text-sm text-gray-500 mt-1">
+                    Password must be at least 8 characters and include uppercase,
+                    lowercase, number and special character
+                  </p>
+                )}
                 {errors.password && (
                   <p className="text-red-500 text-sm">{errors.password}</p>
                 )}

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -22,6 +22,7 @@ export default function UserSignup() {
   const [country, setCountry] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [passwordFocused, setPasswordFocused] = useState(false);
   const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
 
@@ -64,7 +65,12 @@ export default function UserSignup() {
     }
   };
 
+  const handlePasswordFocus = () => {
+    setPasswordFocused(true);
+  };
+
   const handlePasswordBlur = () => {
+    setPasswordFocused(false);
     setErrors((prev) => {
       const next = { ...prev };
       if (password && !passwordRegex.test(password)) {
@@ -125,6 +131,9 @@ export default function UserSignup() {
       setFormError('Signup failed');
     }
   };
+
+  const showPasswordHint =
+    passwordFocused || (password !== '' && !passwordRegex.test(password));
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
@@ -209,7 +218,9 @@ export default function UserSignup() {
               className={`input input-bordered w-full pr-10 ${errors.password ? 'border-red-500' : ''}`}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              onFocus={handlePasswordFocus}
               onBlur={handlePasswordBlur}
+              aria-describedby="password-help"
               placeholder="Password"
             />
             <button
@@ -261,10 +272,12 @@ export default function UserSignup() {
                 </svg>
               )}
             </button>
-            <p className="text-sm text-gray-500">
-              Password must be at least 8 characters and include uppercase,
-              lowercase, number and special character
-            </p>
+            {showPasswordHint && (
+              <p id="password-help" className="text-sm text-gray-500 mt-1">
+                Password must be at least 8 characters and include uppercase,
+                lowercase, number and special character
+              </p>
+            )}
             {errors.password && (
               <p className="text-red-500 text-sm">{errors.password}</p>
             )}


### PR DESCRIPTION
## Summary
- add focus state for password fields on signup pages
- display helper text only when focused or invalid
- keep accessibility using `aria-describedby`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6854fc799524832f8e6a3320ede0cb85