### PR TITLE
Unify Category interface

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,19 +14,12 @@ import ChevronDownIcon from './icons/ChevronDownIcon';
 import ElectronicsIcon from './icons/ElectronicsIcon';
 import FashionIcon from './icons/FashionIcon';
 import { Theme } from 'react-select';
-import { Category as PrismaCategory } from '@prisma/client';
+import type { Category } from '../types/category';
 import type {
   CategoriesResponse,
   SuggestionsResponse,
   TrendingResponse,
 } from '../types/api';
-
-interface Category extends PrismaCategory {
-  parentId?: number | null;
-  children?: Category[];
-  image?: string | null;
-  subcategories?: string[];
-}
 
 import type { Product } from '../types/product';
 

--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -1,31 +1,12 @@
 import { useContext, useEffect, useState, useCallback } from 'react';
 import Image from 'next/image';
 import { AppContext } from '../../contexts/AppContext';
-<<<<<<< HEAD
 import { Category, CategoryInput, ApiMessage } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
-=======
-import type { Category } from '../../types/category';
-import type { CategoriesResponse } from '../../types/api';
->>>>>>> origin/codex/apply-proper-types-to-data-components
 
 export default function Categories() {
   const { user } = useContext(AppContext)!;
   const [categories, setCategories] = useState<Category[]>([]);
-<<<<<<< HEAD
-  const [newCat, setNewCat] = useState<string>('');
-  const [newParent, setNewParent] = useState<string>('');
-  const [newImage, setNewImage] = useState<string>('');
-  const [message, setMessage] = useState<string>('');
-  const [editing, setEditing] = useState<number | null>(null);
-  const [editName, setEditName] = useState<string>('');
-  const [editImage, setEditImage] = useState<string>('');
-
-  const load = useCallback(async () => {
-    if (!user) return;
-    const data = await fetchJson<Category[]>('/api/admin/categories');
-    setCategories(data);
-=======
   const [newCat, setNewCat] = useState('');
   const [newParent, setNewParent] = useState('');
   const [newImage, setNewImage] = useState('');
@@ -36,12 +17,8 @@ export default function Categories() {
 
   const load = useCallback(async () => {
     if (!user) return;
-    const res = await fetch('/api/admin/categories');
-    if (res.ok) {
-      const data: CategoriesResponse | Category[] = await res.json();
-      setCategories(Array.isArray(data) ? data : data.categories);
-    }
->>>>>>> origin/codex/apply-proper-types-to-data-components
+    const data = await fetchJson<Category[]>('/api/admin/categories');
+    setCategories(data);
   }, [user]);
 
   useEffect(() => {
@@ -85,11 +62,7 @@ export default function Categories() {
   };
 
   const remove = async (id: number) => {
-<<<<<<< HEAD
     await fetchJson<ApiMessage>(`/api/admin/categories?id=${id}`, {
-=======
-    const res = await fetch(`/api/admin/categories?id=${id}`, {
->>>>>>> origin/codex/apply-proper-types-to-data-components
       method: 'DELETE',
     });
     setMessage('Category deleted');
@@ -144,21 +117,15 @@ export default function Categories() {
     </div>
   );
 
-<<<<<<< HEAD
   function buildTree(list: Category[]): (Category & { children: Category[] })[] {
-    const map: Record<number, Category & { children: Category[] }> = {} as Record<number, Category & { children: Category[] }>;
+    const map: Record<number, Category & { children: Category[] }> = {} as Record<
+      number,
+      Category & { children: Category[] }
+    >;
     list.forEach((c) => {
       map[c.id!] = { ...c, children: [] };
     });
     const tree: (Category & { children: Category[] })[] = [];
-=======
-  function buildTree(list: Category[]): Category[] {
-    const map: Record<number, Category & { children: Category[] }> = {};
-    list.forEach((c) => {
-      map[c.id!] = { ...c, children: [] };
-    });
-    const tree: Category[] = [];
->>>>>>> origin/codex/apply-proper-types-to-data-components
     list.forEach((c) => {
       if (c.parentId) {
         map[c.parentId]?.children.push(map[c.id!]);
@@ -169,11 +136,7 @@ export default function Categories() {
     return tree;
   }
 
-<<<<<<< HEAD
   function CategoryItem({ cat }: { cat: Category & { children: Category[] } }) {
-=======
-  function CategoryItem({ cat }: { cat: Category }) {
->>>>>>> origin/codex/apply-proper-types-to-data-components
     const hasChildren = cat.children && cat.children.length > 0;
     return (
       <li className={cat.parentId ? 'ml-4' : ''}>

--- a/types/category.ts
+++ b/types/category.ts
@@ -1,10 +1,14 @@
 export interface Category {
   id?: number;
   name: string;
+  slug?: string;
   parentId?: number | null;
+  description?: string | null;
+  image?: string | null;
+  createdAt?: string | Date;
+  updatedAt?: string | Date;
   children?: Category[];
   subcategories?: string[];
-  image?: string;
 }
 
 export interface CategoryInput {


### PR DESCRIPTION
## Summary
- centralize `Category` type with slug, timestamps and more
- refactor Header and Admin categories page to use new interface

## Testing
- `npm run type-check` *(fails: cannot find node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68565613e57c832fbffbabbee5635055