### PR TITLE
Implement hybrid UUIDs

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -21,13 +21,20 @@ export async function getProductById(id: string | number) {
   });
 }
 
+export async function getProductByUuid(uuid: string) {
+  return prisma.product.findUnique({ where: { uuid } });
+}
+
 export async function getProductBySlug(slug: string) {
   return prisma.product.findUnique({ where: { slug } });
 }
 
-export async function decreaseProductQuantity(id: string | number, qty: number) {
+export async function decreaseProductQuantity(
+  uuid: string,
+  qty: number
+) {
   return prisma.product.update({
-    where: { id: Number(id) },
+    where: { uuid },
     data: { quantity: { decrement: qty } },
   });
 }

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -5,6 +5,7 @@ import { mapDbRowToProduct } from './products';
 function mapOrderRow(row: OrderRow): Order {
   return {
     id: row.id,
+    uuid: row.uuid,
     userId: row.userId,
     items: [
       {
@@ -62,7 +63,7 @@ export async function addOrder({
     const created = await db.order.create({
       data: {
         user: { connect: { id: user.id } },
-        product: { connect: { id: Number(item.id) } },
+        product: { connect: { uuid: item.uuid || String(item.id) } },
         quantity: item.qty || 1,
         total,
         status,
@@ -105,16 +106,18 @@ export async function getOrdersForVendor(vendor: string) {
     .map(mapOrderRow);
 }
 
-export async function hasOrdersForProduct(productId: string | number) {
+export async function hasOrdersForProduct(productUuid: string) {
   const db = getDb();
-  const count = await db.order.count({ where: { productId: Number(productId) } });
+  const product = await db.product.findUnique({ where: { uuid: productUuid } });
+  if (!product) return false;
+  const count = await db.order.count({ where: { productId: product.id } });
   return count > 0;
 }
 
-export async function getOrderById(id: string | number): Promise<(Order & { userEmail: string }) | null> {
+export async function getOrderByUuid(uuid: string): Promise<(Order & { userEmail: string }) | null> {
   const db = getDb();
   const row = await db.order.findUnique({
-    where: { id: Number(id) },
+    where: { uuid },
     include: { user: true, product: { include: { vendor: true, category: true } } },
   });
   if (!row) return null;
@@ -122,9 +125,9 @@ export async function getOrderById(id: string | number): Promise<(Order & { user
   return { ...order, userEmail: row.user.email };
 }
 
-export async function updateOrderStatus(id: string | number, status: string) {
+export async function updateOrderStatus(uuid: string, status: string) {
   const db = getDb();
-  await db.order.update({ where: { id: Number(id) }, data: { status } });
+  await db.order.update({ where: { uuid }, data: { status } });
 }
 
 export async function getBestSellingProducts(limit = 8) {

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -57,6 +57,9 @@ function processProductRow(row: Record<string, unknown>): Product {
   processed.reviewCount = parseInt(meta?.yotpo_reviews_count?.value ?? '0', 10);
   processed.averageRating = parseFloat(meta?.yotpo_reviews_average?.value ?? '0');
   processed.id = String(processed.id);
+  if (row.uuid) {
+    processed.uuid = String(row.uuid);
+  }
   if (processed.slug) {
     processed.slug = String(processed.slug);
   }
@@ -77,6 +80,7 @@ async function loadProductsData(): Promise<Product[]> {
     return rows.map((row: ProductDbRow) =>
       processProductRow({
         id: row.id,
+        uuid: row.uuid,
         slug: row.slug,
         title: row.title,
         vendor: row.vendor?.brandName ?? String(row.vendorId),
@@ -107,6 +111,7 @@ async function loadProductsData(): Promise<Product[]> {
 export function mapDbRowToProduct(row: Record<string, unknown>): Product {
   return processProductRow({
     id: row.id,
+    uuid: row.uuid,
     slug: row.slug,
     title: row.title,
     vendor: row.vendor,
@@ -142,7 +147,8 @@ export async function addProduct(product: Product): Promise<void> {
     ? await db.category.findFirst({ where: { name: product.category } })
     : null;
   const data: any = {
-    id: Number(product.id),
+    id: product.id ? Number(product.id) : undefined,
+    uuid: product.uuid ?? undefined,
     slug: product.slug,
     title: product.title,
     description: product.description ?? '',
@@ -174,7 +180,7 @@ export async function updateProduct(product: Product): Promise<void> {
     ? await db.category.findFirst({ where: { name: product.category } })
     : null;
   await db.product.update({
-    where: { id: Number(product.id) },
+    where: { uuid: product.uuid || String(product.id) },
     data: {
       title: product.title,
       description: product.description,
@@ -217,14 +223,14 @@ export async function getPendingProducts(): Promise<Product[]> {
   );
 }
 
-export async function approveProduct(id: string | number): Promise<void> {
+export async function approveProduct(uuid: string): Promise<void> {
   const db = getDb();
-  await db.product.update({ where: { id: Number(id) }, data: { status: 'approved' } });
+  await db.product.update({ where: { uuid }, data: { status: 'approved' } });
 }
 
-export async function rejectProduct(id: string | number): Promise<void> {
+export async function rejectProduct(uuid: string): Promise<void> {
   const db = getDb();
-  await db.product.update({ where: { id: Number(id) }, data: { status: 'rejected' } });
+  await db.product.update({ where: { uuid }, data: { status: 'rejected' } });
 }
 
 export async function getCategoriesFlat(): Promise<Category[]> {
@@ -284,26 +290,28 @@ export async function createCategory(
 }
 
 export async function renameCategory(
-  id: string | number,
+  uuid: string,
   name: string,
   _parentId: number | null = null,
   _image: string | null = null
 ): Promise<void> {
   const db = getDb();
-  await db.category.update({ where: { id: Number(id) }, data: { name } });
+  await db.category.update({ where: { uuid }, data: { name } });
 }
 
-export async function removeCategory(id: string | number): Promise<void> {
+export async function removeCategory(uuid: string): Promise<void> {
   const db = getDb();
-  const count = await db.product.count({ where: { categoryId: Number(id) } });
+  const category = await db.category.findUnique({ where: { uuid } });
+  if (!category) return;
+  const count = await db.product.count({ where: { categoryId: category.id } });
   if (count === 0) {
-    await db.category.delete({ where: { id: Number(id) } });
+    await db.category.delete({ where: { uuid } });
   } else {
     throw new Error('category in use');
   }
 }
 
-export async function deleteProduct(id: string | number): Promise<void> {
+export async function deleteProduct(uuid: string): Promise<void> {
   const db = getDb();
-  await db.product.delete({ where: { id: Number(id) } });
+  await db.product.delete({ where: { uuid } });
 }

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -40,19 +40,19 @@ async function handler(
       return res.status(201).json({ message: 'category created' });
     }
     if (req.method === 'PUT') {
-      const { id, name, parentId, image } = req.body as CategoryInput & { id: number };
-      if (!id || !name)
-        return res.status(400).json({ message: 'id and name required' });
-      await renameCategory(id, name, parentId || null, image || null);
-      logAudit('rename_category', { id, name, parentId, image });
+      const { uuid, name, parentId, image } = req.body as CategoryInput & { uuid: string };
+      if (!uuid || !name)
+        return res.status(400).json({ message: 'uuid and name required' });
+      await renameCategory(uuid, name, parentId || null, image || null);
+      logAudit('rename_category', { uuid, name, parentId, image });
       return res.status(200).json({ message: 'category updated' });
     }
     if (req.method === 'DELETE') {
-      const { id } = req.query;
-      if (!id) return res.status(400).json({ message: 'id required' });
+      const { uuid } = req.query;
+      if (!uuid) return res.status(400).json({ message: 'uuid required' });
       try {
-        await removeCategory(String(id));
-        logAudit('delete_category', { id });
+        await removeCategory(String(uuid));
+        logAudit('delete_category', { uuid });
         return res.status(200).json({ message: 'category deleted' });
       } catch (e: unknown) {
         if (e instanceof Error && e.message === 'category in use') {

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -138,20 +138,20 @@ async function handler(
     }
 
     if (req.method === 'DELETE') {
-      const { id } = req.query;
-      if (!id) {
-        return res.status(400).json({ message: 'id required' });
+      const { uuid } = req.query;
+      if (!uuid) {
+        return res.status(400).json({ message: 'uuid required' });
       }
-      const existing = await db.product.findUnique({ where: { id: Number(id) } });
+      const existing = await db.product.findUnique({ where: { uuid } });
       if (!existing) {
         return res.status(404).json({ message: 'Not found' });
       }
-      if (existing.quantity > 0 || (await hasOrdersForProduct(String(id)))) {
+      if (existing.quantity > 0 || (await hasOrdersForProduct(String(uuid)))) {
         return res
           .status(400)
           .json({ message: 'cannot delete product with stock or orders' });
       }
-      await db.product.delete({ where: { id: Number(id) } });
+      await db.product.delete({ where: { uuid } });
       return res.status(200).json({ message: 'Product deleted' });
     }
 

--- a/pages/api/admin/vendor-products.ts
+++ b/pages/api/admin/vendor-products.ts
@@ -18,15 +18,15 @@ async function handler(
       return res.status(200).json(list as PendingProduct[]);
     }
     if (req.method === 'PUT') {
-      const { id, action } = req.body as { id?: string; action?: string };
-      if (!id || !action)
-        return res.status(400).json({ message: 'id and action required' });
+      const { uuid, action } = req.body as { uuid?: string; action?: string };
+      if (!uuid || !action)
+        return res.status(400).json({ message: 'uuid and action required' });
       if (action === 'approve') {
-        await approveProduct(id);
+        await approveProduct(uuid);
         return res.status(200).json({ message: 'approved' });
       }
       if (action === 'reject') {
-        await rejectProduct(id);
+        await rejectProduct(uuid);
         return res.status(200).json({ message: 'rejected' });
       }
       return res.status(400).json({ message: 'invalid action' });

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -1,16 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateProduct, deleteProduct, loadAndIndexProducts } from '../../../../lib/products';
-import { getProductById } from '../../../../lib/db';
+import { getProductByUuid } from '../../../../lib/db';
 import { hasOrdersForProduct } from '../../../../lib/orders';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const { id } = req.query;
-    if (!id) return res.status(400).json({ message: 'id required' });
+    const { uuid } = req.query;
+    if (!uuid) return res.status(400).json({ message: 'uuid required' });
 
     if (req.method === 'PUT') {
-      const existing = await getProductById(String(id));
+      const existing = await getProductByUuid(String(uuid));
       if (!existing) return res.status(404).json({ message: 'Not found' });
       const {
         title,
@@ -25,7 +25,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       currency,
     } = req.body || {};
     await updateProduct({
-      id: String(id),
+      id: String(uuid),
       title: title ?? existing.title,
       vendor: vendor ?? existing.vendor,
       description: description ?? existing.description,
@@ -45,12 +45,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     if (req.method === 'DELETE') {
-      const existing = await getProductById(String(id));
+      const existing = await getProductByUuid(String(uuid));
       if (!existing) return res.status(404).json({ message: 'Not found' });
-      if (existing.quantity > 0 || hasOrdersForProduct(String(id))) {
+      if (existing.quantity > 0 || hasOrdersForProduct(String(uuid))) {
         return res.status(400).json({ message: 'cannot delete product with stock or orders' });
       }
-      await deleteProduct(String(id));
+      await deleteProduct(String(uuid));
       await loadAndIndexProducts();
       return res.status(200).json({ message: 'product deleted' });
     }

--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -7,7 +7,7 @@ import {
 } from '../../lib/orders';
 import { findUser } from '../../lib/users';
 import {
-  getProductById,
+  getProductByUuid,
   decreaseProductQuantity,
   clearCart,
 } from '../../lib/db';
@@ -24,7 +24,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     for (const item of items) {
-      const product = await getProductById(String(item.id));
+      const product = await getProductByUuid(String(item.uuid || item.id));
       if (!product) {
         return res.status(404).json({ message: 'Product not found' });
       }
@@ -36,7 +36,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     for (const item of items) {
-      await decreaseProductQuantity(String(item.id), item.qty);
+      await decreaseProductQuantity(String(item.uuid || item.id), item.qty);
     }
 
     const orderId = await addOrder({

--- a/pages/api/orders/[uuid].ts
+++ b/pages/api/orders/[uuid].ts
@@ -1,19 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrderById } from '../../../lib/orders';
-import { updateOrderStatus } from '../../../lib/orders';
+import { getOrderByUuid, updateOrderStatus } from '../../../lib/orders';
 import { sendOrderStatusUpdate } from '../../../lib/email';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const { id } = req.query;
-    if (!id) {
-      return res.status(400).json({ message: 'id required' });
+    const { uuid } = req.query;
+    if (!uuid) {
+      return res.status(400).json({ message: 'uuid required' });
     }
 
     if (req.method === 'GET') {
-      const result = await getOrderById(String(id));
+      const result = await getOrderByUuid(String(uuid));
       if (!result) return res.status(404).json({ message: 'Not found' });
       const { userEmail, ...order } = result;
       return res.status(200).json(order);
@@ -24,8 +23,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       if (!status || !['pending', 'shipped', 'completed'].includes(status)) {
         return res.status(400).json({ message: 'invalid status' });
       }
-      await updateOrderStatus(String(id), status);
-      const result = await getOrderById(String(id));
+      await updateOrderStatus(String(uuid), status);
+      const result = await getOrderByUuid(String(uuid));
       if (!result) return res.status(404).json({ message: 'Not found' });
       const { userEmail, ...order } = result;
       await sendOrderStatusUpdate(userEmail, order);

--- a/pages/api/products/[uuid].ts
+++ b/pages/api/products/[uuid].ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getProductById, getAverageRating } from '../../../lib/db.js';
+import { getProductByUuid, getAverageRating } from '../../../lib/db.js';
 import { mapDbRowToProduct } from '../../../lib/products.js';
 import { Product } from '../../../types/product';
 import { handleApiError } from '../../../lib/utils/handleApiError';
@@ -13,17 +13,17 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ProductResponse | { message: string }>
 ) {
-  const { id } = req.query;
-  if (!id) {
-    return res.status(400).json({ message: 'id required' });
+  const { uuid } = req.query;
+  if (!uuid) {
+    return res.status(400).json({ message: 'uuid required' });
   }
   try {
-    const row = await getProductById(String(id));
+    const row = await getProductByUuid(String(uuid));
     if (!row) {
       return res.status(404).json({ message: 'Not found' });
     }
     const product = mapDbRowToProduct(row) as Product;
-    const stats = getAverageRating(String(id));
+    const stats = getAverageRating(String(uuid));
     res.status(200).json({
       ...product,
       AVERAGE_RATING: stats.average,

--- a/pages/api/products/[uuid]/reviews.ts
+++ b/pages/api/products/[uuid]/reviews.ts
@@ -13,15 +13,15 @@ export default async function handler(
   res: NextApiResponse<ReviewsResponse | ReviewAddedResponse | { message: string }>
 ) {
   const {
-    query: { id },
+    query: { uuid },
     method,
   } = req;
   try {
-    if (!id) return res.status(400).json({ message: 'id required' });
+    if (!uuid) return res.status(400).json({ message: 'uuid required' });
 
     if (method === 'GET') {
-      const reviews = getReviewsForProduct(String(id)) as Review[];
-      const stats = getAverageRating(String(id));
+      const reviews = getReviewsForProduct(String(uuid)) as Review[];
+      const stats = getAverageRating(String(uuid));
       return res.status(200).json({
         reviews,
         averageRating: stats.average,
@@ -43,12 +43,12 @@ export default async function handler(
         return res.status(400).json({ message: 'rating 1-5 required' });
       }
       addReview({
-        productId: String(id),
+        productId: String(uuid),
         userEmail: session.user.email!,
         rating: r,
         comment,
       });
-      const stats = getAverageRating(String(id));
+      const stats = getAverageRating(String(uuid));
       return res.status(201).json({
         message: 'review added',
         averageRating: stats.average,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ enum Role {
 
 model User {
   id                Int       @id @default(autoincrement())
+  uuid              String    @unique @default(uuid())
   email             String    @unique
   password          String
   firstName         String
@@ -47,6 +48,7 @@ model User {
 
 model Category {
   id        Int       @id @default(autoincrement())
+  uuid      String    @unique @default(uuid())
   name      String
   slug      String    @unique
   createdAt DateTime  @default(now())
@@ -58,6 +60,7 @@ model Category {
 
 model Product {
   id          Int       @id @default(autoincrement())
+  uuid        String    @unique @default(uuid())
   slug        String    @unique
   title       String
   description String
@@ -81,6 +84,7 @@ model Product {
 
 model Order {
   id        Int       @id @default(autoincrement())
+  uuid      String    @unique @default(uuid())
   userId    Int
   productId Int
   quantity  Int
@@ -95,6 +99,7 @@ model Order {
 
 model DeletionRequest {
   id        Int       @id @default(autoincrement())
+  uuid      String    @unique @default(uuid())
   categoryId Int
   brandId   Int
   reason    String?
@@ -108,6 +113,7 @@ model DeletionRequest {
 
 model SearchLog {
   id        Int       @id @default(autoincrement())
+  uuid      String    @unique @default(uuid())
   userId    Int?
   query     String
   createdAt DateTime  @default(now())

--- a/types/brand.ts
+++ b/types/brand.ts
@@ -1,5 +1,6 @@
 export interface Brand {
   id?: number | string;
+  uuid?: string;
   name: string;
   slug?: string;
   logo?: string;

--- a/types/category.ts
+++ b/types/category.ts
@@ -1,5 +1,6 @@
 export interface Category {
   id?: number;
+  uuid?: string;
   name: string;
   slug?: string;
   parentId?: number | null;

--- a/types/coupon.ts
+++ b/types/coupon.ts
@@ -1,5 +1,6 @@
 export interface Coupon {
   id?: string | number;
+  uuid?: string;
   code: string;
   discountType: 'percent' | 'amount';
   value: number;

--- a/types/order.ts
+++ b/types/order.ts
@@ -6,6 +6,7 @@ export interface OrderItem extends Product {
 
 export interface Order {
   id: number;
+  uuid?: string;
   userId: number;
   items: OrderItem[];
   total: number;
@@ -28,6 +29,7 @@ export interface OrderInput {
 
 export interface OrderRow {
   id: number;
+  uuid?: string;
   userId: number;
   user: {
     id: number;

--- a/types/product.ts
+++ b/types/product.ts
@@ -1,5 +1,6 @@
 export interface Product {
   id: string;
+  uuid?: string;
   slug: string;
   title: string;
   vendor?: string;
@@ -49,6 +50,7 @@ export interface ProductInput {
 
 export interface ProductDbRow {
   id: number;
+  uuid?: string;
   slug: string | null;
   title: string;
   vendorId?: number | undefined;

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,5 +1,6 @@
 export interface User {
   id?: string | number;
+  uuid?: string;
   email: string;
   firstName?: string;
   lastName?: string;

--- a/types/vendor.ts
+++ b/types/vendor.ts
@@ -1,5 +1,6 @@
 export interface Vendor {
   id?: number;
+  uuid?: string;
   name?: string;
   email: string;
   company?: string;


### PR DESCRIPTION
## Summary
- add UUIDs to Prisma schema models
- expose `uuid` field in TypeScript types
- provide helpers to fetch records by UUID
- update product and order endpoints to use UUIDs
- refactor admin routes for UUID aware mutations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68565dd9a908832f9b4fd741402cddb2