### PR TITLE
Unify user interface

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -29,16 +29,9 @@ interface Category extends PrismaCategory {
 }
 
 import type { Product } from '../types/product';
+import type { User } from '../types/user';
 
 type CartItem = Product & { qty: number };
-
-interface User {
-  name?: string | null;
-  email?: string | null;
-  image?: string | null;
-  role?: string;
-  firstName?: string;
-}
 
 interface HeaderProps {
   theme?: string;

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,31 +1,22 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import NextAuth, { AuthOptions, User as NextAuthUser } from 'next-auth';
+import NextAuth, { AuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 import GitHubProvider from 'next-auth/providers/github';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import bcrypt from 'bcryptjs';
 import { findUser, addUser } from '../../../lib/users';
+import type { User as AppUser } from '../../../types/user';
 
 // Extend the User type to include 'role'
 declare module 'next-auth' {
-  interface User {
-    role?: string;
-    disabled?: boolean;
-  }
+  interface User extends AppUser {}
   interface Session {
-    user?: {
-      role?: string;
-      disabled?: boolean;
-      [key: string]: any;
-    };
+    user?: AppUser & { [key: string]: any };
   }
 }
 
 declare module 'next-auth/jwt' {
-  interface JWT {
-    role?: string;
-    [key: string]: any;
-  }
+  interface JWT extends AppUser {}
 }
 
 if (!process.env.NEXTAUTH_SECRET) {

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useContext, useCallback, ChangeEvent, FormEvent } from 'react';
 import { AppContext } from '../../contexts/AppContext';
+import type { User } from '../../types/user';
 
 type ProductForm = {
   id: string;
@@ -29,14 +30,6 @@ type ProductApi = {
   CURRENCY: string;
 };
 
-type User = {
-  brandName?: string;
-  role: string;
-};
-
-type AppContextType = {
-  user: User | null;
-};
 
 const emptyForm: ProductForm = {
   id: '',
@@ -53,7 +46,7 @@ const emptyForm: ProductForm = {
 };
 
 const BrandDashboard: React.FC = () => {
-  const { user } = useContext(AppContext) as AppContextType;
+  const { user } = useContext(AppContext) as { user: User | null };
   const [form, setForm] = useState<ProductForm>(emptyForm);
   const [products, setProducts] = useState<ProductApi[]>([]);
   const [lowStock, setLowStock] = useState<ProductApi[]>([]);

--- a/pages/brand/profile.tsx
+++ b/pages/brand/profile.tsx
@@ -1,17 +1,6 @@
 import React, { useContext, useState, useEffect, ChangeEvent, FormEvent } from 'react';
 import { AppContext } from '../../contexts/AppContext';
-
-interface User {
-  brandName?: string;
-  phoneNumber?: string;
-  businessAddress?: string;
-  city?: string;
-  country?: string;
-  website?: string;
-  businessDescription?: string;
-  taxId?: string;
-  role?: string;
-}
+import type { User } from '../../types/user';
 
 export const BrandProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -2,6 +2,7 @@ import { useContext, useState, FormEvent, ChangeEvent } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { AppContext, AppContextValue } from '../contexts/AppContext';
+import type { User } from '../types/user';
 
 // Types for cart item and user
 type CartItem = {
@@ -9,12 +10,6 @@ type CartItem = {
   TITLE: string;
   MIN_PRICE?: string;
   qty: number;
-};
-
-type User = {
-  firstName: string;
-  lastName: string;
-  email: string;
 };
 
 type AppContextType = {

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -1,16 +1,6 @@
 import React, { useContext, useState, useEffect, FormEvent } from 'react';
 import { AppContext } from '../../contexts/AppContext';
-
-interface User {
-  id: string;
-  name: string;
-  email: string;
-  role: string;
-  phoneNumber?: string;
-  address?: string;
-  city?: string;
-  country?: string;
-}
+import type { User } from '../../types/user';
 
 export const UserProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,7 +1,10 @@
 export interface User {
+  id?: string | number;
   email: string;
   firstName?: string;
   lastName?: string;
+  name?: string | null;
+  image?: string | null;
   brandName?: string;
   gender?: string;
   role?: string;


### PR DESCRIPTION
## Summary
- define a full-featured `User` interface
- use the unified interface in user, brand, checkout pages
- update dashboard and header to import the shared `User` type
- extend NextAuth session and JWT types with the shared interface

## Testing
- `npm run type-check` *(fails: merge conflict markers)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685652fde104832fbc55fddb79207b25