### PR TITLE
Add proper types for admin pages and API

### DIFF
--- a/lib/utils/fetchJson.ts
+++ b/lib/utils/fetchJson.ts
@@ -1,0 +1,8 @@
+export async function fetchJson<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || res.statusText);
+  }
+  return res.json() as Promise<T>;
+}

--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -1,12 +1,8 @@
 import { useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import Link from 'next/link';
-
-type AnalyticsData = {
-  totalOrders: number;
-  totalRevenue: number;
-  topProducts: { id: string; qty: number }[];
-};
+import { AnalyticsData } from '../../types';
+import { fetchJson } from '../../lib/utils/fetchJson';
 
 export default function AdminAnalytics() {
   const { user } = useContext(AppContext)!;
@@ -14,9 +10,9 @@ export default function AdminAnalytics() {
 
   useEffect(() => {
     if (!user) return;
-    fetch('/api/admin/analytics')
-      .then((res) => (res.ok ? res.json() : null))
-      .then(setData);
+    fetchJson<AnalyticsData>('/api/admin/analytics')
+      .then(setData)
+      .catch(() => setData(null));
   }, [user]);
 
   if (!user) return <div className="p-4">Please log in to view analytics.</div>;

--- a/pages/admin/approvals.tsx
+++ b/pages/admin/approvals.tsx
@@ -1,16 +1,17 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/AppContext';
+import { PendingProduct, ApiMessage } from '../../types';
+import { fetchJson } from '../../lib/utils/fetchJson';
 
 export default function Approvals() {
   const { user } = useContext(AppContext)!;
-  type PendingProduct = { id: string; title: string };
   const [pending, setPending] = useState<PendingProduct[]>([]);
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState<string>('');
 
   const load = useCallback(async () => {
     if (!user) return;
-    const res = await fetch('/api/admin/vendor-products');
-    if (res.ok) setPending(await res.json());
+    const data = await fetchJson<PendingProduct[]>('/api/admin/vendor-products');
+    setPending(data);
   }, [user]);
 
   useEffect(() => {
@@ -18,15 +19,13 @@ export default function Approvals() {
   }, [load]);
 
   const act = async (id: string, action: 'approve' | 'reject') => {
-    const res = await fetch('/api/admin/vendor-products', {
+    await fetchJson<ApiMessage>('/api/admin/vendor-products', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id, action }),
     });
-    if (res.ok) {
-      setMessage('Updated');
-      load();
-    }
+    setMessage('Updated');
+    load();
   };
 
   if (!user)

--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -1,22 +1,24 @@
 import { useContext, useEffect, useState, useCallback } from 'react';
 import Image from 'next/image';
 import { AppContext } from '../../contexts/AppContext';
+import { Category, CategoryInput, ApiMessage } from '../../types';
+import { fetchJson } from '../../lib/utils/fetchJson';
 
 export default function Categories() {
   const { user } = useContext(AppContext)!;
-  const [categories, setCategories] = useState([]);
-  const [newCat, setNewCat] = useState('');
-  const [newParent, setNewParent] = useState('');
-  const [newImage, setNewImage] = useState('');
-  const [message, setMessage] = useState('');
-  const [editing, setEditing] = useState(null);
-  const [editName, setEditName] = useState('');
-  const [editImage, setEditImage] = useState('');
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [newCat, setNewCat] = useState<string>('');
+  const [newParent, setNewParent] = useState<string>('');
+  const [newImage, setNewImage] = useState<string>('');
+  const [message, setMessage] = useState<string>('');
+  const [editing, setEditing] = useState<number | null>(null);
+  const [editName, setEditName] = useState<string>('');
+  const [editImage, setEditImage] = useState<string>('');
 
   const load = useCallback(async () => {
     if (!user) return;
-    const res = await fetch('/api/admin/categories');
-    if (res.ok) setCategories(await res.json());
+    const data = await fetchJson<Category[]>('/api/admin/categories');
+    setCategories(data);
   }, [user]);
 
   useEffect(() => {
@@ -25,42 +27,46 @@ export default function Categories() {
 
   const add = async () => {
     if (!newCat.trim()) return;
-    const res = await fetch('/api/admin/categories', {
+    const payload: CategoryInput = {
+      name: newCat,
+      parentId: newParent ? Number(newParent) : null,
+      image: newImage || undefined,
+    };
+    await fetchJson<ApiMessage>('/api/admin/categories', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: newCat, parentId: newParent || null, image: newImage || null }),
+      body: JSON.stringify(payload),
     });
-    if (res.ok) {
-      setNewCat('');
-      setNewImage('');
-      setMessage('Category added');
-      load();
-    }
+    setNewCat('');
+    setNewImage('');
+    setMessage('Category added');
+    load();
   };
 
   const update = async () => {
-    const res = await fetch('/api/admin/categories', {
+    const payload: CategoryInput & { id: number } = {
+      id: editing as number,
+      name: editName,
+      image: editImage || undefined,
+    };
+    await fetchJson<ApiMessage>('/api/admin/categories', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: editing, name: editName, image: editImage || null }),
+      body: JSON.stringify(payload),
     });
-    if (res.ok) {
-      setEditing(null);
-      setEditName('');
-      setEditImage('');
-      setMessage('Category updated');
-      load();
-    }
+    setEditing(null);
+    setEditName('');
+    setEditImage('');
+    setMessage('Category updated');
+    load();
   };
 
-  const remove = async (id) => {
-    const res = await fetch(`/api/admin/categories?id=${id}`, {
+  const remove = async (id: number) => {
+    await fetchJson<ApiMessage>(`/api/admin/categories?id=${id}`, {
       method: 'DELETE',
     });
-    if (res.ok) {
-      setMessage('Category deleted');
-      load();
-    }
+    setMessage('Category deleted');
+    load();
   };
 
   if (!user)
@@ -111,23 +117,23 @@ export default function Categories() {
     </div>
   );
 
-  function buildTree(list) {
-    const map = {};
+  function buildTree(list: Category[]): (Category & { children: Category[] })[] {
+    const map: Record<number, Category & { children: Category[] }> = {} as Record<number, Category & { children: Category[] }>;
     list.forEach((c) => {
-      map[c.id] = { ...c, children: [] };
+      map[c.id!] = { ...c, children: [] };
     });
-    const tree = [];
+    const tree: (Category & { children: Category[] })[] = [];
     list.forEach((c) => {
       if (c.parentId) {
-        map[c.parentId]?.children.push(map[c.id]);
+        map[c.parentId]?.children.push(map[c.id!]);
       } else {
-        tree.push(map[c.id]);
+        tree.push(map[c.id!]);
       }
     });
     return tree;
   }
 
-  function CategoryItem({ cat }) {
+  function CategoryItem({ cat }: { cat: Category & { children: Category[] } }) {
     const hasChildren = cat.children && cat.children.length > 0;
     return (
       <li className={cat.parentId ? 'ml-4' : ''}>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,10 +1,24 @@
 import { useState, useEffect, useContext, useCallback } from 'react';
 import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
+import { Product, ApiMessage } from '../../types';
+import { fetchJson } from '../../lib/utils/fetchJson';
 
 export default function Admin() {
   const { user } = useContext(AppContext)!;
-  const emptyForm = {
+  interface FormState {
+    id: string;
+    title: string;
+    vendor: string;
+    description: string;
+    product_type: string;
+    tags: string;
+    quantity: number;
+    min_price: number;
+    max_price: number;
+    currency: string;
+  }
+  const emptyForm: FormState = {
     id: '',
     title: '',
     vendor: '',
@@ -16,54 +30,52 @@ export default function Admin() {
     max_price: 0,
     currency: 'USD',
   };
-  const [form, setForm] = useState(emptyForm);
-  const [products, setProducts] = useState([]);
-  const [message, setMessage] = useState('');
-  const [editingId, setEditingId] = useState(null);
-  const [showModal, setShowModal] = useState(false);
-  const [photos, setPhotos] = useState([]);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [message, setMessage] = useState<string>('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [photos, setPhotos] = useState<File[]>([]);
 
   const fetchProducts = useCallback(async () => {
     if (!user) return;
-    const res = await fetch(
+    const data = await fetchJson<Product[]>(
       `/api/admin/products?vendor=${encodeURIComponent(user.brandName || '')}`
     );
-    if (res.ok) {
-      setProducts(await res.json());
-    }
+    setProducts(data);
   }, [user]);
 
   useEffect(() => {
     fetchProducts();
   }, [fetchProducts]);
 
-  const handleChange = (e) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
-  const submit = async (e) => {
+  const submit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const fd = new FormData();
     const payload = editingId ? { ...form, id: editingId } : form;
     Object.entries(payload).forEach(([k, v]) => fd.append(k, v));
     photos.forEach((file) => fd.append('photos', file));
-    const res = await fetch('/api/admin/products', {
-      method: editingId ? 'PUT' : 'POST',
-      body: fd,
-    });
-    if (res.ok) {
+    try {
+      await fetchJson<ApiMessage>('/api/admin/products', {
+        method: editingId ? 'PUT' : 'POST',
+        body: fd,
+      });
       setMessage(editingId ? 'Product updated' : 'Product added');
       setForm(emptyForm);
       setEditingId(null);
       setPhotos([]);
       fetchProducts();
-    } else {
-      const data = await res.json();
-      setMessage(data.message || 'Error');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Error';
+      setMessage(msg);
     }
   };
 
-  const handleEdit = (p) => {
+  const handleEdit = (p: Product) => {
     setForm({
       id: p.ID,
       title: p.TITLE || '',
@@ -161,7 +173,9 @@ export default function Admin() {
                 <input
                   type="file"
                   multiple
-                  onChange={(e) => setPhotos(Array.from(e.target.files))}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setPhotos(e.target.files ? Array.from(e.target.files) : [])
+                  }
                   className="file-input file-input-bordered w-full"
                 />
               </div>

--- a/pages/admin/search-analytics.tsx
+++ b/pages/admin/search-analytics.tsx
@@ -1,24 +1,18 @@
 import { useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import Link from 'next/link';
-
-interface SearchCount {
-  query: string;
-  count: number;
-}
+import { SearchAnalyticsResponse } from '../../types';
+import { fetchJson } from '../../lib/utils/fetchJson';
 
 export default function SearchAnalytics() {
   const { user } = useContext(AppContext)!;
-  const [data, setData] = useState<{
-    topSearches: SearchCount[];
-    failedSearches: SearchCount[];
-  } | null>(null);
+  const [data, setData] = useState<SearchAnalyticsResponse | null>(null);
 
   useEffect(() => {
     if (!user) return;
-    fetch('/api/admin/search-analytics')
-      .then((res) => (res.ok ? res.json() : null))
-      .then(setData);
+    fetchJson<SearchAnalyticsResponse>('/api/admin/search-analytics')
+      .then(setData)
+      .catch(() => setData(null));
   }, [user]);
 
   if (!user) return <div className="p-4">Please log in to view analytics.</div>;

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,54 +1,57 @@
 import { useContext, useEffect, useState, useCallback } from 'react';
 import { AppContext } from '../../contexts/AppContext';
+import {
+  AdminUser,
+  UserRoleUpdateRequest,
+  UserDisabledUpdateRequest,
+  ApiMessage,
+} from '../../types';
+import { fetchJson } from '../../lib/utils/fetchJson';
 
 export default function ManageUsers() {
   const { user } = useContext(AppContext)!;
-  const [users, setUsers] = useState([]);
-  const [message, setMessage] = useState('');
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [message, setMessage] = useState<string>('');
 
   const fetchUsers = useCallback(async () => {
     if (!user) return;
-    const res = await fetch('/api/admin/users');
-    if (res.ok) setUsers(await res.json());
+    const data = await fetchJson<AdminUser[]>('/api/admin/users');
+    setUsers(data);
   }, [user]);
 
   useEffect(() => {
     fetchUsers();
   }, [fetchUsers]);
 
-  const changeRole = async (email, role) => {
-    const res = await fetch('/api/admin/users', {
+  const changeRole = async (email: string, role: string) => {
+    const payload: UserRoleUpdateRequest = { email, role };
+    await fetchJson<ApiMessage>('/api/admin/users', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, role }),
+      body: JSON.stringify(payload),
     });
-    if (res.ok) {
-      setMessage('Role updated');
-      fetchUsers();
-    }
+    setMessage('Role updated');
+    fetchUsers();
   };
 
-  const toggleDisabled = async (email, disabled) => {
-    const res = await fetch('/api/admin/users', {
+  const toggleDisabled = async (email: string, disabled: boolean) => {
+    const payload: UserDisabledUpdateRequest = { email, disabled };
+    await fetchJson<ApiMessage>('/api/admin/users', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, disabled }),
+      body: JSON.stringify(payload),
     });
-    if (res.ok) {
-      setMessage('Status updated');
-      fetchUsers();
-    }
+    setMessage('Status updated');
+    fetchUsers();
   };
 
-  const remove = async (email) => {
-    const res = await fetch(
+  const remove = async (email: string) => {
+    await fetchJson<ApiMessage>(
       `/api/admin/users?email=${encodeURIComponent(email)}`,
       { method: 'DELETE' }
     );
-    if (res.ok) {
-      setMessage('User deleted');
-      fetchUsers();
-    }
+    setMessage('User deleted');
+    fetchUsers();
   };
 
   if (!user) return <div className="p-4">Please log in to view users.</div>;

--- a/pages/api/admin/analytics.ts
+++ b/pages/api/admin/analytics.ts
@@ -2,14 +2,18 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getAllOrders } from '../../../lib/orders';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { AnalyticsData, ApiMessage } from '../../../types';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<AnalyticsData | ApiMessage>
+) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
   try {
     const orders = await getAllOrders();
-    const summary = {
+    const summary: AnalyticsData = {
       totalOrders: orders.length,
       totalRevenue: 0,
       topProducts: [],

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -8,14 +8,19 @@ import {
 import { withRole } from '../../../lib/withRole';
 import { logAudit } from '../../../lib/audit';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { Category, CategoryInput, ApiMessage } from '../../../types';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Category[] | ApiMessage>
+) {
   try {
     if (req.method === 'GET') {
-      return res.status(200).json(await getCategoriesFlat());
+      const cats = await getCategoriesFlat();
+      return res.status(200).json(cats as Category[]);
     }
     if (req.method === 'POST') {
-      const { name, parentId, image } = req.body || {};
+      const { name, parentId, image } = req.body as CategoryInput;
       if (!name) return res.status(400).json({ message: 'name required' });
       const exists = (await getCategoriesFlat()).find(
         (c) => c.name.toLowerCase() === name.toLowerCase()
@@ -35,7 +40,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       return res.status(201).json({ message: 'category created' });
     }
     if (req.method === 'PUT') {
-      const { id, name, parentId, image } = req.body || {};
+      const { id, name, parentId, image } = req.body as CategoryInput & { id: number };
       if (!id || !name)
         return res.status(400).json({ message: 'id and name required' });
       await renameCategory(id, name, parentId || null, image || null);
@@ -46,7 +51,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       const { id } = req.query;
       if (!id) return res.status(400).json({ message: 'id required' });
       try {
-        await removeCategory(id);
+        await removeCategory(String(id));
         logAudit('delete_category', { id });
         return res.status(200).json({ message: 'category deleted' });
       } catch (e: unknown) {

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { Product, ApiMessage } from '../../../types';
 
 function slugify(text) {
   return text
@@ -44,7 +45,10 @@ async function parseBody(req: NextApiRequest) {
   );
 }
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Product[] | ApiMessage>
+) {
   try {
     const db = getDb();
 
@@ -153,13 +157,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
     if (req.method === 'GET') {
       const { vendor } = req.query;
-      const where: any = {};
+      const where: Record<string, unknown> = {};
       if (vendor) where.vendor = { brandName: String(vendor) };
       const rows = await db.product.findMany({
         where,
         include: { category: true, vendor: true },
       });
-      const data = rows.map((p) => ({
+      const data: Product[] = rows.map((p) => ({
         ID: String(p.id),
         SLUG: p.slug,
         TITLE: p.title,

--- a/pages/api/admin/search-analytics.ts
+++ b/pages/api/admin/search-analytics.ts
@@ -1,16 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-
-interface SearchAnalyticsResponse {
-  topSearches: { query: string; count: number }[];
-  failedSearches: { query: string; count: number }[];
-}
+import { SearchAnalyticsResponse, ApiMessage } from '../../../types';
 import { getDb } from '../../../lib/db';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<SearchAnalyticsResponse | { message: string }>
+  res: NextApiResponse<SearchAnalyticsResponse | ApiMessage>
 ) {
   try {
     if (req.method !== 'GET') {

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -8,21 +8,32 @@ import {
 } from '../../../lib/users';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import {
+  AdminUser,
+  UserRoleUpdateRequest,
+  UserDisabledUpdateRequest,
+  CreateUserRequest,
+  ApiMessage,
+} from '../../../types';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<AdminUser[] | ApiMessage>
+) {
   try {
     if (req.method === 'GET') {
-      return res.status(200).json(await getAllUsers());
+      const users = await getAllUsers();
+      return res.status(200).json(users as AdminUser[]);
     }
     if (req.method === 'PUT') {
-      const { email, role } = req.body || {};
+      const { email, role } = req.body as UserRoleUpdateRequest;
       if (!email || !role)
         return res.status(400).json({ message: 'email and role required' });
-      await updateUserRole(email, role);
+      await updateUserRole(email, role as any);
       return res.status(200).json({ message: 'role updated' });
     }
     if (req.method === 'PATCH') {
-      const { email, disabled } = req.body || {};
+      const { email, disabled } = req.body as UserDisabledUpdateRequest;
       if (typeof disabled !== 'boolean' || !email)
         return res.status(400).json({ message: 'email and disabled required' });
       await setUserDisabled(email, disabled);
@@ -31,12 +42,19 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method === 'DELETE') {
       const { email } = req.query;
       if (!email) return res.status(400).json({ message: 'email required' });
-      await deleteUser(email);
+      await deleteUser(String(email));
       return res.status(200).json({ message: 'user deleted' });
     }
     if (req.method === 'POST') {
-      const { email, password, firstName, lastName, brandName, gender, role } =
-        req.body || {};
+      const {
+        email,
+        password,
+        firstName,
+        lastName,
+        brandName,
+        gender,
+        role,
+      } = req.body as CreateUserRequest;
       if (!email || !password || !firstName || !lastName || !gender) {
         return res.status(400).json({ message: 'missing required fields' });
       }
@@ -47,7 +65,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         last_name: lastName,
         brand_name: brandName,
         gender,
-        role: role || 'USER',
+        role: (role || 'USER') as any,
       });
       return res.status(201).json({ message: 'user created' });
     }

--- a/pages/api/admin/vendor-products.ts
+++ b/pages/api/admin/vendor-products.ts
@@ -6,14 +6,19 @@ import {
 } from '../../../lib/products';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { PendingProduct, ApiMessage } from '../../../types';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<PendingProduct[] | ApiMessage>
+) {
   try {
     if (req.method === 'GET') {
-      return res.status(200).json(await getPendingProducts());
+      const list = await getPendingProducts();
+      return res.status(200).json(list as PendingProduct[]);
     }
     if (req.method === 'PUT') {
-      const { id, action } = req.body || {};
+      const { id, action } = req.body as { id?: string; action?: string };
       if (!id || !action)
         return res.status(400).json({ message: 'id and action required' });
       if (action === 'approve') {

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -1,0 +1,54 @@
+export interface AdminUser {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  brandName?: string;
+  gender?: string;
+  role: string;
+  disabled: boolean;
+}
+
+export interface UserRoleUpdateRequest {
+  email: string;
+  role: string;
+}
+
+export interface UserDisabledUpdateRequest {
+  email: string;
+  disabled: boolean;
+}
+
+export interface CreateUserRequest {
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  brandName?: string;
+  gender: string;
+  role?: string;
+}
+
+export interface ApiMessage {
+  message: string;
+}
+
+export interface PendingProduct {
+  id: string;
+  title: string;
+}
+
+export interface SearchCount {
+  query: string;
+  count: number;
+}
+
+export interface SearchAnalyticsResponse {
+  topSearches: SearchCount[];
+  failedSearches: SearchCount[];
+}
+
+export interface AnalyticsData {
+  totalOrders: number;
+  totalRevenue: number;
+  topProducts: { id: string; qty: number }[];
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,3 +3,4 @@ export * from './category';
 export * from './user';
 export * from './order';
 export * from './review';
+export * from './admin';


### PR DESCRIPTION
## Summary
- introduce reusable `fetchJson` helper
- define admin API interfaces
- use strong typing in admin React pages
- strongly type admin API handlers

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails with TS errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855bb9c8dc4832f9cde604e0026fa8c