### PR TITLE
Refactor login form with react-hook-form

### DIFF
--- a/components/ui/InputField.tsx
+++ b/components/ui/InputField.tsx
@@ -16,50 +16,61 @@ export type InputFieldProps = {
   className?: string;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
-export const InputField: React.FC<InputFieldProps> = ({
-  label,
-  name,
-  type = 'text',
-  id,
-  placeholder,
-  value,
-  onChange,
-  onBlur,
-  disabled = false,
-  required = false,
-  error,
-  hint,
-  className = '',
-  ...rest
-}) => {
-  const inputId = id || name;
+export const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
+  (
+    {
+      label,
+      name,
+      type = 'text',
+      id,
+      placeholder,
+      value,
+      onChange,
+      onBlur,
+      disabled = false,
+      required = false,
+      error,
+      hint,
+      className = '',
+      ...rest
+    },
+    ref
+  ) => {
+    const inputId = id || name;
 
-  return (
-    <div className="mb-4 w-full">
-      {label && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 mb-1">
-          {label} {required && <span className="text-red-500">*</span>}
-        </label>
-      )}
-      <input
-        id={inputId}
-        name={name}
-        type={type}
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
-        placeholder={placeholder}
-        disabled={disabled}
-        required={required}
-        className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
-          error ? 'border-red-500' : 'border-gray-300'
-        } ${className}`}
-        {...rest}
-      />
-      {hint && !error && <p className="text-sm text-gray-500 mt-1">{hint}</p>}
-      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
-    </div>
-  );
-};
+    return (
+      <div className="mb-4 w-full">
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            {label} {required && <span className="text-red-500">*</span>}
+          </label>
+        )}
+        <input
+          id={inputId}
+          name={name}
+          type={type}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+          placeholder={placeholder}
+          disabled={disabled}
+          required={required}
+          className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+            error ? 'border-red-500' : 'border-gray-300'
+          } ${className}`}
+          ref={ref}
+          {...rest}
+        />
+        {hint && !error && <p className="text-sm text-gray-500 mt-1">{hint}</p>}
+        {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+      </div>
+    );
+  }
+);
+
+InputField.displayName = 'InputField';
 
 export default InputField;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "react-select": "^5.10.1",
     "react-select-country-list": "^2.2.3",
     "react-world-flags": "^1.6.0",
+    "react-hook-form": "^7.50.0",
+    "@hookform/resolvers": "^3.3.4",
+    "zod": "^3.22.4",
     "stripe": "^12.18.0",
     "swiper": "^11.2.8",
     "typesense": "^2.0.3"

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,20 +1,31 @@
 import { useState, useContext, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { AppContext } from '../contexts/AppContext';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
+import InputField from '../components/ui/InputField';
 
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const schema = z.object({
+  email: z.string().email('Invalid email format'),
+  password: z.string().min(1, 'Password is required'),
+});
+type LoginFormValues = z.infer<typeof schema>;
 
 export default function Login() {
   const router = useRouter();
   const { login, user } = useContext(AppContext)!;
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-  const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormValues>({ resolver: zodResolver(schema) });
 
   useEffect(() => {
     if (user) {
@@ -24,26 +35,7 @@ export default function Login() {
     }
   }, [user, router]);
 
-  const handleEmailBlur = () => {
-    setErrors((prev) => {
-      const next = { ...prev };
-      if (email && !emailRegex.test(email)) {
-        next.email = 'Invalid email format';
-      } else if (next.email === 'Invalid email format') {
-        delete next.email;
-      }
-      return next;
-    });
-  };
-
-  const submit = async (e) => {
-    e.preventDefault();
-    const newErrors = {};
-    if (!email) newErrors.email = 'Email is required';
-    if (!password) newErrors.password = 'Password is required';
-    setErrors(newErrors);
-    if (Object.keys(newErrors).length > 0) return;
-
+  const onSubmit = async ({ email, password }: LoginFormValues) => {
     try {
       setLoading(true);
       await login(email, password);
@@ -93,26 +85,20 @@ export default function Login() {
           Login with GitHub
         </button>
         {formError && <div className="text-red-500 mb-2">{formError}</div>}
-        <form onSubmit={submit} className="space-y-2">
-          <div>
-            <input
-              className={`input input-bordered w-full ${errors.email ? 'border-red-500' : ''}`}
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              onBlur={handleEmailBlur}
-              placeholder="Email"
-            />
-            {errors.email && (
-              <p className="text-red-500 text-sm">{errors.email}</p>
-            )}
-          </div>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+          <InputField
+            type="email"
+            placeholder="Email"
+            {...register('email')}
+            error={errors.email?.message as string}
+          />
           <div className="relative">
-            <input
+            <InputField
               type={showPassword ? 'text' : 'password'}
-              className={`input input-bordered w-full pr-10 ${errors.password ? 'border-red-500' : ''}`}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
               placeholder="Password"
+              className="pr-10"
+              {...register('password')}
+              error={errors.password?.message as string}
             />
             <button
               type="button"
@@ -163,9 +149,6 @@ export default function Login() {
                 </svg>
               )}
             </button>
-            {errors.password && (
-              <p className="text-red-500 text-sm">{errors.password}</p>
-            )}
           </div>
           <button
             className="btn btn-primary w-full"


### PR DESCRIPTION
## Summary
- convert `InputField` to forward refs for integration with form libraries
- add React Hook Form, resolver, and zod packages
- refactor login page to use `react-hook-form` and validation schema

## Testing
- `npx jest --runTestsByPath __tests__/Header.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6854ff3e45d8832f937b88fbe5c20d27