### PR TITLE
Create unified coupon interface

### DIFF
--- a/pages/api/coupons/[code].ts
+++ b/pages/api/coupons/[code].ts
@@ -1,11 +1,34 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { handleApiError } from '../../../lib/utils/handleApiError';
-const coupons = {
-  SAVE10: { percent: 10 },
-  SAVE20: { percent: 20 },
+import type { Coupon } from '../../../types';
+
+const coupons: Record<string, Coupon> = {
+  SAVE10: {
+    id: '1',
+    code: 'SAVE10',
+    discountType: 'percent',
+    value: 10,
+    expiresAt: '2099-12-31T23:59:59Z',
+    minOrderAmount: 0,
+    usageLimit: 100,
+    createdAt: '2023-01-01T00:00:00Z',
+  },
+  SAVE20: {
+    id: '2',
+    code: 'SAVE20',
+    discountType: 'percent',
+    value: 20,
+    expiresAt: '2099-12-31T23:59:59Z',
+    minOrderAmount: 0,
+    usageLimit: 100,
+    createdAt: '2023-01-01T00:00:00Z',
+  },
 };
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Coupon | { message: string }>
+) {
   try {
     const { code } = req.query;
     const coupon = coupons[code?.toUpperCase() as string];

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { AppContext, AppContextValue } from '../contexts/AppContext';
 import type { User } from '../types/user';
+import type { Coupon } from '../types';
 
 // Types for cart item and user
 type CartItem = {
@@ -118,7 +119,9 @@ const Checkout: React.FC = () => {
               id="coupon"
               className="input input-bordered flex-1"
               value={coupon}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setCoupon(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setCoupon(e.target.value)
+              }
             />
             <button
               type="button"
@@ -129,8 +132,14 @@ const Checkout: React.FC = () => {
                   `/api/coupons/${encodeURIComponent(coupon)}`
                 );
                 if (res.ok) {
-                  const data = await res.json();
-                  setDiscount(data.percent);
+                  const data: Coupon = await res.json();
+                  if (data.discountType === 'percent') {
+                    setDiscount(data.value);
+                  } else {
+                    setDiscount(
+                      totalPrice > 0 ? (data.value / totalPrice) * 100 : 0
+                    );
+                  }
                 } else {
                   setDiscount(0);
                 }
@@ -153,7 +162,9 @@ const Checkout: React.FC = () => {
             id="name"
             className="input input-bordered w-full"
             value={name}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setName(e.target.value)
+            }
             required
           />
         </div>
@@ -165,7 +176,9 @@ const Checkout: React.FC = () => {
             id="address"
             className="textarea textarea-bordered w-full"
             value={address}
-            onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setAddress(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+              setAddress(e.target.value)
+            }
             required
           />
         </div>

--- a/types/api.ts
+++ b/types/api.ts
@@ -15,9 +15,7 @@ export interface CheckoutSessionResponse {
   message?: string;
 }
 
-export interface CouponResponse {
-  percent: number;
-}
+export type CouponResponse = import('./coupon').Coupon;
 
 export interface CategoriesResponse {
   categories: import('./category').Category[];

--- a/types/coupon.ts
+++ b/types/coupon.ts
@@ -1,0 +1,10 @@
+export interface Coupon {
+  id?: string | number;
+  code: string;
+  discountType: 'percent' | 'amount';
+  value: number;
+  expiresAt?: string;
+  minOrderAmount?: number;
+  usageLimit?: number;
+  createdAt?: string;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,3 +8,4 @@ export * from './api';
 export * from './brand';
 export * from './cart';
 export * from './vendor';
+export * from './coupon';


### PR DESCRIPTION
## Summary
- add a central `Coupon` interface
- expose coupon types from index
- update API endpoint to return `Coupon`
- use `Coupon` in checkout page discount logic
- update API types to use `Coupon`

## Testing
- `npm test`
- `npm run type-check` *(fails: Could not find declaration file and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685656720598832f92c69e39202d21db