### PR TITLE
feat(types): improve API typings

### DIFF
--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -95,7 +95,7 @@ async function handler(
       }
       const slug = slugify(title || (existing?.title as string) || String(id));
       const qty = quantity ? parseInt(String(quantity), 10) : 0;
-      const data = {
+      const data: Record<string, unknown> = {
         id: Number(id),
         slug,
         title,
@@ -108,7 +108,7 @@ async function handler(
         currency: (currency as string) || 'USD',
         status: 'approved',
         images: JSON.stringify(imagePaths),
-      } as any;
+      };
 
       if (vendor) {
         const vid = parseInt(String(vendor), 10);

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -6,6 +6,7 @@ import {
   addUser,
   setUserDisabled,
 } from '../../../lib/users';
+import type { Role } from '@prisma/client';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import {
@@ -29,7 +30,7 @@ async function handler(
       const { email, role } = req.body as UserRoleUpdateRequest;
       if (!email || !role)
         return res.status(400).json({ message: 'email and role required' });
-      await updateUserRole(email, role as any);
+      await updateUserRole(email, role as Role);
       return res.status(200).json({ message: 'role updated' });
     }
     if (req.method === 'PATCH') {
@@ -65,7 +66,7 @@ async function handler(
         last_name: lastName,
         brand_name: brandName,
         gender,
-        role: (role || 'USER') as any,
+        role: (role || 'USER') as Role,
       });
       return res.status(201).json({ message: 'user created' });
     }

--- a/pages/api/cart.ts
+++ b/pages/api/cart.ts
@@ -3,8 +3,12 @@ import { getCart, setCart } from '../../lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { CartItem } from '../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CartItem[] | { message: string }>
+) {
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
@@ -16,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(200).json(items);
     }
     if (req.method === 'POST') {
-      const { items } = req.body || {};
+      const { items } = req.body as { items?: CartItem[] } || {};
       if (!Array.isArray(items)) {
         return res.status(400).json({ message: 'items required' });
       }

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -1,11 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '../../lib/products';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { CategoriesResponse } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
-) {
+  res: NextApiResponse<CategoriesResponse | { message: string }>
+ ) {
   try {
     if (req.method === 'GET') {
       const data = await getCategoryTree();

--- a/pages/api/category-tree.ts
+++ b/pages/api/category-tree.ts
@@ -1,11 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '../../lib/products';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { CategoriesResponse } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
-) {
+  res: NextApiResponse<CategoriesResponse | { message: string }>
+ ) {
   try {
     if (req.method === 'GET') {
       const data = await getCategoryTree();

--- a/pages/api/check-email.ts
+++ b/pages/api/check-email.ts
@@ -2,7 +2,10 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser } from '../../lib/users';
 import { handleApiError } from '../../lib/utils/handleApiError';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ exists: boolean } | { message: string }>
+) {
   try {
     const { email } = req.query;
     if (!email) {

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -2,13 +2,17 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser } from '../../lib/users';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { User } from '../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ message: string; user?: User }>
+) {
   try {
     if (req.method !== 'POST') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const { email, password } = req.body;
+  const { email, password } = req.body as { email?: string; password?: string };
     if (!email || !password) {
       return res.status(400).json({ message: 'email and password required' });
     }

--- a/pages/api/wishlist.ts
+++ b/pages/api/wishlist.ts
@@ -3,8 +3,12 @@ import { getWishlist, setWishlist } from '../../lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { Product } from '../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Product[] | { message: string }>
+) {
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
@@ -16,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(200).json(items);
     }
     if (req.method === 'POST') {
-      const { items } = req.body || {};
+      const { items } = req.body as { items?: Product[] } || {};
       if (!Array.isArray(items)) {
         return res.status(400).json({ message: 'items required' });
       }

--- a/types/brand.ts
+++ b/types/brand.ts
@@ -1,0 +1,12 @@
+export interface BrandProfile {
+  email: string;
+  brandName: string;
+  phoneNumber: string;
+  businessAddress: string;
+  city: string;
+  country: string;
+  website?: string;
+  businessDescription?: string;
+  logo?: string;
+  taxId?: string;
+}

--- a/types/cart.ts
+++ b/types/cart.ts
@@ -1,0 +1,9 @@
+import type { Product } from './product';
+
+export interface CartItem extends Product {
+  qty: number;
+}
+
+export interface CartResponse {
+  items: CartItem[];
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -5,3 +5,5 @@ export * from './order';
 export * from './review';
 export * from './admin';
 export * from './api';
+export * from './brand';
+export * from './cart';

--- a/types/product.ts
+++ b/types/product.ts
@@ -29,6 +29,8 @@ export interface Product {
   IMAGES_URLS?: string[];
   IMAGES_ALT_TEXT?: string[];
   STATUS?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export type ProductResponse = Product;

--- a/types/user.ts
+++ b/types/user.ts
@@ -5,6 +5,16 @@ export interface User {
   brandName?: string;
   gender?: string;
   role?: string;
+  disabled?: boolean;
+  phoneNumber?: string;
+  address?: string;
+  city?: string;
+  country?: string;
+  businessAddress?: string;
+  website?: string;
+  businessDescription?: string;
+  logo?: string;
+  taxId?: string;
 }
 
 export type UserResponse = User;


### PR DESCRIPTION
## Summary
- refine API request and response types
- share new Cart and Brand types
- expand User and Product typings
- use typed generics across API handlers
- remove remaining `as any` cast in admin products

## Testing
- `npm run type-check` *(fails: merge conflict markers)*

------
https://chatgpt.com/codex/tasks/task_e_68564a9bc730832f8f959014b341f55d