### PR TITLE
Update generic inputs for react-use-form-state

### DIFF
--- a/components/form-fields/Checkbox.tsx
+++ b/components/form-fields/Checkbox.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UseFormFieldProps } from '../../types';
 
 export interface CheckboxProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -6,10 +7,12 @@ export interface CheckboxProps
   name: string;
   checked?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   error?: string;
   required?: boolean;
   disabled?: boolean;
   className?: string;
+  field?: UseFormFieldProps;
 }
 
 const Checkbox: React.FC<CheckboxProps> = ({
@@ -17,25 +20,29 @@ const Checkbox: React.FC<CheckboxProps> = ({
   name,
   checked,
   onChange,
+  onBlur,
   error,
   required = false,
   disabled = false,
   className = '',
+  field,
   ...rest
 }) => {
-  const inputId = rest.id || name;
+  const inputId = rest.id || field?.id || name;
   return (
     <div className="mb-4 w-full">
       <div className="flex items-center">
         <input
           type="checkbox"
           id={inputId}
-          name={name}
-          checked={checked}
-          onChange={onChange}
+          name={field?.name ?? name}
+          checked={field?.checked ?? checked}
+          onChange={field?.onChange ?? onChange}
+          onBlur={field?.onBlur ?? onBlur}
           disabled={disabled}
           required={required}
           className={`mr-2 border rounded text-blue-600 focus:ring-blue-500 ${className}`}
+          ref={field?.ref as any}
           {...rest}
         />
         {label && (

--- a/components/form-fields/DatePicker.tsx
+++ b/components/form-fields/DatePicker.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UseFormFieldProps } from '../../types';
 
 export interface DatePickerProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -6,10 +7,12 @@ export interface DatePickerProps
   name: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   error?: string;
   required?: boolean;
   disabled?: boolean;
   className?: string;
+  field?: UseFormFieldProps;
 }
 
 const DatePicker: React.FC<DatePickerProps> = ({
@@ -17,13 +20,15 @@ const DatePicker: React.FC<DatePickerProps> = ({
   name,
   value,
   onChange,
+  onBlur,
   error,
   required = false,
   disabled = false,
   className = '',
+  field,
   ...rest
 }) => {
-  const inputId = rest.id || name;
+  const inputId = rest.id || field?.id || name;
 
   return (
     <div className="mb-4 w-full">
@@ -38,14 +43,16 @@ const DatePicker: React.FC<DatePickerProps> = ({
       <input
         type="date"
         id={inputId}
-        name={name}
-        value={value}
-        onChange={onChange}
+        name={field?.name ?? name}
+        value={field?.value ?? value}
+        onChange={field?.onChange ?? onChange}
+        onBlur={field?.onBlur ?? onBlur}
         disabled={disabled}
         required={required}
         className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
           error ? 'border-red-500' : 'border-gray-300'
         } ${className}`}
+        ref={field?.ref as any}
         {...rest}
       />
       {error && <p className="text-sm text-red-600 mt-1">{error}</p>}

--- a/components/form-fields/EmailInput.tsx
+++ b/components/form-fields/EmailInput.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UseFormFieldProps } from '../../types';
 
 export interface EmailInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -7,12 +8,14 @@ export interface EmailInputProps
   placeholder?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   error?: string;
   required?: boolean;
   disabled?: boolean;
   className?: string;
   leftAddon?: React.ReactNode;
   rightAddon?: React.ReactNode;
+  field?: UseFormFieldProps;
 }
 
 const EmailInput: React.FC<EmailInputProps> = ({
@@ -21,15 +24,17 @@ const EmailInput: React.FC<EmailInputProps> = ({
   placeholder,
   value,
   onChange,
+  onBlur,
   error,
   required = false,
   disabled = false,
   className = '',
   leftAddon,
   rightAddon,
+  field,
   ...rest
 }) => {
-  const inputId = rest.id || name;
+  const inputId = rest.id || field?.id || name;
 
   return (
     <div className="mb-4 w-full">
@@ -50,15 +55,17 @@ const EmailInput: React.FC<EmailInputProps> = ({
         <input
           type="email"
           id={inputId}
-          name={name}
+          name={field?.name ?? name}
           placeholder={placeholder}
-          value={value}
-          onChange={onChange}
+          value={field?.value ?? value}
+          onChange={field?.onChange ?? onChange}
+          onBlur={field?.onBlur ?? onBlur}
           disabled={disabled}
           required={required}
           className={`flex-1 px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
             error ? 'border-red-500' : 'border-gray-300'
           } ${leftAddon ? 'rounded-l-none' : ''} ${rightAddon ? 'rounded-r-none' : ''} ${className}`}
+          ref={field?.ref as any}
           {...rest}
         />
         {rightAddon && (

--- a/components/form-fields/FileUpload.tsx
+++ b/components/form-fields/FileUpload.tsx
@@ -1,27 +1,32 @@
 import React from 'react';
+import { UseFormFieldProps } from '../../types';
 
 export interface FileUploadProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   name: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   error?: string;
   required?: boolean;
   disabled?: boolean;
   className?: string;
+  field?: UseFormFieldProps;
 }
 
 const FileUpload: React.FC<FileUploadProps> = ({
   label,
   name,
   onChange,
+  onBlur,
   error,
   required = false,
   disabled = false,
   className = '',
+  field,
   ...rest
 }) => {
-  const inputId = rest.id || name;
+  const inputId = rest.id || field?.id || name;
 
   return (
     <div className="mb-4 w-full">
@@ -36,11 +41,13 @@ const FileUpload: React.FC<FileUploadProps> = ({
       <input
         type="file"
         id={inputId}
-        name={name}
-        onChange={onChange}
+        name={field?.name ?? name}
+        onChange={field?.onChange ?? onChange}
+        onBlur={field?.onBlur ?? onBlur}
         disabled={disabled}
         required={required}
         className={`w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 ${className}`}
+        ref={field?.ref as any}
         {...rest}
       />
       {error && <p className="text-sm text-red-600 mt-1">{error}</p>}

--- a/components/form-fields/PasswordInput.tsx
+++ b/components/form-fields/PasswordInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { UseFormFieldProps } from '../../types';
 
 export interface PasswordInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -7,11 +8,13 @@ export interface PasswordInputProps
   placeholder?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   error?: string;
   required?: boolean;
   disabled?: boolean;
   className?: string;
   leftAddon?: React.ReactNode;
+  field?: UseFormFieldProps;
 }
 
 const PasswordInput: React.FC<PasswordInputProps> = ({
@@ -20,15 +23,17 @@ const PasswordInput: React.FC<PasswordInputProps> = ({
   placeholder,
   value,
   onChange,
+  onBlur,
   error,
   required = false,
   disabled = false,
   className = '',
   leftAddon,
+  field,
   ...rest
 }) => {
   const [show, setShow] = useState(false);
-  const inputId = rest.id || name;
+  const inputId = rest.id || field?.id || name;
   const toggle = () => setShow(!show);
 
   return (
@@ -50,15 +55,17 @@ const PasswordInput: React.FC<PasswordInputProps> = ({
         <input
           type={show ? 'text' : 'password'}
           id={inputId}
-          name={name}
+          name={field?.name ?? name}
           placeholder={placeholder}
-          value={value}
-          onChange={onChange}
+          value={field?.value ?? value}
+          onChange={field?.onChange ?? onChange}
+          onBlur={field?.onBlur ?? onBlur}
           disabled={disabled}
           required={required}
           className={`flex-1 px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
             error ? 'border-red-500' : 'border-gray-300'
           } ${leftAddon ? 'rounded-l-none' : ''} rounded-r-none ${className}`}
+          ref={field?.ref as any}
           {...rest}
         />
         <button

--- a/components/form-fields/RadioGroup.tsx
+++ b/components/form-fields/RadioGroup.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UseFormFieldProps } from '../../types';
 
 export interface RadioOption {
   label: string;
@@ -10,11 +11,13 @@ export interface RadioGroupProps {
   name: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   options: RadioOption[];
   error?: string;
   required?: boolean;
   disabled?: boolean;
   className?: string;
+  field?: UseFormFieldProps;
 }
 
 const RadioGroup: React.FC<RadioGroupProps> = ({
@@ -22,11 +25,13 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
   name,
   value,
   onChange,
+  onBlur,
   options,
   error,
   required = false,
   disabled = false,
   className = '',
+  field,
 }) => {
   const groupName = name;
 
@@ -40,10 +45,11 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
           <label key={opt.value} className="flex items-center">
             <input
               type="radio"
-              name={groupName}
+              name={field?.name ?? groupName}
               value={opt.value}
-              checked={value === opt.value}
-              onChange={onChange}
+              checked={(field?.value ?? value) === opt.value}
+              onChange={field?.onChange ?? onChange}
+              onBlur={field?.onBlur ?? onBlur}
               disabled={disabled}
               required={required}
               className="mr-2 text-blue-600 focus:ring-blue-500"

--- a/components/form-fields/SelectDropdown.tsx
+++ b/components/form-fields/SelectDropdown.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UseFormFieldProps } from '../../types';
 import Select from 'react-select';
 
 export interface SelectOption {
@@ -19,6 +20,7 @@ export interface SelectDropdownProps {
   error?: string;
   className?: string;
   icon?: React.ReactNode;
+  field?: UseFormFieldProps;
   [key: string]: unknown;
 }
 
@@ -35,9 +37,10 @@ const SelectDropdown: React.FC<SelectDropdownProps> = ({
   error,
   className = '',
   icon,
+  field,
   ...rest
 }) => {
-  const inputId = rest.id || name;
+  const inputId = rest.id || field?.id || name;
 
   return (
     <div className="mb-4 w-full">
@@ -57,9 +60,16 @@ const SelectDropdown: React.FC<SelectDropdownProps> = ({
         )}
         <Select<SelectOption, boolean>
           inputId={inputId}
-          name={name}
-          value={value as SelectOption | SelectOption[] | null}
-          onChange={(val) => onChange?.(val as SelectOption | SelectOption[] | null)}
+          name={field?.name ?? name}
+          value={
+            (field?.value ?? value) as SelectOption | SelectOption[] | null
+          }
+          onChange={(val) =>
+            (field?.onChange ?? onChange)?.(
+              val as SelectOption | SelectOption[] | null
+            )
+          }
+          onBlur={(e) => field?.onBlur?.(e as any)}
           options={options}
           placeholder={placeholder}
           isSearchable={isSearchable}
@@ -72,6 +82,7 @@ const SelectDropdown: React.FC<SelectDropdownProps> = ({
               ? { control: (base) => ({ ...base, paddingLeft: '2rem' }) }
               : undefined
           }
+          ref={field?.ref as any}
           {...rest}
         />
       </div>

--- a/components/form-fields/TextInput.tsx
+++ b/components/form-fields/TextInput.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UseFormFieldProps } from '../../types';
 
 export interface TextInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -7,12 +8,14 @@ export interface TextInputProps
   placeholder?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   error?: string;
   required?: boolean;
   disabled?: boolean;
   className?: string;
   leftAddon?: React.ReactNode;
   rightAddon?: React.ReactNode;
+  field?: UseFormFieldProps;
 }
 
 const TextInput: React.FC<TextInputProps> = ({
@@ -21,15 +24,17 @@ const TextInput: React.FC<TextInputProps> = ({
   placeholder,
   value,
   onChange,
+  onBlur,
   error,
   required = false,
   disabled = false,
   className = '',
   leftAddon,
   rightAddon,
+  field,
   ...rest
 }) => {
-  const inputId = rest.id || name;
+  const inputId = rest.id || field?.id || name;
 
   return (
     <div className="mb-4 w-full">
@@ -50,15 +55,17 @@ const TextInput: React.FC<TextInputProps> = ({
         <input
           type="text"
           id={inputId}
-          name={name}
+          name={field?.name ?? name}
           placeholder={placeholder}
-          value={value}
-          onChange={onChange}
+          value={field?.value ?? value}
+          onChange={field?.onChange ?? onChange}
+          onBlur={field?.onBlur ?? onBlur}
           disabled={disabled}
           required={required}
           className={`flex-1 px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
             error ? 'border-red-500' : 'border-gray-300'
           } ${leftAddon ? 'rounded-l-none' : ''} ${rightAddon ? 'rounded-r-none' : ''} ${className}`}
+          ref={field?.ref as any}
           {...rest}
         />
         {rightAddon && (

--- a/components/form-fields/Textarea.tsx
+++ b/components/form-fields/Textarea.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UseFormFieldProps } from '../../types';
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -7,10 +8,12 @@ export interface TextareaProps
   placeholder?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
   error?: string;
   required?: boolean;
   disabled?: boolean;
   className?: string;
+  field?: UseFormFieldProps;
 }
 
 const Textarea: React.FC<TextareaProps> = ({
@@ -19,13 +22,15 @@ const Textarea: React.FC<TextareaProps> = ({
   placeholder,
   value,
   onChange,
+  onBlur,
   error,
   required = false,
   disabled = false,
   className = '',
+  field,
   ...rest
 }) => {
-  const inputId = rest.id || name;
+  const inputId = rest.id || field?.id || name;
 
   return (
     <div className="mb-4 w-full">
@@ -39,15 +44,17 @@ const Textarea: React.FC<TextareaProps> = ({
       )}
       <textarea
         id={inputId}
-        name={name}
+        name={field?.name ?? name}
         placeholder={placeholder}
-        value={value}
-        onChange={onChange}
+        value={field?.value ?? value}
+        onChange={field?.onChange ?? onChange}
+        onBlur={field?.onBlur ?? onBlur}
         disabled={disabled}
         required={required}
         className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
           error ? 'border-red-500' : 'border-gray-300'
         } ${className}`}
+        ref={field?.ref as any}
         {...rest}
       />
       {error && <p className="text-sm text-red-600 mt-1">{error}</p>}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@hookform/resolvers": "^3.3.4",
         "@prisma/client": "^6.9.0",
         "@vercel/blob": "^0.23.0",
         "bcryptjs": "^3.0.2",
@@ -22,12 +23,15 @@
         "nodemailer": "^6.10.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.50.0",
         "react-select": "^5.10.1",
         "react-select-country-list": "^2.2.3",
+        "react-use-form-state": "^0.13.2",
         "react-world-flags": "^1.6.0",
         "stripe": "^12.18.0",
         "swiper": "^11.2.8",
-        "typesense": "^2.0.3"
+        "typesense": "^2.0.3",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.27.2",
@@ -2424,6 +2428,15 @@
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -3669,7 +3682,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
       "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jiti": "2.4.2"
@@ -3679,7 +3692,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -3689,14 +3702,14 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
       "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
       "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3710,14 +3723,14 @@
       "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
       "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
       "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.9.0",
@@ -3729,7 +3742,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
       "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.9.0"
@@ -4133,12 +4146,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -11493,7 +11508,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
       "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11644,6 +11659,22 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.58.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.58.1.tgz",
+      "integrity": "sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -11690,6 +11721,16 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-use-form-state": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/react-use-form-state/-/react-use-form-state-0.13.2.tgz",
+      "integrity": "sha512-bP2H5V6bBFZCJIrbpUcahvJX/f5rGueOvIjg818sq3wg0aX6BFz70u81yhaSg2aCZq0aF3R8eMc2MRWIjr5yhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0"
       }
     },
     "node_modules/react-world-flags": {
@@ -13283,7 +13324,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -13954,6 +13995,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "init:typesense": "ts-node scripts/initTypesense.ts"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
     "@prisma/client": "^6.9.0",
     "@vercel/blob": "^0.23.0",
     "bcryptjs": "^3.0.2",
@@ -29,15 +30,15 @@
     "nodemailer": "^6.10.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.50.0",
     "react-select": "^5.10.1",
     "react-select-country-list": "^2.2.3",
+    "react-use-form-state": "^0.13.2",
     "react-world-flags": "^1.6.0",
-    "react-hook-form": "^7.50.0",
-    "@hookform/resolvers": "^3.3.4",
-    "zod": "^3.22.4",
     "stripe": "^12.18.0",
     "swiper": "^11.2.8",
-    "typesense": "^2.0.3"
+    "typesense": "^2.0.3",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/types/form.ts
+++ b/types/form.ts
@@ -1,0 +1,9 @@
+export interface UseFormFieldProps {
+  name?: string;
+  value?: any;
+  checked?: boolean;
+  onChange?: (...args: any[]) => void;
+  onBlur?: (...args: any[]) => void;
+  id?: string;
+  ref?: React.Ref<any>;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,3 +3,4 @@ export * from './category';
 export * from './user';
 export * from './order';
 export * from './review';
+export * from './form';


### PR DESCRIPTION
## Summary
- add `react-use-form-state` dependency
- add `UseFormFieldProps` type
- accept `field` and `error` props from react-use-form-state across input components

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685506bac22c832f83e4c549e78cdb80