### PR TITLE
Show country code in dropdown

### DIFF
--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -13,24 +13,20 @@ const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
 
 type CountryOptionType = { label: string; value: string };
 
-const CountryOption = (
-  props: OptionProps<CountryOptionType, false>
-) => (
+const CountryOption = (props: OptionProps<CountryOptionType, false>) => (
   <components.Option {...props}>
     <div className="flex items-center gap-2">
       <Flag code={props.data.value} style={{ width: 20, height: 15 }} />
-      <span>{props.data.label}</span>
+      <span aria-label={props.data.label}>{props.data.label}</span>
     </div>
   </components.Option>
 );
 
-const CountrySingleValue = (
-  props: SingleValueProps<CountryOptionType, false>
-) => (
+const CountrySingleValue = (props: SingleValueProps<CountryOptionType, false>) => (
   <components.SingleValue {...props}>
     <div className="flex items-center gap-2">
       <Flag code={props.data.value} style={{ width: 20, height: 15 }} />
-      <span>{props.data.label}</span>
+      <span aria-label={props.data.label}>{props.data.label}</span>
     </div>
   </components.SingleValue>
 );
@@ -58,7 +54,13 @@ export default function BrandSignup() {
   const [showConfirm, setShowConfirm] = useState(false);
   const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
-  const countryOptions = useMemo(() => countryList().getData(), []);
+  const countryOptions = useMemo(
+    () =>
+      countryList()
+        .getData()
+        .map((c) => ({ label: `${c.label} (${c.value})`, value: c.value })),
+    []
+  );
 
   useEffect(() => {
     if (user) {


### PR DESCRIPTION
## Summary
- display country code next to name when signing up as a brand
- keep flag icons and search working with `react-select`

## Testing
- `npm install` *(fails: binaries.prisma.sh blocked)*
- `npx jest --runInBand` *(fails: jest missing without install)*

------
https://chatgpt.com/codex/tasks/task_e_6854fc7ec1b0832f8658bc7ac615c290