### PR TITLE
Standardize login & signup forms

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -3,6 +3,7 @@ import { AppContext } from '../contexts/AppContext';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
+import { EmailInput, PasswordInput } from '../components/form-fields';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -11,7 +12,6 @@ export default function Login() {
   const { login, user } = useContext(AppContext)!;
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
   const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -56,7 +56,7 @@ export default function Login() {
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
-      <div className="w-full max-w-md space-y-4 -mt-8">
+      <div className="max-w-md mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full space-y-4">
         <h1 className="text-2xl font-bold mb-4">Login</h1>
         <button
           type="button"
@@ -94,79 +94,21 @@ export default function Login() {
         </button>
         {formError && <div className="text-red-500 mb-2">{formError}</div>}
         <form onSubmit={submit} className="space-y-2">
-          <div>
-            <input
-              className={`input input-bordered w-full ${errors.email ? 'border-red-500' : ''}`}
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              onBlur={handleEmailBlur}
-              placeholder="Email"
-            />
-            {errors.email && (
-              <p className="text-red-500 text-sm">{errors.email}</p>
-            )}
-          </div>
-          <div className="relative">
-            <input
-              type={showPassword ? 'text' : 'password'}
-              className={`input input-bordered w-full pr-10 ${errors.password ? 'border-red-500' : ''}`}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="Password"
-            />
-            <button
-              type="button"
-              onClick={() => setShowPassword(!showPassword)}
-              className="absolute right-2 top-2"
-            >
-              {showPassword ? (
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  className="h-5 w-5"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.965 9.965 0 012.652-4.304m3.821-2.338A9.953 9.953 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.952 9.952 0 01-.46 1.08M15 12a3 3 0 11-6 0 3 3 0 016 0zm-1.259 4.75L5.21 5.21"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M3 3l18 18"
-                  />
-                </svg>
-              ) : (
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  className="h-5 w-5"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                  />
-                </svg>
-              )}
-            </button>
-            {errors.password && (
-              <p className="text-red-500 text-sm">{errors.password}</p>
-            )}
-          </div>
+          <EmailInput
+            name="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onBlur={handleEmailBlur}
+            error={errors.email as string}
+          />
+          <PasswordInput
+            name="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            error={errors.password as string}
+          />
           <button
             className="btn btn-primary w-full"
             type="submit"

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -1,11 +1,40 @@
-import { useState, useContext, useEffect } from 'react';
+import { useState, useContext, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
 import { signIn } from 'next-auth/react';
+import { components, OptionProps, SingleValueProps } from 'react-select';
+import countryList from 'react-select-country-list';
+import Flag from 'react-world-flags';
+import {
+  TextInput,
+  EmailInput,
+  PasswordInput,
+  SelectDropdown,
+} from '../../components/form-fields';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+
+type CountryOptionType = { label: string; value: string };
+
+const CountryOption = (props: OptionProps<CountryOptionType, false>) => (
+  <components.Option {...props}>
+    <div className="flex items-center gap-2">
+      <Flag code={props.data.value} style={{ width: 20, height: 15 }} />
+      <span aria-label={props.data.label}>{props.data.label}</span>
+    </div>
+  </components.Option>
+);
+
+const CountrySingleValue = (props: SingleValueProps<CountryOptionType, false>) => (
+  <components.SingleValue {...props}>
+    <div className="flex items-center gap-2">
+      <Flag code={props.data.value} style={{ width: 20, height: 15 }} />
+      <span aria-label={props.data.label}>{props.data.label}</span>
+    </div>
+  </components.SingleValue>
+);
 
 export default function UserSignup() {
   const router = useRouter();
@@ -20,11 +49,16 @@ export default function UserSignup() {
   const [address, setAddress] = useState('');
   const [city, setCity] = useState('');
   const [country, setCountry] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirm, setShowConfirm] = useState(false);
   const [passwordFocused, setPasswordFocused] = useState(false);
   const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
+  const countryOptions = useMemo(
+    () =>
+      countryList()
+        .getData()
+        .map((c) => ({ label: `${c.label} (${c.value})`, value: c.value })),
+    []
+  );
 
   useEffect(() => {
     if (user) {
@@ -177,220 +211,90 @@ export default function UserSignup() {
       </div>
       {formError && <div className="text-red-500 mb-2">{formError}</div>}
       <form onSubmit={submit} className="space-y-2">
-        <div>
-          <input
-            className={`input input-bordered w-full ${errors.firstName ? 'border-red-500' : ''}`}
-            value={firstName}
-            onChange={(e) => setFirstName(e.target.value)}
-            placeholder="First Name"
-          />
-          {errors.firstName && (
-            <p className="text-red-500 text-sm">{errors.firstName}</p>
-          )}
-        </div>
-        <div>
-          <input
-            className={`input input-bordered w-full ${errors.lastName ? 'border-red-500' : ''}`}
-            value={lastName}
-            onChange={(e) => setLastName(e.target.value)}
-            placeholder="Last Name"
-          />
-          {errors.lastName && (
-            <p className="text-red-500 text-sm">{errors.lastName}</p>
-          )}
-        </div>
-        <div>
-          <input
-            className={`input input-bordered w-full ${errors.email ? 'border-red-500' : ''}`}
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            onBlur={handleEmailBlur}
-            placeholder="Email"
-          />
-          {errors.email && (
-            <p className="text-red-500 text-sm">{errors.email}</p>
-          )}
-        </div>
+        <TextInput
+          name="firstName"
+          placeholder="First Name"
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          error={errors.firstName as string}
+        />
+        <TextInput
+          name="lastName"
+          placeholder="Last Name"
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          error={errors.lastName as string}
+        />
+        <EmailInput
+          name="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          onBlur={handleEmailBlur}
+          error={errors.email as string}
+        />
         <div className="grid grid-cols-2 gap-2">
-          <div className="relative">
-            <input
-              type={showPassword ? 'text' : 'password'}
-              className={`input input-bordered w-full pr-10 ${errors.password ? 'border-red-500' : ''}`}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              onFocus={handlePasswordFocus}
-              onBlur={handlePasswordBlur}
-              aria-describedby="password-help"
-              placeholder="Password"
-            />
-            <button
-              type="button"
-              className="absolute right-2 top-2"
-              onClick={() => setShowPassword(!showPassword)}
-            >
-              {showPassword ? (
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  className="h-5 w-5"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.965 9.965 0 012.652-4.304m3.821-2.338A9.953 9.953 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.952 9.952 0 01-.46 1.08M15 12a3 3 0 11-6 0 3 3 0 016 0zm-1.259 4.75L5.21 5.21"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M3 3l18 18"
-                  />
-                </svg>
-              ) : (
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  className="h-5 w-5"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                  />
-                </svg>
-              )}
-            </button>
-            {showPasswordHint && (
-              <p id="password-help" className="text-sm text-gray-500 mt-1">
-                Password must be at least 8 characters and include uppercase,
-                lowercase, number and special character
-              </p>
-            )}
-            {errors.password && (
-              <p className="text-red-500 text-sm">{errors.password}</p>
-            )}
-          </div>
-          <div className="relative">
-            <input
-              type={showConfirm ? 'text' : 'password'}
-              className={`input input-bordered w-full pr-10 ${errors.confirm ? 'border-red-500' : ''}`}
-              value={confirm}
-              onChange={(e) => setConfirm(e.target.value)}
-              onBlur={handleConfirmBlur}
-              placeholder="Confirm Password"
-            />
-            <button
-              type="button"
-              className="absolute right-2 top-2"
-              onClick={() => setShowConfirm(!showConfirm)}
-            >
-              {showConfirm ? (
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  className="h-5 w-5"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.965 9.965 0 012.652-4.304m3.821-2.338A9.953 9.953 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.952 9.952 0 01-.46 1.08M15 12a3 3 0 11-6 0 3 3 0 016 0zm-1.259 4.75L5.21 5.21"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M3 3l18 18"
-                  />
-                </svg>
-              ) : (
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  className="h-5 w-5"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                  />
-                </svg>
-              )}
-            </button>
-            {errors.confirm && (
-              <p className="text-red-500 text-sm">{errors.confirm}</p>
-            )}
-          </div>
-        </div>
-        <div>
-          <select
-            className="select select-bordered w-full"
-            value={gender}
-            onChange={(e) => setGender(e.target.value)}
-          >
-            <option value="">Select Gender</option>
-            <option value="male">Male</option>
-            <option value="female">Female</option>
-            <option value="other">Other</option>
-          </select>
-        </div>
-        <div>
-          <input
-            className="input input-bordered w-full"
-            value={phoneNumber}
-            onChange={(e) => setPhoneNumber(e.target.value)}
-            placeholder="Phone Number"
+          <PasswordInput
+            name="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onFocus={handlePasswordFocus}
+            onBlur={handlePasswordBlur}
+            error={errors.password as string}
+          />
+          <PasswordInput
+            name="confirm"
+            placeholder="Confirm Password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            onBlur={handleConfirmBlur}
+            error={errors.confirm as string}
           />
         </div>
-        <div>
-          <input
-            className="input input-bordered w-full"
-            value={address}
-            onChange={(e) => setAddress(e.target.value)}
-            placeholder="Address"
-          />
-        </div>
-        <div className="grid grid-cols-2 gap-2">
-          <div>
-            <input
-              className="input input-bordered w-full"
-              value={city}
-              onChange={(e) => setCity(e.target.value)}
-              placeholder="City"
-            />
-          </div>
-          <div>
-            <input
-              className="input input-bordered w-full"
-              value={country}
-              onChange={(e) => setCountry(e.target.value)}
-              placeholder="Country"
-            />
-          </div>
-        </div>
+        {showPasswordHint && (
+          <p id="password-help" className="text-sm text-gray-500">
+            Password must be at least 8 characters and include uppercase,
+            lowercase, number and special character
+          </p>
+        )}
+        <SelectDropdown
+          name="gender"
+          options={[
+            { label: 'Male', value: 'male' },
+            { label: 'Female', value: 'female' },
+            { label: 'Other', value: 'other' },
+          ]}
+          value={gender ? { label: gender.charAt(0).toUpperCase() + gender.slice(1), value: gender } : null}
+          onChange={(opt) => setGender((opt as any)?.value || '')}
+          placeholder="Select Gender"
+        />
+        <TextInput
+          name="phone"
+          placeholder="Phone Number"
+          value={phoneNumber}
+          onChange={(e) => setPhoneNumber(e.target.value)}
+        />
+        <TextInput
+          name="address"
+          placeholder="Address"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+        />
+        <TextInput
+          name="city"
+          placeholder="City"
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+        />
+        <SelectDropdown
+          name="country"
+          options={countryOptions}
+          value={country ? countryOptions.find((c) => c.label === country) : null}
+          onChange={(opt) => setCountry((opt as any)?.label || '')}
+          placeholder="Country"
+          components={{ Option: CountryOption, SingleValue: CountrySingleValue }}
+        />
         <button className="btn btn-primary w-full" type="submit">
           Sign Up
         </button>


### PR DESCRIPTION
## Summary
- add generic form fields to Login page
- update container layout on Login page
- convert User signup form to reusable components
- add country dropdown with flags to User signup

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: dependency issues and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854fe932f74832fa72a71d7d52fbcb3