### PR TITLE
Add full-width hero slider support

### DIFF
--- a/components/HeroSlider.tsx
+++ b/components/HeroSlider.tsx
@@ -55,6 +55,7 @@ export default function HeroSlider() {
               alt=""
               fill
               className="object-cover"
+              priority={i === 0}
             />
             <div className="relative z-10 flex flex-col items-center justify-center h-full bg-black/40 text-center text-white px-4">
               <h2 className="text-4xl md:text-6xl font-extrabold mb-2">

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -2,12 +2,13 @@ import useTheme from '../hooks/useTheme';
 import Header from './Header';
 import Footer from './Footer';
 
-export default function Layout({ children }) {
+export default function Layout({ children, heroSecond }) {
   const [theme, setTheme] = useTheme();
 
   return (
     <div className="flex flex-col min-h-screen overflow-x-hidden">
       <Header theme={theme} setTheme={setTheme} />
+      {heroSecond && <div className="w-full">{heroSecond}</div>}
       <main className="container mx-auto flex-1 px-4 sm:px-6 lg:px-8 py-6">
         {children}
       </main>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,11 +8,12 @@ export default function App({
   Component,
   pageProps: { session, ...pageProps },
 }) {
+  const HeroSecond = (Component as any).heroSecond;
   return (
     <SessionProvider session={session}>
       <NotificationProvider>
         <AppProvider>
-          <Layout>
+          <Layout heroSecond={HeroSecond ? <HeroSecond /> : null}>
             <Component {...pageProps} />
           </Layout>
         </AppProvider>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link';
 import Head from 'next/head';
 import ProductCard from '../components/ProductCard';
 import Hero from '../components/Hero';
+import HeroSlider from '../components/HeroSlider';
 import { Product } from '../types/product';
 import RecommendedProducts from '../components/RecommendedProducts';
 
@@ -572,3 +573,5 @@ export default function Home() {
     </div>
   );
 }
+
+Home.heroSecond = HeroSlider;


### PR DESCRIPTION
## Summary
- allow Layout to render an extra hero section outside the container
- hook up heroSecond prop in _app
- add HeroSlider import and register it for the home page
- ensure first slide loads eagerly

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ffea8738832fb60a81fc0e7a5cd2