### PR TITLE
Add SKU to Product model and update types

### DIFF
--- a/lib/products.ts
+++ b/lib/products.ts
@@ -82,6 +82,7 @@ async function loadProductsData(): Promise<Product[]> {
         id: row.id,
         uuid: row.uuid,
         slug: row.slug,
+        sku: row.sku,
         title: row.title,
         vendor: row.vendor?.brandName ?? String(row.vendorId),
         description: row.description,
@@ -113,6 +114,7 @@ export function mapDbRowToProduct(row: Record<string, unknown>): Product {
     id: row.id,
     uuid: row.uuid,
     slug: row.slug,
+    sku: row.sku,
     title: row.title,
     vendor: row.vendor,
     description: row.description,
@@ -150,6 +152,7 @@ export async function addProduct(product: Product): Promise<void> {
     id: product.id ? Number(product.id) : undefined,
     uuid: product.uuid ?? undefined,
     slug: product.slug,
+    sku: product.sku,
     title: product.title,
     description: product.description ?? '',
     productType: product.productType ?? '',
@@ -182,6 +185,7 @@ export async function updateProduct(product: Product): Promise<void> {
   await db.product.update({
     where: { uuid: product.uuid || String(product.id) },
     data: {
+      sku: product.sku,
       title: product.title,
       description: product.description,
       productType: product.productType,
@@ -207,6 +211,7 @@ export async function getPendingProducts(): Promise<Product[]> {
     processProductRow({
       id: row.id,
       slug: row.slug,
+      sku: row.sku,
       title: row.title,
       vendor: row.vendor?.brandName ?? String(row.vendorId),
       description: row.description,

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -9,6 +9,7 @@ export default function Admin() {
   type FormState = Partial<Product>;
   const emptyForm: FormState = {
     id: '',
+    sku: '',
     title: '',
     vendor: '',
     description: '',
@@ -65,8 +66,9 @@ export default function Admin() {
   };
 
   const handleEdit = (p: Product) => {
-    setForm({
+      setForm({
       id: p.id,
+      sku: p.sku || '',
       title: p.title || '',
       vendor: p.vendor || '',
       description: p.description || '',
@@ -130,6 +132,7 @@ export default function Admin() {
             <form onSubmit={submit} className="space-y-2">
               {[
                 'id',
+                'sku',
                 'title',
                 'vendor',
                 'description',
@@ -197,7 +200,7 @@ export default function Admin() {
         {products.map((p) => (
           <li key={p.id} className="flex justify-between items-center">
             <span>
-              {p.title} - {p.productType}
+              {p.title} ({p.sku}) - {p.productType}
             </span>
             <button
               type="button"

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -56,6 +56,7 @@ async function handler(
       const { fields, files } = await parseBody(req);
       const {
         id,
+        sku,
         title,
         vendor,
         description,
@@ -67,8 +68,10 @@ async function handler(
       max_price,
       currency,
       } = fields as Record<string, any>;
-      if (!id || !title) {
-        return res.status(400).json({ message: 'id and title are required' });
+      if (!id || !title || !sku) {
+        return res
+          .status(400)
+          .json({ message: 'id, sku and title are required' });
       }
     const photos = files.photos
       ? Array.isArray(files.photos)
@@ -98,6 +101,7 @@ async function handler(
       const data: Record<string, unknown> = {
         id: Number(id),
         slug,
+        sku,
         title,
         description: description || '',
         productType: product_type || '',
@@ -166,6 +170,7 @@ async function handler(
       const data: Product[] = rows.map((p) => ({
         ID: String(p.id),
         SLUG: p.slug,
+        sku: p.sku,
         TITLE: p.title,
         VENDOR: p.vendor?.brandName ?? String(p.vendorId),
         DESCRIPTION: p.description,

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -14,6 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (!existing) return res.status(404).json({ message: 'Not found' });
       const {
         title,
+        sku,
         vendor,
         description,
         product_type,
@@ -26,6 +27,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     } = req.body || {};
     await updateProduct({
       id: String(uuid),
+      sku: sku ?? existing.sku,
       title: title ?? existing.title,
       vendor: vendor ?? existing.vendor,
       description: description ?? existing.description,

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -24,6 +24,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (req.method === 'POST') {
       const {
         id,
+        sku,
         title,
         vendor,
         description,
@@ -35,12 +36,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       max_price,
       currency,
     } = req.body || {};
-    if (!id || !title || !vendor) {
-      return res.status(400).json({ message: 'id, title, vendor required' });
+    if (!id || !sku || !title || !vendor) {
+      return res.status(400).json({ message: 'id, sku, title, vendor required' });
     }
     await addProduct({
       id: String(id),
       slug: slugify(title || String(id)),
+      sku,
       title,
       vendor,
       description,

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -9,6 +9,7 @@ type ProductApi = Product;
 
 const emptyForm: ProductForm = {
   id: '',
+  sku: '',
   title: '',
   vendor: '',
   description: '',
@@ -72,6 +73,7 @@ const BrandDashboard: React.FC = () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         id: payload.id,
+        sku: payload.sku,
         title: payload.title,
         vendor: payload.vendor,
         description: payload.description,
@@ -98,6 +100,7 @@ const BrandDashboard: React.FC = () => {
   const handleEdit = (p: ProductApi) => {
     setForm({
       id: p.id,
+      sku: p.sku || '',
       title: p.title || '',
       vendor: p.vendor || '',
       description: p.description || '',
@@ -148,6 +151,7 @@ const BrandDashboard: React.FC = () => {
         {(
           [
             'id',
+              'sku',
             'title',
             'vendor',
             'description',
@@ -196,7 +200,7 @@ const BrandDashboard: React.FC = () => {
         {products.map((p) => (
           <li key={p.id} className="flex justify-between items-center gap-2">
             <span>
-              {p.title} - {p.category || p.productType}
+              {p.title} ({p.sku}) - {p.category || p.productType}
             </span>
             <div className="flex gap-2">
               <button

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -91,6 +91,7 @@ export default function ProductDetail({
         <div className="md:w-1/2">
           <h1 className="text-2xl font-bold mb-4">{product.title}</h1>
           <p className="mb-2">Vendor: {product.vendor}</p>
+          <p className="mb-2">SKU: {product.sku}</p>
           <p className="mb-2">Type: {product.productType}</p>
           <p className="mb-4">
             {product.descriptionText || product.bodyHtmlText || 'No description available.'}

--- a/prisma/migrations/20250621075746_add-sku-to-product/migration.sql
+++ b/prisma/migrations/20250621075746_add-sku-to-product/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Product" ADD COLUMN "sku" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Product_sku_key" ON "Product"("sku");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ model Product {
   id          Int       @id @default(autoincrement())
   uuid        String    @unique @default(uuid())
   slug        String    @unique
+  sku         String    @unique
   title       String
   description String
   productType String

--- a/types/product.ts
+++ b/types/product.ts
@@ -4,6 +4,7 @@ export interface Product {
   id: string;
   uuid?: string;
   slug: string;
+  sku: PrismaProduct['sku'];
   title: string;
   vendor?: string;
   description?: string;
@@ -40,6 +41,7 @@ export interface Product {
 export type ProductResponse = Product;
 
 export interface ProductInput {
+  sku: PrismaProduct['sku'];
   title: string;
   description?: string;
   vendor?: string;
@@ -55,6 +57,7 @@ export interface ProductDbRow {
   id: number;
   uuid?: string;
   slug: string | null;
+  sku: PrismaProduct['sku'] | null;
   title: string;
   vendorId?: number | undefined;
   vendor?: { brandName: string | null } | null;


### PR DESCRIPTION
## Summary
- introduce `sku` field to Product schema and generate migration
- expose SKU in Prisma-based product utilities
- update admin and brand product APIs to accept `sku`
- include SKU in forms and displays for admin and brand dashboards
- show SKU on product detail pages
- extend TypeScript product types with `sku`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685665888ccc832f85dcc24e1f7c5c5d