### PR TITLE
Migrate forms to react-hook-form

### DIFF
--- a/components/form-fields/Checkbox.tsx
+++ b/components/form-fields/Checkbox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormFieldProps } from '../../types';
+import { UseFormRegister, RegisterOptions } from 'react-hook-form';
 
 export interface CheckboxProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -12,7 +12,8 @@ export interface CheckboxProps
   required?: boolean;
   disabled?: boolean;
   className?: string;
-  field?: UseFormFieldProps;
+  register?: UseFormRegister<any>;
+  rules?: RegisterOptions;
 }
 
 const Checkbox: React.FC<CheckboxProps> = ({
@@ -25,24 +26,26 @@ const Checkbox: React.FC<CheckboxProps> = ({
   required = false,
   disabled = false,
   className = '',
-  field,
+  register,
+  rules,
   ...rest
 }) => {
-  const inputId = rest.id || field?.id || name;
+  const inputId = rest.id || name;
+  const registration = register ? register(name, rules) : {};
   return (
     <div className="mb-4 w-full">
       <div className="flex items-center">
         <input
           type="checkbox"
           id={inputId}
-          name={field?.name ?? name}
-          checked={field?.checked ?? checked}
-          onChange={field?.onChange ?? onChange}
-          onBlur={field?.onBlur ?? onBlur}
+          name={name}
+          checked={checked}
+          onChange={onChange}
+          onBlur={onBlur}
           disabled={disabled}
           required={required}
           className={`mr-2 border rounded text-blue-600 focus:ring-blue-500 ${className}`}
-          ref={field?.ref as any}
+          {...registration}
           {...rest}
         />
         {label && (

--- a/components/form-fields/DatePicker.tsx
+++ b/components/form-fields/DatePicker.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormFieldProps } from '../../types';
+import { UseFormRegister, RegisterOptions } from 'react-hook-form';
 
 export interface DatePickerProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -12,7 +12,8 @@ export interface DatePickerProps
   required?: boolean;
   disabled?: boolean;
   className?: string;
-  field?: UseFormFieldProps;
+  register?: UseFormRegister<any>;
+  rules?: RegisterOptions;
 }
 
 const DatePicker: React.FC<DatePickerProps> = ({
@@ -25,10 +26,12 @@ const DatePicker: React.FC<DatePickerProps> = ({
   required = false,
   disabled = false,
   className = '',
-  field,
+  register,
+  rules,
   ...rest
 }) => {
-  const inputId = rest.id || field?.id || name;
+  const inputId = rest.id || name;
+  const registration = register ? register(name, rules) : {};
 
   return (
     <div className="mb-4 w-full">
@@ -43,16 +46,16 @@ const DatePicker: React.FC<DatePickerProps> = ({
       <input
         type="date"
         id={inputId}
-        name={field?.name ?? name}
-        value={field?.value ?? value}
-        onChange={field?.onChange ?? onChange}
-        onBlur={field?.onBlur ?? onBlur}
+        name={name}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
         disabled={disabled}
         required={required}
         className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
           error ? 'border-red-500' : 'border-gray-300'
         } ${className}`}
-        ref={field?.ref as any}
+        {...registration}
         {...rest}
       />
       {error && <p className="text-sm text-red-600 mt-1">{error}</p>}

--- a/components/form-fields/EmailInput.tsx
+++ b/components/form-fields/EmailInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormFieldProps } from '../../types';
+import { UseFormRegister, RegisterOptions } from 'react-hook-form';
 
 export interface EmailInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -15,7 +15,8 @@ export interface EmailInputProps
   className?: string;
   leftAddon?: React.ReactNode;
   rightAddon?: React.ReactNode;
-  field?: UseFormFieldProps;
+  register?: UseFormRegister<any>;
+  rules?: RegisterOptions;
 }
 
 const EmailInput: React.FC<EmailInputProps> = ({
@@ -31,10 +32,12 @@ const EmailInput: React.FC<EmailInputProps> = ({
   className = '',
   leftAddon,
   rightAddon,
-  field,
+  register,
+  rules,
   ...rest
 }) => {
-  const inputId = rest.id || field?.id || name;
+  const inputId = rest.id || name;
+  const registration = register ? register(name, rules) : {};
 
   return (
     <div className="mb-4 w-full">
@@ -55,17 +58,17 @@ const EmailInput: React.FC<EmailInputProps> = ({
         <input
           type="email"
           id={inputId}
-          name={field?.name ?? name}
+          name={name}
           placeholder={placeholder}
-          value={field?.value ?? value}
-          onChange={field?.onChange ?? onChange}
-          onBlur={field?.onBlur ?? onBlur}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
           disabled={disabled}
           required={required}
           className={`flex-1 px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
             error ? 'border-red-500' : 'border-gray-300'
           } ${leftAddon ? 'rounded-l-none' : ''} ${rightAddon ? 'rounded-r-none' : ''} ${className}`}
-          ref={field?.ref as any}
+          {...registration}
           {...rest}
         />
         {rightAddon && (

--- a/components/form-fields/FileUpload.tsx
+++ b/components/form-fields/FileUpload.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormFieldProps } from '../../types';
+import { UseFormRegister, RegisterOptions } from 'react-hook-form';
 
 export interface FileUploadProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -11,7 +11,8 @@ export interface FileUploadProps
   required?: boolean;
   disabled?: boolean;
   className?: string;
-  field?: UseFormFieldProps;
+  register?: UseFormRegister<any>;
+  rules?: RegisterOptions;
 }
 
 const FileUpload: React.FC<FileUploadProps> = ({
@@ -23,10 +24,12 @@ const FileUpload: React.FC<FileUploadProps> = ({
   required = false,
   disabled = false,
   className = '',
-  field,
+  register,
+  rules,
   ...rest
 }) => {
-  const inputId = rest.id || field?.id || name;
+  const inputId = rest.id || name;
+  const registration = register ? register(name, rules) : {};
 
   return (
     <div className="mb-4 w-full">
@@ -41,13 +44,13 @@ const FileUpload: React.FC<FileUploadProps> = ({
       <input
         type="file"
         id={inputId}
-        name={field?.name ?? name}
-        onChange={field?.onChange ?? onChange}
-        onBlur={field?.onBlur ?? onBlur}
+        name={name}
+        onChange={onChange}
+        onBlur={onBlur}
         disabled={disabled}
         required={required}
         className={`w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 ${className}`}
-        ref={field?.ref as any}
+        {...registration}
         {...rest}
       />
       {error && <p className="text-sm text-red-600 mt-1">{error}</p>}

--- a/components/form-fields/PasswordInput.tsx
+++ b/components/form-fields/PasswordInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { UseFormFieldProps } from '../../types';
+import { UseFormRegister, RegisterOptions } from 'react-hook-form';
 
 export interface PasswordInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -14,7 +14,8 @@ export interface PasswordInputProps
   disabled?: boolean;
   className?: string;
   leftAddon?: React.ReactNode;
-  field?: UseFormFieldProps;
+  register?: UseFormRegister<any>;
+  rules?: RegisterOptions;
 }
 
 const PasswordInput: React.FC<PasswordInputProps> = ({
@@ -29,11 +30,13 @@ const PasswordInput: React.FC<PasswordInputProps> = ({
   disabled = false,
   className = '',
   leftAddon,
-  field,
+  register,
+  rules,
   ...rest
 }) => {
   const [show, setShow] = useState(false);
-  const inputId = rest.id || field?.id || name;
+  const inputId = rest.id || name;
+  const registration = register ? register(name, rules) : {};
   const toggle = () => setShow(!show);
 
   return (
@@ -55,17 +58,17 @@ const PasswordInput: React.FC<PasswordInputProps> = ({
         <input
           type={show ? 'text' : 'password'}
           id={inputId}
-          name={field?.name ?? name}
+          name={name}
           placeholder={placeholder}
-          value={field?.value ?? value}
-          onChange={field?.onChange ?? onChange}
-          onBlur={field?.onBlur ?? onBlur}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
           disabled={disabled}
           required={required}
           className={`flex-1 px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
             error ? 'border-red-500' : 'border-gray-300'
           } ${leftAddon ? 'rounded-l-none' : ''} rounded-r-none ${className}`}
-          ref={field?.ref as any}
+          {...registration}
           {...rest}
         />
         <button

--- a/components/form-fields/RadioGroup.tsx
+++ b/components/form-fields/RadioGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormFieldProps } from '../../types';
+import { UseFormRegister, RegisterOptions } from 'react-hook-form';
 
 export interface RadioOption {
   label: string;
@@ -17,7 +17,8 @@ export interface RadioGroupProps {
   required?: boolean;
   disabled?: boolean;
   className?: string;
-  field?: UseFormFieldProps;
+  register?: UseFormRegister<any>;
+  rules?: RegisterOptions;
 }
 
 const RadioGroup: React.FC<RadioGroupProps> = ({
@@ -31,9 +32,11 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
   required = false,
   disabled = false,
   className = '',
-  field,
+  register,
+  rules,
 }) => {
   const groupName = name;
+  const registration = register ? register(name, rules) : {};
 
   return (
     <div className={`mb-4 w-full ${className}`}>
@@ -45,14 +48,15 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
           <label key={opt.value} className="flex items-center">
             <input
               type="radio"
-              name={field?.name ?? groupName}
+              name={groupName}
               value={opt.value}
-              checked={(field?.value ?? value) === opt.value}
-              onChange={field?.onChange ?? onChange}
-              onBlur={field?.onBlur ?? onBlur}
+              checked={value === opt.value}
+              onChange={onChange}
+              onBlur={onBlur}
               disabled={disabled}
               required={required}
               className="mr-2 text-blue-600 focus:ring-blue-500"
+              {...registration}
             />
             <span>{opt.label}</span>
           </label>

--- a/components/form-fields/SelectDropdown.tsx
+++ b/components/form-fields/SelectDropdown.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormFieldProps } from '../../types';
+import { Control, Controller, RegisterOptions } from 'react-hook-form';
 import Select from 'react-select';
 
 export interface SelectOption {
@@ -21,7 +21,8 @@ export interface SelectDropdownProps {
   className?: string;
   icon?: React.ReactNode;
   components?: any;
-  field?: UseFormFieldProps;
+  control?: Control<any>;
+  rules?: RegisterOptions;
   [key: string]: unknown;
 }
 
@@ -39,10 +40,11 @@ const SelectDropdown: React.FC<SelectDropdownProps> = ({
   className = '',
   icon,
   components: selectComponents,
-  field,
+  control,
+  rules,
   ...rest
 }) => {
-  const inputId = rest.id || field?.id || name;
+  const inputId = rest.id || name;
 
   return (
     <div className="mb-4 w-full">
@@ -60,34 +62,57 @@ const SelectDropdown: React.FC<SelectDropdownProps> = ({
             {icon}
           </span>
         )}
-        <Select<SelectOption, boolean>
-          inputId={inputId}
-          name={field?.name ?? name}
-          value={
-            (field?.value ?? value) as SelectOption | SelectOption[] | null
-          }
-          onChange={(val) =>
-            (field?.onChange ?? onChange)?.(
-              val as SelectOption | SelectOption[] | null
-            )
-          }
-          onBlur={(e) => field?.onBlur?.(e as any)}
-          options={options}
-          placeholder={placeholder}
-          isSearchable={isSearchable}
-          isDisabled={isDisabled}
-          isMulti={isMulti}
-          components={selectComponents}
-          className={`w-full ${className}`}
-          classNamePrefix="react-select"
-          styles={
-            icon
-              ? { control: (base) => ({ ...base, paddingLeft: '2rem' }) }
-              : undefined
-          }
-          ref={field?.ref as any}
-          {...rest}
-        />
+        {control ? (
+          <Controller
+            name={name}
+            control={control}
+            rules={rules}
+            render={({ field }) => (
+              <Select<SelectOption, boolean>
+                inputId={inputId}
+                {...field}
+                value={field.value as any}
+                onChange={(val) => field.onChange(val)}
+                onBlur={field.onBlur}
+                options={options}
+                placeholder={placeholder}
+                isSearchable={isSearchable}
+                isDisabled={isDisabled}
+                isMulti={isMulti}
+                components={selectComponents}
+                className={`w-full ${className}`}
+                classNamePrefix="react-select"
+                styles={
+                  icon
+                    ? { control: (base) => ({ ...base, paddingLeft: '2rem' }) }
+                    : undefined
+                }
+                {...rest}
+              />
+            )}
+          />
+        ) : (
+          <Select<SelectOption, boolean>
+            inputId={inputId}
+            name={name}
+            value={value as any}
+            onChange={(val) => onChange?.(val)}
+            options={options}
+            placeholder={placeholder}
+            isSearchable={isSearchable}
+            isDisabled={isDisabled}
+            isMulti={isMulti}
+            components={selectComponents}
+            className={`w-full ${className}`}
+            classNamePrefix="react-select"
+            styles={
+              icon
+                ? { control: (base) => ({ ...base, paddingLeft: '2rem' }) }
+                : undefined
+            }
+            {...rest}
+          />
+        )}
       </div>
       {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
     </div>

--- a/components/form-fields/TextInput.tsx
+++ b/components/form-fields/TextInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormFieldProps } from '../../types';
+import { UseFormRegister, RegisterOptions } from 'react-hook-form';
 
 export interface TextInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -15,7 +15,8 @@ export interface TextInputProps
   className?: string;
   leftAddon?: React.ReactNode;
   rightAddon?: React.ReactNode;
-  field?: UseFormFieldProps;
+  register?: UseFormRegister<any>;
+  rules?: RegisterOptions;
 }
 
 const TextInput: React.FC<TextInputProps> = ({
@@ -31,10 +32,12 @@ const TextInput: React.FC<TextInputProps> = ({
   className = '',
   leftAddon,
   rightAddon,
-  field,
+  register,
+  rules,
   ...rest
 }) => {
-  const inputId = rest.id || field?.id || name;
+  const inputId = rest.id || name;
+  const registration = register ? register(name, rules) : {};
 
   return (
     <div className="mb-4 w-full">
@@ -55,17 +58,17 @@ const TextInput: React.FC<TextInputProps> = ({
         <input
           type="text"
           id={inputId}
-          name={field?.name ?? name}
+          name={name}
           placeholder={placeholder}
-          value={field?.value ?? value}
-          onChange={field?.onChange ?? onChange}
-          onBlur={field?.onBlur ?? onBlur}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
           disabled={disabled}
           required={required}
           className={`flex-1 px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
             error ? 'border-red-500' : 'border-gray-300'
           } ${leftAddon ? 'rounded-l-none' : ''} ${rightAddon ? 'rounded-r-none' : ''} ${className}`}
-          ref={field?.ref as any}
+          {...registration}
           {...rest}
         />
         {rightAddon && (

--- a/components/form-fields/Textarea.tsx
+++ b/components/form-fields/Textarea.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormFieldProps } from '../../types';
+import { UseFormRegister, RegisterOptions } from 'react-hook-form';
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -13,7 +13,8 @@ export interface TextareaProps
   required?: boolean;
   disabled?: boolean;
   className?: string;
-  field?: UseFormFieldProps;
+  register?: UseFormRegister<any>;
+  rules?: RegisterOptions;
 }
 
 const Textarea: React.FC<TextareaProps> = ({
@@ -27,10 +28,12 @@ const Textarea: React.FC<TextareaProps> = ({
   required = false,
   disabled = false,
   className = '',
-  field,
+  register,
+  rules,
   ...rest
 }) => {
-  const inputId = rest.id || field?.id || name;
+  const inputId = rest.id || name;
+  const registration = register ? register(name, rules) : {};
 
   return (
     <div className="mb-4 w-full">
@@ -44,17 +47,17 @@ const Textarea: React.FC<TextareaProps> = ({
       )}
       <textarea
         id={inputId}
-        name={field?.name ?? name}
+        name={name}
         placeholder={placeholder}
-        value={field?.value ?? value}
-        onChange={field?.onChange ?? onChange}
-        onBlur={field?.onBlur ?? onBlur}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
         disabled={disabled}
         required={required}
         className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
           error ? 'border-red-500' : 'border-gray-300'
         } ${className}`}
-        ref={field?.ref as any}
+        {...registration}
         {...rest}
       />
       {error && <p className="text-sm text-red-600 mt-1">{error}</p>}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "react-hook-form": "^7.50.0",
         "react-select": "^5.10.1",
         "react-select-country-list": "^2.2.3",
-        "react-use-form-state": "^0.13.2",
         "react-world-flags": "^1.6.0",
         "stripe": "^12.18.0",
         "swiper": "^11.2.8",
@@ -11721,16 +11720,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/react-use-form-state": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/react-use-form-state/-/react-use-form-state-0.13.2.tgz",
-      "integrity": "sha512-bP2H5V6bBFZCJIrbpUcahvJX/f5rGueOvIjg818sq3wg0aX6BFz70u81yhaSg2aCZq0aF3R8eMc2MRWIjr5yhw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
       }
     },
     "node_modules/react-world-flags": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-hook-form": "^7.50.0",
     "react-select": "^5.10.1",
     "react-select-country-list": "^2.2.3",
-    "react-use-form-state": "^0.13.2",
     "react-world-flags": "^1.6.0",
     "stripe": "^12.18.0",
     "swiper": "^11.2.8",

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,5 +1,5 @@
 import { useState, useContext, useEffect } from 'react';
-import { useFormState } from 'react-use-form-state';
+import { useForm } from 'react-hook-form';
 import { AppContext } from '../contexts/AppContext';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/router';
@@ -19,10 +19,11 @@ export default function Login() {
   const [formError, setFormError] = useState('');
   const [loading, setLoading] = useState(false);
 
-  const [formState, inputs] = useFormState({
-    email: '',
-    password: '',
-  });
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ email: string; password: string }>();
 
   useEffect(() => {
     if (user) {
@@ -32,15 +33,7 @@ export default function Login() {
     }
   }, [user, router]);
 
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const { email, password } = formState.values;
-    const errors: Record<string, string> = {};
-    if (!email) errors.email = 'Email is required';
-    else if (!emailRegex.test(email)) errors.email = 'Invalid email format';
-    if (!password) errors.password = 'Password is required';
-    Object.entries(errors).forEach(([k, v]) => formState.setFieldError(k, v));
-    if (Object.keys(errors).length > 0) return;
+  const onSubmit = async ({ email, password }: { email: string; password: string }) => {
     try {
       setLoading(true);
       await login(email, password);
@@ -72,19 +65,25 @@ export default function Login() {
           Login with GitHub
         </button>
         {formError && <div className="text-red-500 mb-2">{formError}</div>}
-        <form onSubmit={onSubmit} className="space-y-2">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
           <EmailInput
-            field={inputs.email('email', { validate: (v) =>
-              v && !emailRegex.test(v) ? 'Invalid email format' : true })}
+            name="email"
             placeholder="Email"
             required
-            error={formState.errors.email as string}
+            register={register}
+            rules={{
+              required: 'Email is required',
+              pattern: { value: emailRegex, message: 'Invalid email format' },
+            }}
+            error={errors.email?.message as string}
           />
           <PasswordInput
-            field={inputs.password('password')}
+            name="password"
             placeholder="Password"
             required
-            error={formState.errors.password as string}
+            register={register}
+            rules={{ required: 'Password is required' }}
+            error={errors.password?.message as string}
           />
           <button
             className="btn btn-primary w-full"

--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import { components, OptionProps, SingleValueProps } from 'react-select';
 import countryList from 'react-select-country-list';
 import Flag from 'react-world-flags';
-import { useFormState } from 'react-use-form-state';
+import { useForm, Controller } from 'react-hook-form';
 import { AppContext } from '../../contexts/AppContext';
 import { signIn } from 'next-auth/react';
 import {
@@ -44,21 +44,30 @@ const CountrySingleValue = (props: SingleValueProps<CountryOptionType, false>) =
 export default function BrandSignup() {
   const router = useRouter();
   const { signup, user } = useContext(AppContext)!;
-  const [formState, inputs] = useFormState({
-    brandName: '',
-    firstName: '',
-    lastName: '',
-    email: '',
-    password: '',
-    confirm: '',
-    phoneNumber: '',
-    businessAddress: '',
-    city: '',
-    country: '',
-    website: '',
-    businessDescription: '',
-    taxId: '',
-  });
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    getValues,
+    setError,
+    clearErrors,
+    formState: { errors },
+  } = useForm<{
+    brandName: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    password: string;
+    confirm: string;
+    phoneNumber: string;
+    businessAddress: string;
+    city: string;
+    country: string;
+    website: string;
+    businessDescription: string;
+    taxId: string;
+  }>();
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [logoPreview, setLogoPreview] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -81,7 +90,7 @@ export default function BrandSignup() {
   }, [user, router]);
 
   const handleEmailBlur = async () => {
-    const value = formState.values.email;
+    const value = getValues('email');
     if (value && emailRegex.test(value)) {
       try {
         const res = await fetch(
@@ -90,11 +99,12 @@ export default function BrandSignup() {
         if (res.ok) {
           const data = await res.json();
           if (data.exists) {
-            formState.setFieldError('email', 'Email already registered');
+            return 'Email already registered';
           }
         }
       } catch (_) {}
     }
+    return true;
   };
 
   const handlePasswordFocus = () => {
@@ -106,13 +116,12 @@ export default function BrandSignup() {
   };
 
   const handleConfirmBlur = () => {
-    if (
-      formState.values.password &&
-      formState.values.confirm &&
-      formState.values.password !== formState.values.confirm
-    ) {
-      formState.setFieldError('confirm', 'Passwords do not match');
+    const password = getValues('password');
+    const confirm = getValues('confirm');
+    if (password && confirm && password !== confirm) {
+      return 'Passwords do not match';
     }
+    return true;
   };
 
   const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -126,58 +135,16 @@ export default function BrandSignup() {
       !['image/png', 'image/jpeg'].includes(file.type) ||
       file.size > 2 * 1024 * 1024
     ) {
-      formState.setFieldError('logo', 'Logo must be PNG/JPG and under 2MB');
+      setError('logo', { type: 'manual', message: 'Logo must be PNG/JPG and under 2MB' });
       return;
     }
-    formState.setFieldError('logo', undefined as any);
+    clearErrors('logo');
     setLogoFile(file);
     setLogoPreview(URL.createObjectURL(file));
   };
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    await handleEmailBlur();
-    const values = formState.values;
-    const newErrors: Record<string, string> = {};
-    const requiredFields = [
-      'brandName',
-      'firstName',
-      'lastName',
-      'email',
-      'password',
-      'confirm',
-      'phoneNumber',
-      'businessAddress',
-      'city',
-      'country',
-    ];
-    requiredFields.forEach((f) => {
-      if (!values[f]) newErrors[f] = `${f} is required`;
-    });
-    if (
-      values.password &&
-      values.confirm &&
-      values.password !== values.confirm
-    ) {
-      newErrors.confirm = 'Passwords do not match';
-    }
-    if (logoFile && !['image/png', 'image/jpeg'].includes(logoFile.type)) {
-      newErrors.logo = 'Logo must be PNG or JPG';
-    }
-    Object.entries(newErrors).forEach(([k, v]) =>
-      formState.setFieldError(k, v)
-    );
-    if (Object.keys(newErrors).length > 0 || Object.keys(formState.errors).some((k) => formState.errors[k])) {
-      const firstKey = Object.keys({ ...formState.errors, ...newErrors })[0];
-      document.querySelector(`[name="${firstKey}"]`)?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
-      });
-      return;
-    }
-
+  const submit = async (values: any) => {
     setLoading(true);
-
     try {
       const {
         brandName,
@@ -192,8 +159,7 @@ export default function BrandSignup() {
         website,
         businessDescription,
         taxId,
-        // confirm not needed
-      } = formState.values as any;
+      } = values;
       const data = await signup('/api/signup/brand', {
         brandName,
         firstName,
@@ -217,10 +183,10 @@ export default function BrandSignup() {
     }
   };
 
+  const passwordValue = watch('password');
   const showPasswordHint =
     passwordFocused ||
-    (formState.values.password !== '' &&
-      !passwordRegex.test(formState.values.password || ''));
+    (passwordValue !== '' && !passwordRegex.test(passwordValue || ''));
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
@@ -247,61 +213,64 @@ export default function BrandSignup() {
         </button>
       </div>
       {formError && <div className="text-red-500 mb-2">{formError}</div>}
-      <form id="brand-signup-form" onSubmit={submit} className="space-y-6">
+      <form id="brand-signup-form" onSubmit={handleSubmit(submit)} className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="space-y-5">
             <h2 className="text-xl font-semibold">Account Info</h2>
             <TextInput
-              field={inputs.text('firstName')}
+              name="firstName"
               placeholder="First Name"
               required
-              error={formState.errors.firstName as string}
+              register={register}
+              rules={{ required: 'firstName is required' }}
+              error={errors.firstName?.message as string}
             />
             <TextInput
-              field={inputs.text('lastName')}
+              name="lastName"
               placeholder="Last Name"
               required
-              error={formState.errors.lastName as string}
+              register={register}
+              rules={{ required: 'lastName is required' }}
+              error={errors.lastName?.message as string}
             />
             <EmailInput
-              field={inputs.email('email', {
-                validate: (v) =>
-                  v && !emailRegex.test(v) ? 'Invalid email format' : true,
-                onBlur: handleEmailBlur,
-                validateOnBlur: true,
-              })}
+              name="email"
               placeholder="Email"
               required
-              error={formState.errors.email as string}
+              register={register}
+              rules={{
+                required: 'Email is required',
+                pattern: { value: emailRegex, message: 'Invalid email format' },
+                validate: handleEmailBlur,
+              }}
+              error={errors.email?.message as string}
             />
             <div className="space-y-5">
               <PasswordInput
-                field={inputs.password('password', {
-                  validate: (v) =>
-                    v && !passwordRegex.test(v)
-                      ? 'Password must be at least 8 characters and include uppercase, lowercase, number and special character'
-                      : true,
-                  onFocus: handlePasswordFocus,
-                  onBlur: handlePasswordBlur,
-                  validateOnBlur: true,
-                })}
+                name="password"
                 aria-describedby="password-help"
                 placeholder="Password"
                 required
-                error={formState.errors.password as string}
+                register={register}
+                rules={{
+                  required: 'Password is required',
+                  pattern: {
+                    value: passwordRegex,
+                    message:
+                      'Password must be at least 8 characters and include uppercase, lowercase, number and special character',
+                  },
+                  onBlur: handlePasswordBlur,
+                  onFocus: handlePasswordFocus,
+                }}
+                error={errors.password?.message as string}
               />
               <PasswordInput
-                field={inputs.password('confirm', {
-                  validate: (v, values) =>
-                    values.password && v !== values.password
-                      ? 'Passwords do not match'
-                      : true,
-                  onBlur: handleConfirmBlur,
-                  validateOnBlur: true,
-                })}
+                name="confirm"
                 placeholder="Confirm Password"
                 required
-                error={formState.errors.confirm as string}
+                register={register}
+                rules={{ validate: handleConfirmBlur }}
+                error={errors.confirm?.message as string}
               />
               {showPasswordHint && (
                 <p id="password-help" className="text-sm text-gray-500">
@@ -314,49 +283,49 @@ export default function BrandSignup() {
           <div className="space-y-5">
             <h2 className="text-xl font-semibold">Business Info</h2>
             <TextInput
-              field={inputs.text('brandName')}
+              name="brandName"
               placeholder="Brand Name"
               required
-              error={formState.errors.brandName as string}
+              register={register}
+              rules={{ required: 'brandName is required' }}
+              error={errors.brandName?.message as string}
             />
             <TextInput
-              field={inputs.text('phoneNumber')}
+              name="phoneNumber"
               placeholder="Phone Number"
               required
-              error={formState.errors.phoneNumber as string}
+              register={register}
+              rules={{ required: 'phoneNumber is required' }}
+              error={errors.phoneNumber?.message as string}
             />
             <TextInput
-              field={inputs.text('businessAddress')}
+              name="businessAddress"
               placeholder="Business Address"
               required
-              error={formState.errors.businessAddress as string}
+              register={register}
+              rules={{ required: 'businessAddress is required' }}
+              error={errors.businessAddress?.message as string}
             />
             <div className="space-y-5">
               <div>
                 <TextInput
-                  field={inputs.text('city')}
+                  name="city"
                   placeholder="City"
                   required
-                  error={formState.errors.city as string}
+                  register={register}
+                  rules={{ required: 'city is required' }}
+                  error={errors.city?.message as string}
                 />
               </div>
               <div>
                 <SelectDropdown
-                  field={inputs.raw('country', {
-                    onChange: (o: any) => o?.label || '',
-                    touchOnChange: true,
-                  })}
+                  name="country"
+                  control={control}
                   options={countryOptions}
-                  value={
-                    formState.values.country
-                      ? countryOptions.find(
-                          (c) => c.label === formState.values.country
-                        ) || null
-                      : null
-                  }
                   placeholder="Country"
                   components={{ Option: CountryOption, SingleValue: CountrySingleValue }}
-                  error={formState.errors.country as string}
+                  rules={{ required: 'country is required' }}
+                  error={errors.country?.message as string}
                 />
               </div>
             </div>
@@ -366,18 +335,24 @@ export default function BrandSignup() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="space-y-5">
             <TextInput
-              field={inputs.text('website')}
+              name="website"
               placeholder="Website"
+              register={register}
+              error={errors.website?.message as string}
             />
             <TextInput
-              field={inputs.text('taxId')}
+              name="taxId"
               placeholder="Tax ID"
+              register={register}
+              error={errors.taxId?.message as string}
             />
           </div>
           <div className="space-y-5">
             <Textarea
-              field={inputs.textarea('businessDescription')}
+              name="businessDescription"
               placeholder="Business Description"
+              register={register}
+              error={errors.businessDescription?.message as string}
             />
             <div>
               <label className="block text-sm mb-1">Logo</label>
@@ -401,8 +376,8 @@ export default function BrandSignup() {
                 onChange={handleLogoChange}
                 className="file-input file-input-bordered w-full rounded-lg mt-2"
               />
-              {formState.errors.logo && (
-                <p className="text-red-500 text-sm">{formState.errors.logo as string}</p>
+              {errors.logo && (
+                <p className="text-red-500 text-sm">{errors.logo.message as string}</p>
               )}
             </div>
           </div>

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -1,4 +1,5 @@
-import { useState, useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
@@ -41,18 +42,28 @@ const CountrySingleValue = (props: SingleValueProps<CountryOptionType, false>) =
 export default function UserSignup() {
   const router = useRouter();
   const { signup, user } = useContext(AppContext)!;
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirm, setConfirm] = useState('');
-  const [gender, setGender] = useState('');
-  const [phoneNumber, setPhoneNumber] = useState('');
-  const [address, setAddress] = useState('');
-  const [city, setCity] = useState('');
-  const [country, setCountry] = useState('');
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    getValues,
+    setError,
+    clearErrors,
+    formState: { errors },
+  } = useForm<{
+    firstName: string;
+    lastName: string;
+    email: string;
+    password: string;
+    confirm: string;
+    gender: string;
+    phone: string;
+    address: string;
+    city: string;
+    country: string;
+  }>();
   const [passwordFocused, setPasswordFocused] = useState(false);
-  const [errors, setErrors] = useState({});
   const [formError, setFormError] = useState('');
   const countryOptions = useMemo(
     () =>
@@ -71,33 +82,23 @@ export default function UserSignup() {
   }, [user, router]);
 
   const handleEmailBlur = async () => {
-    setErrors((prev) => {
-      const next = { ...prev };
-      if (email && !emailRegex.test(email)) {
-        next.email = 'Invalid email format';
-      } else if (
-        next.email === 'Invalid email format' ||
-        next.email === 'Email already registered'
-      ) {
-        delete next.email;
-      }
-      return next;
-    });
-    if (email && emailRegex.test(email)) {
+    const value = getValues('email');
+    if (value && !emailRegex.test(value)) {
+      setError('email', { type: 'pattern', message: 'Invalid email format' });
+      return;
+    }
+    if (value) {
       try {
-        const res = await fetch(
-          `/api/check-email?email=${encodeURIComponent(email)}`
-        );
+        const res = await fetch(`/api/check-email?email=${encodeURIComponent(value)}`);
         if (res.ok) {
           const data = await res.json();
           if (data.exists) {
-            setErrors((prev) => ({
-              ...prev,
-              email: 'Email already registered',
-            }));
+            setError('email', { type: 'manual', message: 'Email already registered' });
+          } else {
+            clearErrors('email');
           }
         }
-      } catch (_) { }
+      } catch (_) {}
     }
   };
 
@@ -107,60 +108,30 @@ export default function UserSignup() {
 
   const handlePasswordBlur = () => {
     setPasswordFocused(false);
-    setErrors((prev) => {
-      const next = { ...prev };
-      if (password && !passwordRegex.test(password)) {
-        next.password =
-          'Password must be at least 8 characters and include uppercase, lowercase, number and special character';
-      } else if (next.password && next.password.startsWith('Password must')) {
-        delete next.password;
-      }
-      if (confirm && password !== confirm) {
-        next.confirm = 'Passwords do not match';
-      } else if (next.confirm === 'Passwords do not match') {
-        delete next.confirm;
-      }
-      return next;
-    });
   };
 
   const handleConfirmBlur = () => {
-    setErrors((prev) => {
-      const next = { ...prev };
-      if (password && confirm && password !== confirm) {
-        next.confirm = 'Passwords do not match';
-      } else if (next.confirm === 'Passwords do not match') {
-        delete next.confirm;
-      }
-      return next;
-    });
+    const password = getValues('password');
+    const confirm = getValues('confirm');
+    if (password && confirm && password !== confirm) {
+      setError('confirm', { type: 'manual', message: 'Passwords do not match' });
+    } else {
+      clearErrors('confirm');
+    }
   };
 
-  const submit = async (e) => {
-    e.preventDefault();
-    const newErrors = {};
-    if (!firstName) newErrors.firstName = 'First name is required';
-    if (!lastName) newErrors.lastName = 'Last name is required';
-    if (!email) newErrors.email = 'Email is required';
-    if (!password) newErrors.password = 'Password is required';
-    if (!confirm) newErrors.confirm = 'Confirm password is required';
-    if (password && confirm && password !== confirm) {
-      newErrors.confirm = 'Passwords do not match';
-    }
-    setErrors(newErrors);
-    if (Object.keys(newErrors).length > 0) return;
-
+  const submit = async (values: any) => {
     try {
       const data = await signup('/api/signup/user', {
-        firstName,
-        lastName,
-        email,
-        password,
-        gender,
-        phoneNumber,
-        address,
-        city,
-        country,
+        firstName: values.firstName,
+        lastName: values.lastName,
+        email: values.email,
+        password: values.password,
+        gender: values.gender,
+        phoneNumber: values.phone,
+        address: values.address,
+        city: values.city,
+        country: values.country,
       });
       router.push(`/confirm/${data.token}`);
     } catch (e) {
@@ -168,8 +139,9 @@ export default function UserSignup() {
     }
   };
 
+  const passwordValue = watch('password');
   const showPasswordHint =
-    passwordFocused || (password !== '' && !passwordRegex.test(password));
+    passwordFocused || (passwordValue !== '' && !passwordRegex.test(passwordValue));
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
@@ -194,46 +166,58 @@ export default function UserSignup() {
         </button>
       </div>
       {formError && <div className="text-red-500 mb-2">{formError}</div>}
-      <form onSubmit={submit} className="space-y-2">
+      <form onSubmit={handleSubmit(submit)} className="space-y-2">
         <TextInput
           name="firstName"
           placeholder="First Name"
-          value={firstName}
-          onChange={(e) => setFirstName(e.target.value)}
-          error={errors.firstName as string}
+          register={register}
+          rules={{ required: 'First name is required' }}
+          error={errors.firstName?.message as string}
         />
         <TextInput
           name="lastName"
           placeholder="Last Name"
-          value={lastName}
-          onChange={(e) => setLastName(e.target.value)}
-          error={errors.lastName as string}
+          register={register}
+          rules={{ required: 'Last name is required' }}
+          error={errors.lastName?.message as string}
         />
         <EmailInput
           name="email"
           placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          onBlur={handleEmailBlur}
-          error={errors.email as string}
+          register={register}
+          rules={{
+            required: 'Email is required',
+            pattern: { value: emailRegex, message: 'Invalid email format' },
+            validate: async () => {
+              await handleEmailBlur();
+              return true;
+            },
+          }}
+          error={errors.email?.message as string}
         />
         <div className="grid grid-cols-2 gap-2">
           <PasswordInput
             name="password"
             placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            onFocus={handlePasswordFocus}
-            onBlur={handlePasswordBlur}
-            error={errors.password as string}
+            register={register}
+            rules={{
+              required: 'Password is required',
+              pattern: {
+                value: passwordRegex,
+                message:
+                  'Password must be at least 8 characters and include uppercase, lowercase, number and special character',
+              },
+              onBlur: handlePasswordBlur,
+              onFocus: handlePasswordFocus,
+            }}
+            error={errors.password?.message as string}
           />
           <PasswordInput
             name="confirm"
             placeholder="Confirm Password"
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-            onBlur={handleConfirmBlur}
-            error={errors.confirm as string}
+            register={register}
+            rules={{ validate: handleConfirmBlur }}
+            error={errors.confirm?.message as string}
           />
         </div>
         {showPasswordHint && (
@@ -244,38 +228,33 @@ export default function UserSignup() {
         )}
         <SelectDropdown
           name="gender"
+          control={control}
           options={[
             { label: 'Male', value: 'male' },
             { label: 'Female', value: 'female' },
             { label: 'Other', value: 'other' },
           ]}
-          value={gender ? { label: gender.charAt(0).toUpperCase() + gender.slice(1), value: gender } : null}
-          onChange={(opt) => setGender((opt as any)?.value || '')}
           placeholder="Select Gender"
         />
         <TextInput
           name="phone"
           placeholder="Phone Number"
-          value={phoneNumber}
-          onChange={(e) => setPhoneNumber(e.target.value)}
+          register={register}
         />
         <TextInput
           name="address"
           placeholder="Address"
-          value={address}
-          onChange={(e) => setAddress(e.target.value)}
+          register={register}
         />
         <TextInput
           name="city"
           placeholder="City"
-          value={city}
-          onChange={(e) => setCity(e.target.value)}
+          register={register}
         />
         <SelectDropdown
           name="country"
+          control={control}
           options={countryOptions}
-          value={country ? countryOptions.find((c) => c.label === country) : null}
-          onChange={(opt) => setCountry((opt as any)?.label || '')}
           placeholder="Country"
           components={{ Option: CountryOption, SingleValue: CountrySingleValue }}
         />

--- a/types/form.ts
+++ b/types/form.ts
@@ -1,9 +1,0 @@
-export interface UseFormFieldProps {
-  name?: string;
-  value?: any;
-  checked?: boolean;
-  onChange?: (...args: any[]) => void;
-  onBlur?: (...args: any[]) => void;
-  id?: string;
-  ref?: React.Ref<any>;
-}

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,4 +3,3 @@ export * from './category';
 export * from './user';
 export * from './order';
 export * from './review';
-export * from './form';


### PR DESCRIPTION
## Summary
- remove deprecated react-use-form-state
- refactor form components to support react-hook-form
- migrate login, brand signup and user signup forms

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68550dc740f4832fab38289d9e7fb716