### PR TITLE
Apply TS types to data-fetching components

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useSession, signOut } from 'next-auth/react';
 import type { FC, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
-import { AppContext } from '../contexts/AppContext';
+import { AppContext, AppContextValue } from '../contexts/AppContext';
 import SearchIcon from './icons/SearchIcon';
 import CartIcon from './icons/CartIcon';
 import MoonIcon from './icons/MoonIcon';
@@ -15,6 +15,11 @@ import ElectronicsIcon from './icons/ElectronicsIcon';
 import FashionIcon from './icons/FashionIcon';
 import { Theme } from 'react-select';
 import { Category as PrismaCategory } from '@prisma/client';
+import type {
+  CategoriesResponse,
+  SuggestionsResponse,
+  TrendingResponse,
+} from '../types/api';
 
 interface Category extends PrismaCategory {
   parentId?: number | null;
@@ -23,16 +28,9 @@ interface Category extends PrismaCategory {
   subcategories?: string[];
 }
 
-interface CartItem {
-  id: string | number;
-  qty: number;
-  [key: string]: any;
-}
+import type { Product } from '../types/product';
 
-interface AppContextValue {
-  cart: CartItem[];
-  [key: string]: any;
-}
+type CartItem = Product & { qty: number };
 
 interface User {
   name?: string | null;
@@ -76,8 +74,8 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
       try {
         const res = await fetch('/api/categories');
         if (res.ok) {
-          const data = await res.json();
-          setCategories(data || []);
+          const data: CategoriesResponse = await res.json();
+          setCategories(data.categories || data || []);
         }
       } catch (err) {
         console.error('Failed to load categories', err);
@@ -102,7 +100,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
       try {
         const res = await fetch('/api/trending');
         if (res.ok) {
-          const data = await res.json();
+          const data: TrendingResponse = await res.json();
           setTrendingKeywords(data.keywords || []);
         }
       } catch {
@@ -121,7 +119,8 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
       if (
         searchRef.current &&
         !searchRef.current.contains(target) &&
-        !(typeof (target as any).closest === 'function' && (target as any).closest('#mega-menu'))
+        !(typeof (target as Element).closest === 'function' &&
+          (target as Element).closest('#mega-menu'))
       ) {
         setMenuOpen(false);
         setShowHistory(false);
@@ -149,7 +148,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
           { signal: controller.signal }
         );
         if (res.ok) {
-          const data = await res.json();
+          const data: SuggestionsResponse = await res.json();
           setSuggestions(data.suggestions || []);
           setActiveIdx(-1);
         }

--- a/components/RecommendedProducts.tsx
+++ b/components/RecommendedProducts.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ProductCard from './ProductCard';
 import { Product } from '../types/product';
+import type { SearchResults } from '../types/api';
 
 interface RecommendedProductsProps {
   category?: string;
@@ -18,10 +19,10 @@ const RecommendedProducts: React.FC<RecommendedProductsProps> = ({
   useEffect(() => {
     if (!category) return;
     fetch(`/api/search?category=${encodeURIComponent(category)}&perPage=4`)
-      .then((res) => (res.ok ? res.json() : null))
+      .then((res) => (res.ok ? (res.json() as Promise<SearchResults>) : null))
       .then((data) => {
         if (data && Array.isArray(data.results)) {
-          const filtered = data.results.filter((p: Product) => p.ID !== excludeId);
+          const filtered = data.results.filter((p) => p.ID !== excludeId);
           setProducts(filtered);
         }
       })

--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -1,22 +1,27 @@
 import { useContext, useEffect, useState, useCallback } from 'react';
 import Image from 'next/image';
 import { AppContext } from '../../contexts/AppContext';
+import type { Category } from '../../types/category';
+import type { CategoriesResponse } from '../../types/api';
 
 export default function Categories() {
   const { user } = useContext(AppContext)!;
-  const [categories, setCategories] = useState([]);
+  const [categories, setCategories] = useState<Category[]>([]);
   const [newCat, setNewCat] = useState('');
   const [newParent, setNewParent] = useState('');
   const [newImage, setNewImage] = useState('');
   const [message, setMessage] = useState('');
-  const [editing, setEditing] = useState(null);
+  const [editing, setEditing] = useState<number | null>(null);
   const [editName, setEditName] = useState('');
   const [editImage, setEditImage] = useState('');
 
   const load = useCallback(async () => {
     if (!user) return;
     const res = await fetch('/api/admin/categories');
-    if (res.ok) setCategories(await res.json());
+    if (res.ok) {
+      const data: CategoriesResponse | Category[] = await res.json();
+      setCategories(Array.isArray(data) ? data : data.categories);
+    }
   }, [user]);
 
   useEffect(() => {
@@ -53,7 +58,7 @@ export default function Categories() {
     }
   };
 
-  const remove = async (id) => {
+  const remove = async (id: number) => {
     const res = await fetch(`/api/admin/categories?id=${id}`, {
       method: 'DELETE',
     });
@@ -111,23 +116,23 @@ export default function Categories() {
     </div>
   );
 
-  function buildTree(list) {
-    const map = {};
+  function buildTree(list: Category[]): Category[] {
+    const map: Record<number, Category & { children: Category[] }> = {};
     list.forEach((c) => {
-      map[c.id] = { ...c, children: [] };
+      map[c.id!] = { ...c, children: [] };
     });
-    const tree = [];
+    const tree: Category[] = [];
     list.forEach((c) => {
       if (c.parentId) {
-        map[c.parentId]?.children.push(map[c.id]);
+        map[c.parentId]?.children.push(map[c.id!]);
       } else {
-        tree.push(map[c.id]);
+        tree.push(map[c.id!]);
       }
     });
     return tree;
   }
 
-  function CategoryItem({ cat }) {
+  function CategoryItem({ cat }: { cat: Category }) {
     const hasChildren = cat.children && cat.children.length > 0;
     return (
       <li className={cat.parentId ? 'ml-4' : ''}>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,10 +1,23 @@
-import { useState, useEffect, useContext, useCallback } from 'react';
+import { useState, useEffect, useContext, useCallback, ChangeEvent } from 'react';
 import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
+import type { Product } from '../../types/product';
 
 export default function Admin() {
   const { user } = useContext(AppContext)!;
-  const emptyForm = {
+  interface FormState {
+    id: string;
+    title: string;
+    vendor: string;
+    description: string;
+    product_type: string;
+    tags: string;
+    quantity: number;
+    min_price: number;
+    max_price: number;
+    currency: string;
+  }
+  const emptyForm: FormState = {
     id: '',
     title: '',
     vendor: '',
@@ -16,12 +29,12 @@ export default function Admin() {
     max_price: 0,
     currency: 'USD',
   };
-  const [form, setForm] = useState(emptyForm);
-  const [products, setProducts] = useState([]);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [products, setProducts] = useState<Product[]>([]);
   const [message, setMessage] = useState('');
-  const [editingId, setEditingId] = useState(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
-  const [photos, setPhotos] = useState([]);
+  const [photos, setPhotos] = useState<File[]>([]);
 
   const fetchProducts = useCallback(async () => {
     if (!user) return;
@@ -29,7 +42,8 @@ export default function Admin() {
       `/api/admin/products?vendor=${encodeURIComponent(user.brandName || '')}`
     );
     if (res.ok) {
-      setProducts(await res.json());
+      const data: Product[] = await res.json();
+      setProducts(data);
     }
   }, [user]);
 
@@ -37,11 +51,11 @@ export default function Admin() {
     fetchProducts();
   }, [fetchProducts]);
 
-  const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name as keyof FormState]: e.target.value });
   };
 
-  const submit = async (e) => {
+  const submit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const fd = new FormData();
     const payload = editingId ? { ...form, id: editingId } : form;
@@ -63,7 +77,7 @@ export default function Admin() {
     }
   };
 
-  const handleEdit = (p) => {
+  const handleEdit = (p: Product) => {
     setForm({
       id: p.ID,
       title: p.TITLE || '',
@@ -161,7 +175,9 @@ export default function Admin() {
                 <input
                   type="file"
                   multiple
-                  onChange={(e) => setPhotos(Array.from(e.target.files))}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setPhotos(Array.from(e.target.files ?? []))
+                  }
                   className="file-input file-input-bordered w-full"
                 />
               </div>

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,22 +1,27 @@
 import { useContext, useEffect, useState, useCallback } from 'react';
 import { AppContext } from '../../contexts/AppContext';
+import type { UsersResponse } from '../../types/api';
+import type { User } from '../../types/user';
 
 export default function ManageUsers() {
   const { user } = useContext(AppContext)!;
-  const [users, setUsers] = useState([]);
+  const [users, setUsers] = useState<(User & { disabled?: boolean })[]>([]);
   const [message, setMessage] = useState('');
 
   const fetchUsers = useCallback(async () => {
     if (!user) return;
     const res = await fetch('/api/admin/users');
-    if (res.ok) setUsers(await res.json());
+    if (res.ok) {
+      const data: UsersResponse = await res.json();
+      setUsers(data.users || data);
+    }
   }, [user]);
 
   useEffect(() => {
     fetchUsers();
   }, [fetchUsers]);
 
-  const changeRole = async (email, role) => {
+  const changeRole = async (email: string, role: string) => {
     const res = await fetch('/api/admin/users', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -28,7 +33,7 @@ export default function ManageUsers() {
     }
   };
 
-  const toggleDisabled = async (email, disabled) => {
+  const toggleDisabled = async (email: string, disabled: boolean) => {
     const res = await fetch('/api/admin/users', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -40,7 +45,7 @@ export default function ManageUsers() {
     }
   };
 
-  const remove = async (email) => {
+  const remove = async (email: string) => {
     const res = await fetch(
       `/api/admin/users?email=${encodeURIComponent(email)}`,
       { method: 'DELETE' }

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,0 +1,28 @@
+export interface SearchResults {
+  results: import('./product').Product[];
+}
+
+export interface SuggestionsResponse {
+  suggestions: string[];
+}
+
+export interface TrendingResponse {
+  keywords: string[];
+}
+
+export interface CheckoutSessionResponse {
+  url: string;
+  message?: string;
+}
+
+export interface CouponResponse {
+  percent: number;
+}
+
+export interface CategoriesResponse {
+  categories: import('./category').Category[];
+}
+
+export interface UsersResponse {
+  users: (import('./user').User & { disabled?: boolean })[];
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,3 +3,4 @@ export * from './category';
 export * from './user';
 export * from './order';
 export * from './review';
+export * from './api';


### PR DESCRIPTION
## Summary
- enforce typed responses with new `types/api`
- use typed fetches and state across header and recommendations components
- improve admin pages with explicit interfaces

## Testing
- `npm run type-check` *(fails: implicit any errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855bbef0674832f95682909537f5757