### PR TITLE
Implement unified Vendor interface

### DIFF
--- a/pages/api/brand/profile.ts
+++ b/pages/api/brand/profile.ts
@@ -1,10 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateUserProfile, findUser } from '../../../lib/users';
+import type { Vendor } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Vendor | { message: string }>
+) {
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
@@ -12,7 +16,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
     if (req.method === 'GET') {
       const userData = await findUser(session.user.email);
-      return res.status(200).json(userData);
+      if (!userData) {
+        return res.status(404).json({ message: 'Not found' });
+      }
+      const vendor: Vendor = {
+        id: Number(userData.id),
+        name: `${userData.firstName} ${userData.lastName}`.trim(),
+        email: userData.email,
+        company: userData.brandName ?? '',
+        phoneNumber: userData.phoneNumber ?? undefined,
+        address: userData.businessAddress ?? undefined,
+        city: userData.city ?? undefined,
+        country: userData.country ?? undefined,
+        website: userData.website ?? undefined,
+        description: userData.businessDescription ?? undefined,
+        taxId: userData.taxId ?? undefined,
+        status: userData.disabled ? 'disabled' : 'active',
+        createdAt: userData.createdAt?.toISOString(),
+        updatedAt: userData.updatedAt?.toISOString(),
+      };
+      return res.status(200).json(vendor);
     }
     if (req.method === 'PUT') {
       const {

--- a/pages/brand/profile.tsx
+++ b/pages/brand/profile.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState, useEffect, ChangeEvent, FormEvent } from 'react';
 import { AppContext } from '../../contexts/AppContext';
-import type { User } from '../../types/user';
+import type { User, Vendor } from '../../types';
 
 export const BrandProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
@@ -26,6 +26,23 @@ export const BrandProfile: React.FC = () => {
       setTaxId(user.taxId || '');
     }
   }, [user]);
+
+  useEffect(() => {
+    fetch('/api/brand/profile')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: Vendor | null) => {
+        if (!data) return;
+        setBrandName(data.company || '');
+        setPhoneNumber(data.phoneNumber || '');
+        setBusinessAddress(data.address || '');
+        setCity(data.city || '');
+        setCountry(data.country || '');
+        setWebsite(data.website || '');
+        setBusinessDescription(data.description || '');
+        setTaxId(data.taxId || '');
+      })
+      .catch(() => {});
+  }, []);
 
   const submit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/types/index.ts
+++ b/types/index.ts
@@ -7,3 +7,4 @@ export * from './admin';
 export * from './api';
 export * from './brand';
 export * from './cart';
+export * from './vendor';

--- a/types/vendor.ts
+++ b/types/vendor.ts
@@ -1,0 +1,16 @@
+export interface Vendor {
+  id?: number;
+  name?: string;
+  email: string;
+  company?: string;
+  phoneNumber?: string;
+  address?: string;
+  city?: string;
+  country?: string;
+  website?: string;
+  description?: string;
+  taxId?: string;
+  status?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}


### PR DESCRIPTION
## Summary
- add `Vendor` interface
- export vendor from types index
- use `Vendor` in brand profile API and page

## Testing
- `npx jest` *(fails: need jest installation)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: TS errors due to merge markers)*

------
https://chatgpt.com/codex/tasks/task_e_6856566241e8832f8057a4341e3a3f37