### PR TITLE
Add SKU field to Product model

### DIFF
--- a/lib/products.ts
+++ b/lib/products.ts
@@ -21,13 +21,7 @@ const stripHtml = (html: string | null | undefined): string => {
 
 function processProductRow(row: Record<string, unknown>): Product {
   const processed: Record<string, unknown> & Partial<Product> = { ...row };
-  const jsonFields = [
-    'SEO',
-    'OPTIONS',
-    'VARIANTS',
-    'priceRange',
-    'METAFIELDS',
-  ];
+  const jsonFields = ['SEO', 'OPTIONS', 'VARIANTS', 'priceRange', 'METAFIELDS'];
   jsonFields.forEach((field) => {
     if (processed[field]) {
       try {
@@ -45,20 +39,37 @@ function processProductRow(row: Record<string, unknown>): Product {
     }
   });
 
-  processed.descriptionText = stripHtml(processed.description as string | null | undefined);
-  processed.bodyHtmlText = stripHtml(processed.bodyHtml as string | null | undefined);
+  processed.descriptionText = stripHtml(
+    processed.description as string | null | undefined
+  );
+  processed.bodyHtmlText = stripHtml(
+    processed.bodyHtml as string | null | undefined
+  );
   processed.minPrice = processed.priceRange?.minVariantPrice?.amount || 0;
   processed.maxPrice = processed.priceRange?.maxVariantPrice?.amount || 0;
-  processed.currency = processed.priceRange?.minVariantPrice?.currencyCode || 'GBP';
+  processed.currency =
+    processed.priceRange?.minVariantPrice?.currencyCode || 'GBP';
   const meta = processed.METAFIELDS as
-    | { stoked_inventory_sold_count?: { value?: string }; yotpo_reviews_count?: { value?: string }; yotpo_reviews_average?: { value?: string } }
+    | {
+        stoked_inventory_sold_count?: { value?: string };
+        yotpo_reviews_count?: { value?: string };
+        yotpo_reviews_average?: { value?: string };
+      }
     | undefined;
-  processed.soldCount = parseInt(meta?.stoked_inventory_sold_count?.value ?? '0', 10);
+  processed.soldCount = parseInt(
+    meta?.stoked_inventory_sold_count?.value ?? '0',
+    10
+  );
   processed.reviewCount = parseInt(meta?.yotpo_reviews_count?.value ?? '0', 10);
-  processed.averageRating = parseFloat(meta?.yotpo_reviews_average?.value ?? '0');
+  processed.averageRating = parseFloat(
+    meta?.yotpo_reviews_average?.value ?? '0'
+  );
   processed.id = String(processed.id);
   if (processed.slug) {
     processed.slug = String(processed.slug);
+  }
+  if (processed.sku) {
+    processed.sku = String(processed.sku);
   }
   if (processed.images && processed.images.length > 0) {
     processed.featuredImage = { url: processed.images[0] };
@@ -78,6 +89,7 @@ async function loadProductsData(): Promise<Product[]> {
       processProductRow({
         id: row.id,
         slug: row.slug,
+        sku: row.sku,
         title: row.title,
         vendor: row.vendor?.brandName ?? String(row.vendorId),
         description: row.description,
@@ -108,6 +120,7 @@ export function mapDbRowToProduct(row: Record<string, unknown>): Product {
   return processProductRow({
     id: row.id,
     slug: row.slug,
+    sku: row.sku,
     title: row.title,
     vendor: row.vendor,
     description: row.description,
@@ -129,7 +142,10 @@ export function mapDbRowToProduct(row: Record<string, unknown>): Product {
   });
 }
 
-export async function loadAndIndexProducts(): Promise<{ products: Product[]; productIndex: null }> {
+export async function loadAndIndexProducts(): Promise<{
+  products: Product[];
+  productIndex: null;
+}> {
   // Legacy function name preserved for API routes.
   const products = await loadProductsData();
   return { products, productIndex: null };
@@ -137,13 +153,16 @@ export async function loadAndIndexProducts(): Promise<{ products: Product[]; pro
 
 export async function addProduct(product: Product): Promise<void> {
   const db = getDb();
-  const vendor = await db.user.findFirst({ where: { brandName: String(product.vendor) } });
+  const vendor = await db.user.findFirst({
+    where: { brandName: String(product.vendor) },
+  });
   const category = product.category
     ? await db.category.findFirst({ where: { name: product.category } })
     : null;
   const data: any = {
     id: Number(product.id),
     slug: product.slug,
+    sku: product.sku,
     title: product.title,
     description: product.description ?? '',
     productType: product.productType ?? '',
@@ -176,6 +195,7 @@ export async function updateProduct(product: Product): Promise<void> {
   await db.product.update({
     where: { id: Number(product.id) },
     data: {
+      sku: product.sku,
       title: product.title,
       description: product.description,
       productType: product.productType,
@@ -201,6 +221,7 @@ export async function getPendingProducts(): Promise<Product[]> {
     processProductRow({
       id: row.id,
       slug: row.slug,
+      sku: row.sku,
       title: row.title,
       vendor: row.vendor?.brandName ?? String(row.vendorId),
       description: row.description,
@@ -219,12 +240,18 @@ export async function getPendingProducts(): Promise<Product[]> {
 
 export async function approveProduct(id: string | number): Promise<void> {
   const db = getDb();
-  await db.product.update({ where: { id: Number(id) }, data: { status: 'approved' } });
+  await db.product.update({
+    where: { id: Number(id) },
+    data: { status: 'approved' },
+  });
 }
 
 export async function rejectProduct(id: string | number): Promise<void> {
   const db = getDb();
-  await db.product.update({ where: { id: Number(id) }, data: { status: 'rejected' } });
+  await db.product.update({
+    where: { id: Number(id) },
+    data: { status: 'rejected' },
+  });
 }
 
 export async function getCategoriesFlat(): Promise<Category[]> {
@@ -232,10 +259,15 @@ export async function getCategoriesFlat(): Promise<Category[]> {
   return db.category.findMany({ orderBy: { name: 'asc' } });
 }
 
-export async function getCategoryTree(): Promise<{ name: string; subcategories: string[]; image?: string }[]> {
+export async function getCategoryTree(): Promise<
+  { name: string; subcategories: string[]; image?: string }[]
+> {
   const flat = await getCategoriesFlat();
   if (flat.length > 0) {
-    const map: Record<number, { name: string; image?: string; subcategories: string[] }> = {};
+    const map: Record<
+      number,
+      { name: string; image?: string; subcategories: string[] }
+    > = {};
     flat.forEach((c) => {
       if (typeof c.id === 'number') {
         map[c.id] = { name: c.name, image: c.image, subcategories: [] };
@@ -280,7 +312,9 @@ export async function createCategory(
   const db = getDb();
   const existing = await db.category.findFirst({ where: { name } });
   if (existing) return;
-  await db.category.create({ data: { name, slug: name.toLowerCase().replace(/\s+/g, '-') } });
+  await db.category.create({
+    data: { name, slug: name.toLowerCase().replace(/\s+/g, '-') },
+  });
 }
 
 export async function renameCategory(

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, useContext, useCallback, ChangeEvent } from 'react';
+import {
+  useState,
+  useEffect,
+  useContext,
+  useCallback,
+  ChangeEvent,
+} from 'react';
 import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
 import { Product, ApiMessage } from '../../types';
@@ -9,6 +15,7 @@ export default function Admin() {
   type FormState = Partial<Product>;
   const emptyForm: FormState = {
     id: '',
+    sku: '',
     title: '',
     vendor: '',
     description: '',
@@ -67,6 +74,7 @@ export default function Admin() {
   const handleEdit = (p: Product) => {
     setForm({
       id: p.id,
+      sku: p.sku || '',
       title: p.title || '',
       vendor: p.vendor || '',
       description: p.description || '',
@@ -130,6 +138,7 @@ export default function Admin() {
             <form onSubmit={submit} className="space-y-2">
               {[
                 'id',
+                'sku',
                 'title',
                 'vendor',
                 'description',
@@ -197,7 +206,7 @@ export default function Admin() {
         {products.map((p) => (
           <li key={p.id} className="flex justify-between items-center">
             <span>
-              {p.title} - {p.productType}
+              {p.title} - {p.productType} (SKU: {p.sku})
             </span>
             <button
               type="button"

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -57,47 +57,60 @@ async function handler(
       const {
         id,
         title,
+        sku,
         vendor,
         description,
         product_type,
-      tags,
-      category,
-      quantity,
-      min_price,
-      max_price,
-      currency,
+        tags,
+        category,
+        quantity,
+        min_price,
+        max_price,
+        currency,
       } = fields as Record<string, any>;
-      if (!id || !title) {
-        return res.status(400).json({ message: 'id and title are required' });
+      if (!id || !title || !sku) {
+        return res
+          .status(400)
+          .json({ message: 'id, title and sku are required' });
       }
-    const photos = files.photos
-      ? Array.isArray(files.photos)
-        ? files.photos
-        : [files.photos]
-      : [];
+      const photos = files.photos
+        ? Array.isArray(files.photos)
+          ? files.photos
+          : [files.photos]
+        : [];
       const destDir = path.join(process.cwd(), 'public', 'uploads', String(id));
       fs.mkdirSync(destDir, { recursive: true });
-    const imagePaths = [];
-    for (const file of photos) {
-      const name = Date.now() + '-' + file.originalFilename;
-      const destPath = path.join(destDir, name);
-      fs.renameSync(file.filepath, destPath);
-      imagePaths.push(`/uploads/${id}/${name}`);
-    }
+      const imagePaths = [];
+      for (const file of photos) {
+        const name = Date.now() + '-' + file.originalFilename;
+        const destPath = path.join(destDir, name);
+        fs.renameSync(file.filepath, destPath);
+        imagePaths.push(`/uploads/${id}/${name}`);
+      }
       let existing = null;
       if (req.method === 'PUT') {
         existing = await db.product.findUnique({ where: { id: Number(id) } });
         if (!existing) {
           return res.status(404).json({ message: 'Not found' });
         }
-        const existingImages = existing.images ? JSON.parse(existing.images) : [];
+        const existingImages = existing.images
+          ? JSON.parse(existing.images)
+          : [];
         imagePaths.push(...existingImages);
+      }
+      const existingSku = await db.product.findUnique({ where: { sku } });
+      if (
+        existingSku &&
+        (req.method === 'POST' || existingSku.id !== Number(id))
+      ) {
+        return res.status(400).json({ message: 'sku must be unique' });
       }
       const slug = slugify(title || (existing?.title as string) || String(id));
       const qty = quantity ? parseInt(String(quantity), 10) : 0;
       const data: Record<string, unknown> = {
         id: Number(id),
         slug,
+        sku,
         title,
         description: description || '',
         productType: product_type || '',
@@ -114,7 +127,9 @@ async function handler(
         const vid = parseInt(String(vendor), 10);
         if (!isNaN(vid)) data.vendorId = vid;
         else {
-          const v = await db.user.findFirst({ where: { brandName: String(vendor) } });
+          const v = await db.user.findFirst({
+            where: { brandName: String(vendor) },
+          });
           if (v) data.vendorId = v.id;
         }
       }
@@ -123,7 +138,9 @@ async function handler(
         const cid = parseInt(String(category), 10);
         if (!isNaN(cid)) data.categoryId = cid;
         else {
-          const c = await db.category.findFirst({ where: { name: String(category) } });
+          const c = await db.category.findFirst({
+            where: { name: String(category) },
+          });
           if (c) data.categoryId = c.id;
         }
       }
@@ -142,7 +159,9 @@ async function handler(
       if (!id) {
         return res.status(400).json({ message: 'id required' });
       }
-      const existing = await db.product.findUnique({ where: { id: Number(id) } });
+      const existing = await db.product.findUnique({
+        where: { id: Number(id) },
+      });
       if (!existing) {
         return res.status(404).json({ message: 'Not found' });
       }
@@ -166,6 +185,7 @@ async function handler(
       const data: Product[] = rows.map((p) => ({
         ID: String(p.id),
         SLUG: p.slug,
+        SKU: p.sku,
         TITLE: p.title,
         VENDOR: p.vendor?.brandName ?? String(p.vendorId),
         DESCRIPTION: p.description,
@@ -194,5 +214,4 @@ async function handler(
   }
 }
 
-
-export default withRole(['BRAND','SUPER_ADMIN'])(handler);
+export default withRole(['BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/api/brand/products/[id].ts
+++ b/pages/api/brand/products/[id].ts
@@ -1,10 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { updateProduct, deleteProduct, loadAndIndexProducts } from '../../../../lib/products';
-import { getProductById } from '../../../../lib/db';
+import {
+  updateProduct,
+  deleteProduct,
+  loadAndIndexProducts,
+} from '../../../../lib/products';
+import { getProductById, getDb } from '../../../../lib/db';
 import { hasOrdersForProduct } from '../../../../lib/orders';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   try {
     const { id } = req.query;
     if (!id) return res.status(400).json({ message: 'id required' });
@@ -14,32 +21,48 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (!existing) return res.status(404).json({ message: 'Not found' });
       const {
         title,
+        sku,
         vendor,
         description,
         product_type,
-      tags,
-      category,
-      quantity,
-      min_price,
-      max_price,
-      currency,
-    } = req.body || {};
-    await updateProduct({
-      id: String(id),
-      title: title ?? existing.title,
-      vendor: vendor ?? existing.vendor,
-      description: description ?? existing.description,
-      product_type: product_type ?? existing.product_type,
-      tags: tags ?? existing.tags,
-      category: category ?? existing.category,
-      quantity:
-        typeof quantity !== 'undefined' ? parseInt(quantity, 10) : existing.quantity,
-      min_price: typeof min_price !== 'undefined' ? parseFloat(min_price) : existing.min_price,
-      max_price: typeof max_price !== 'undefined' ? parseFloat(max_price) : existing.max_price,
-      currency: currency ?? existing.currency,
-      status: existing.status,
-      images: existing.images,
-    });
+        tags,
+        category,
+        quantity,
+        min_price,
+        max_price,
+        currency,
+      } = req.body || {};
+      const db = getDb();
+      if (sku && sku !== existing.sku) {
+        const exists = await db.product.findUnique({ where: { sku } });
+        if (exists)
+          return res.status(400).json({ message: 'sku must be unique' });
+      }
+      await updateProduct({
+        id: String(id),
+        title: title ?? existing.title,
+        vendor: vendor ?? existing.vendor,
+        description: description ?? existing.description,
+        product_type: product_type ?? existing.product_type,
+        tags: tags ?? existing.tags,
+        category: category ?? existing.category,
+        quantity:
+          typeof quantity !== 'undefined'
+            ? parseInt(quantity, 10)
+            : existing.quantity,
+        min_price:
+          typeof min_price !== 'undefined'
+            ? parseFloat(min_price)
+            : existing.min_price,
+        max_price:
+          typeof max_price !== 'undefined'
+            ? parseFloat(max_price)
+            : existing.max_price,
+        currency: currency ?? existing.currency,
+        sku: sku ?? existing.sku,
+        status: existing.status,
+        images: existing.images,
+      });
       await loadAndIndexProducts();
       return res.status(200).json({ message: 'product updated' });
     }
@@ -48,7 +71,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const existing = await getProductById(String(id));
       if (!existing) return res.status(404).json({ message: 'Not found' });
       if (existing.quantity > 0 || hasOrdersForProduct(String(id))) {
-        return res.status(400).json({ message: 'cannot delete product with stock or orders' });
+        return res
+          .status(400)
+          .json({ message: 'cannot delete product with stock or orders' });
       }
       await deleteProduct(String(id));
       await loadAndIndexProducts();

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { addProduct, loadAndIndexProducts } from '../../../../lib/products';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
+import { getDb } from '../../../../lib/db';
 
 function slugify(text) {
   return text
@@ -11,7 +12,10 @@ function slugify(text) {
     .replace(/-+/g, '-');
 }
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   try {
     if (req.method === 'GET') {
       const { vendor } = req.query;
@@ -25,34 +29,43 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const {
         id,
         title,
+        sku,
         vendor,
         description,
-      product_type,
-      tags,
-      category,
-      quantity,
-      min_price,
-      max_price,
-      currency,
-    } = req.body || {};
-    if (!id || !title || !vendor) {
-      return res.status(400).json({ message: 'id, title, vendor required' });
-    }
-    await addProduct({
-      id: String(id),
-      slug: slugify(title || String(id)),
-      title,
-      vendor,
-      description,
-      product_type,
-      tags,
-      category,
-      quantity: quantity ? parseInt(quantity, 10) : 0,
-      min_price: parseFloat(min_price || 0),
-      max_price: parseFloat(max_price || 0),
-      currency: currency || 'USD',
-      status: 'approved',
-      images: JSON.stringify([]),
+        product_type,
+        tags,
+        category,
+        quantity,
+        min_price,
+        max_price,
+        currency,
+      } = req.body || {};
+      if (!id || !title || !vendor || !sku) {
+        return res
+          .status(400)
+          .json({ message: 'id, title, vendor, sku required' });
+      }
+      const db = getDb();
+      const existingSku = await db.product.findUnique({ where: { sku } });
+      if (existingSku) {
+        return res.status(400).json({ message: 'sku must be unique' });
+      }
+      await addProduct({
+        id: String(id),
+        slug: slugify(title || String(id)),
+        sku,
+        title,
+        vendor,
+        description,
+        product_type,
+        tags,
+        category,
+        quantity: quantity ? parseInt(quantity, 10) : 0,
+        min_price: parseFloat(min_price || 0),
+        max_price: parseFloat(max_price || 0),
+        currency: currency || 'USD',
+        status: 'approved',
+        images: JSON.stringify([]),
       });
       await loadAndIndexProducts();
       return res.status(201).json({ message: 'product created' });

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useEffect, useContext, useCallback, ChangeEvent, FormEvent } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useContext,
+  useCallback,
+  ChangeEvent,
+  FormEvent,
+} from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import type { User } from '../../types/user';
 
@@ -6,9 +13,9 @@ type ProductForm = Partial<Product>;
 
 type ProductApi = Product;
 
-
 const emptyForm: ProductForm = {
   id: '',
+  sku: '',
   title: '',
   vendor: '',
   description: '',
@@ -73,6 +80,7 @@ const BrandDashboard: React.FC = () => {
       body: JSON.stringify({
         id: payload.id,
         title: payload.title,
+        sku: payload.sku,
         vendor: payload.vendor,
         description: payload.description,
         product_type: payload.productType,
@@ -98,6 +106,7 @@ const BrandDashboard: React.FC = () => {
   const handleEdit = (p: ProductApi) => {
     setForm({
       id: p.id,
+      sku: p.sku || '',
       title: p.title || '',
       vendor: p.vendor || '',
       description: p.description || '',
@@ -148,6 +157,7 @@ const BrandDashboard: React.FC = () => {
         {(
           [
             'id',
+            'sku',
             'title',
             'vendor',
             'description',
@@ -196,7 +206,7 @@ const BrandDashboard: React.FC = () => {
         {products.map((p) => (
           <li key={p.id} className="flex justify-between items-center gap-2">
             <span>
-              {p.title} - {p.category || p.productType}
+              {p.title} - {p.category || p.productType} (SKU: {p.sku})
             </span>
             <div className="flex gap-2">
               <button

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -5,10 +5,13 @@ import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { AppContext } from '../../contexts/AppContext';
 import ProductImageSlider from '../../components/ProductImageSlider';
 import RecommendedProducts from '../../components/RecommendedProducts';
-import { getProductBySlug, getReviewsForProduct, getAverageRating } from '../../lib/db';
+import {
+  getProductBySlug,
+  getReviewsForProduct,
+  getAverageRating,
+} from '../../lib/db';
 import { mapDbRowToProduct } from '../../lib/products';
 import { Product, Review } from '../../types';
-
 
 type ProductDetailProps = {
   product: Product;
@@ -18,7 +21,9 @@ type ProductDetailProps = {
 };
 
 // --- getServerSideProps ---
-export const getServerSideProps: GetServerSideProps<ProductDetailProps> = async (context: GetServerSidePropsContext) => {
+export const getServerSideProps: GetServerSideProps<
+  ProductDetailProps
+> = async (context: GetServerSidePropsContext) => {
   const { params } = context;
   if (!params || typeof params.slug !== 'string') {
     return { notFound: true };
@@ -57,22 +62,31 @@ export default function ProductDetail({
 
   useEffect(() => {
     try {
-      const stored: string[] = JSON.parse(localStorage.getItem('browse-history') || '[]');
+      const stored: string[] = JSON.parse(
+        localStorage.getItem('browse-history') || '[]'
+      );
       const updated = [id, ...stored.filter((v) => v !== id)];
-      localStorage.setItem('browse-history', JSON.stringify(updated.slice(0, 20)));
+      localStorage.setItem(
+        'browse-history',
+        JSON.stringify(updated.slice(0, 20))
+      );
     } catch {
       // ignore
     }
   }, [id]);
 
   if (!appCtx) return null;
-  const { addToCart, addToWishlist, removeFromWishlist, wishlist, user } = appCtx;
+  const { addToCart, addToWishlist, removeFromWishlist, wishlist, user } =
+    appCtx;
 
   return (
     <div className="p-6 max-w-screen-2xl mx-auto bg-base-100 rounded-box shadow-md min-h-screen">
       <Head>
         <title>{product.title} - Product</title>
-        <meta name="description" content={product.descriptionText?.slice(0, 150)} />
+        <meta
+          name="description"
+          content={product.descriptionText?.slice(0, 150)}
+        />
       </Head>
       <div className="flex flex-col md:flex-row gap-8">
         <div className="md:w-1/2 flex justify-center">
@@ -82,8 +96,8 @@ export default function ProductDetail({
               product.images && product.images.length > 0
                 ? product.images
                 : product.featuredImage?.url
-                ? [product.featuredImage.url]
-                : []
+                  ? [product.featuredImage.url]
+                  : []
             }
             imgClass="hover:scale-110 transition"
           />
@@ -91,9 +105,12 @@ export default function ProductDetail({
         <div className="md:w-1/2">
           <h1 className="text-2xl font-bold mb-4">{product.title}</h1>
           <p className="mb-2">Vendor: {product.vendor}</p>
+          <p className="mb-2">SKU: {product.sku}</p>
           <p className="mb-2">Type: {product.productType}</p>
           <p className="mb-4">
-            {product.descriptionText || product.bodyHtmlText || 'No description available.'}
+            {product.descriptionText ||
+              product.bodyHtmlText ||
+              'No description available.'}
           </p>
           <p className="text-lg font-bold mb-4">
             {product.currency}{' '}
@@ -171,7 +188,9 @@ export default function ProductDetail({
               <label className="mr-2">Rating</label>
               <select
                 value={myRating}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setMyRating(parseInt(e.target.value))}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                  setMyRating(parseInt(e.target.value))
+                }
                 className="select select-bordered"
               >
                 {[1, 2, 3, 4, 5].map((n) => (
@@ -184,10 +203,15 @@ export default function ProductDetail({
             <textarea
               className="textarea textarea-bordered w-full"
               value={comment}
-              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setComment(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                setComment(e.target.value)
+              }
               placeholder="Write a review"
             />
-            <button className="btn btn-sm btn-primary transition-all duration-200" type="submit">
+            <button
+              className="btn btn-sm btn-primary transition-all duration-200"
+              type="submit"
+            >
               Submit Review
             </button>
           </form>

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -5,7 +5,11 @@ import Link from 'next/link';
 import Head from 'next/head';
 import ProductImageSlider from '../../components/ProductImageSlider';
 import type { Product } from '../../types';
-import type { Review, ReviewsResponse, ReviewAddedResponse } from '../../types/review';
+import type {
+  Review,
+  ReviewsResponse,
+  ReviewAddedResponse,
+} from '../../types/review';
 
 interface ProductDetailProps {}
 
@@ -22,7 +26,8 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
   const [myRating, setMyRating] = useState<number>(5);
   const [comment, setComment] = useState<string>('');
 
-  const { addToCart, addToWishlist, removeFromWishlist, wishlist, user } = appContext ?? {};
+  const { addToCart, addToWishlist, removeFromWishlist, wishlist, user } =
+    appContext ?? {};
 
   useEffect(() => {
     if (!id) return;
@@ -100,6 +105,7 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
         />
       </div>
       <p className="mb-2">Vendor: {product.vendor}</p>
+      <p className="mb-2">SKU: {product.sku}</p>
       <p className="mb-2">Type: {product.productType}</p>
       <p className="mb-4">
         {product.descriptionText ||
@@ -110,7 +116,9 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
         {product.currency || ''}{' '}
         {product.minPrice ? product.minPrice.toFixed(2) : 'N/A'}
       </p>
-      <p className="mb-2">Rating: {averageRating.toFixed(1)} ({reviewCount})</p>
+      <p className="mb-2">
+        Rating: {averageRating.toFixed(1)} ({reviewCount})
+      </p>
       <div className="flex gap-2">
         <button
           className="btn btn-primary"
@@ -127,7 +135,11 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
             Remove Wishlist
           </button>
         ) : (
-          <button className="btn" onClick={() => addToWishlist?.(product)} disabled={!addToWishlist}>
+          <button
+            className="btn"
+            onClick={() => addToWishlist?.(product)}
+            disabled={!addToWishlist}
+          >
             Add Wishlist
           </button>
         )}
@@ -172,18 +184,24 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
               <label className="mr-2">Rating</label>
               <select
                 value={myRating}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setMyRating(parseInt(e.target.value))}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                  setMyRating(parseInt(e.target.value))
+                }
                 className="select select-bordered"
               >
                 {[1, 2, 3, 4, 5].map((n) => (
-                  <option key={n} value={n}>{n}</option>
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
                 ))}
               </select>
             </div>
             <textarea
               className="textarea textarea-bordered w-full"
               value={comment}
-              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setComment(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                setComment(e.target.value)
+              }
               placeholder="Write a review"
             />
             <button className="btn btn-sm btn-primary" type="submit">

--- a/pages/vendor/index.tsx
+++ b/pages/vendor/index.tsx
@@ -14,6 +14,7 @@ export default function VendorDashboard() {
   type FormState = Partial<Product>;
   const emptyForm: FormState = {
     id: '',
+    sku: '',
     title: '',
     vendor: '',
     description: '',
@@ -57,6 +58,7 @@ export default function VendorDashboard() {
       body: JSON.stringify({
         id: payload.id,
         title: payload.title,
+        sku: payload.sku,
         vendor: payload.vendor,
         description: payload.description,
         product_type: payload.productType,
@@ -82,6 +84,7 @@ export default function VendorDashboard() {
   const handleEdit = (p: Product) => {
     setForm({
       id: p.id,
+      sku: p.sku || '',
       title: p.title || '',
       vendor: p.vendor || '',
       description: p.description || '',
@@ -126,6 +129,7 @@ export default function VendorDashboard() {
       <form onSubmit={submit} className="space-y-2 mb-6">
         {[
           'id',
+          'sku',
           'title',
           'vendor',
           'description',
@@ -166,7 +170,7 @@ export default function VendorDashboard() {
         {products.map((p) => (
           <li key={p.id} className="flex justify-between items-center gap-2">
             <span>
-              {p.title} - {p.category || p.productType}
+              {p.title} - {p.category || p.productType} (SKU: {p.sku})
             </span>
             <div className="flex gap-2">
               <button

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model Category {
 model Product {
   id          Int       @id @default(autoincrement())
   slug        String    @unique
+  sku         String    @unique
   title       String
   description String
   productType String

--- a/types/product.ts
+++ b/types/product.ts
@@ -1,6 +1,7 @@
 export interface Product {
   id: string;
   slug: string;
+  sku: string;
   title: string;
   vendor?: string;
   description?: string;
@@ -36,6 +37,7 @@ export interface Product {
 export type ProductResponse = Product;
 
 export interface ProductInput {
+  sku?: string;
   title: string;
   description?: string;
   vendor?: string;
@@ -50,6 +52,7 @@ export interface ProductInput {
 export interface ProductDbRow {
   id: number;
   slug: string | null;
+  sku: string | null;
   title: string;
   vendorId?: number | undefined;
   vendor?: { brandName: string | null } | null;


### PR DESCRIPTION
## Summary
- add `sku` to Prisma Product model
- expose sku in `Product` TypeScript definitions
- handle sku on product CRUD API routes
- display sku in admin and brand dashboards, vendor dashboard, and product pages
- add sku processing in product helpers

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68565de77770832faf586da6f7e7bcfe