### PR TITLE
Refactor product types

### DIFF
--- a/lib/products.ts
+++ b/lib/products.ts
@@ -64,7 +64,10 @@ function processProductRow(row: Record<string, unknown>): Product {
     processed.slug = String(processed.slug);
   }
   if (processed.images && processed.images.length > 0) {
-    processed.featuredImage = { url: processed.images[0] };
+    if (typeof processed.images[0] === 'string') {
+      processed.images = (processed.images as string[]).map((u) => ({ url: u }));
+    }
+    processed.featuredImage = processed.images[0];
   }
   return processed as Product;
 }
@@ -84,12 +87,14 @@ async function loadProductsData(): Promise<Product[]> {
         slug: row.slug,
         sku: row.sku,
         title: row.title,
-        vendor: row.vendor?.brandName ?? String(row.vendorId),
+        vendor: row.vendor ?? null,
         description: row.description,
         productType: row.productType,
         tags: row.tags,
-        category: row.category?.name,
-        images: row.images ? JSON.parse(row.images) : [],
+        category: row.category ?? null,
+        images: row.images
+          ? (JSON.parse(row.images) as string[]).map((u) => ({ url: u }))
+          : [],
         totalInventory: row.quantity,
         priceRange: {
           minVariantPrice: {
@@ -121,7 +126,9 @@ export function mapDbRowToProduct(row: Record<string, unknown>): Product {
     productType: row.product_type,
     tags: row.tags,
     category: row.category,
-    images: row.images ? JSON.parse(row.images as string) : [],
+    images: row.images
+      ? (JSON.parse(row.images as string) as string[]).map((u) => ({ url: u }))
+      : [],
     totalInventory: row.quantity,
     priceRange: {
       minVariantPrice: {
@@ -144,9 +151,11 @@ export async function loadAndIndexProducts(): Promise<{ products: Product[]; pro
 
 export async function addProduct(product: Product): Promise<void> {
   const db = getDb();
-  const vendor = await db.user.findFirst({ where: { brandName: String(product.vendor) } });
-  const category = product.category
-    ? await db.category.findFirst({ where: { name: product.category } })
+  const vendor = product.vendor?.brandName
+    ? await db.user.findFirst({ where: { brandName: product.vendor.brandName } })
+    : null;
+  const category = product.category?.name
+    ? await db.category.findFirst({ where: { name: product.category.name } })
     : null;
   const data: any = {
     id: product.id ? Number(product.id) : undefined,
@@ -176,11 +185,11 @@ export async function addProduct(product: Product): Promise<void> {
 
 export async function updateProduct(product: Product): Promise<void> {
   const db = getDb();
-  const vendor = product.vendor
-    ? await db.user.findFirst({ where: { brandName: product.vendor } })
+  const vendor = product.vendor?.brandName
+    ? await db.user.findFirst({ where: { brandName: product.vendor.brandName } })
     : null;
-  const category = product.category
-    ? await db.category.findFirst({ where: { name: product.category } })
+  const category = product.category?.name
+    ? await db.category.findFirst({ where: { name: product.category.name } })
     : null;
   await db.product.update({
     where: { uuid: product.uuid || String(product.id) },
@@ -213,12 +222,14 @@ export async function getPendingProducts(): Promise<Product[]> {
       slug: row.slug,
       sku: row.sku,
       title: row.title,
-      vendor: row.vendor?.brandName ?? String(row.vendorId),
+      vendor: row.vendor ?? null,
       description: row.description,
       productType: row.productType,
       tags: row.tags,
-      category: row.category?.name,
-      images: row.images ? JSON.parse(row.images) : [],
+      category: row.category ?? null,
+      images: row.images
+        ? (JSON.parse(row.images) as string[]).map((u) => ({ url: u }))
+        : [],
       totalInventory: row.quantity,
       priceRange: {
         minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },

--- a/types/image.ts
+++ b/types/image.ts
@@ -1,0 +1,4 @@
+export interface Image {
+  url: string;
+  alt?: string;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,3 +8,5 @@ export * from './brand';
 export * from './cart';
 export * from './vendor';
 export * from './coupon';
+export * from './image';
+export * from './price';

--- a/types/price.ts
+++ b/types/price.ts
@@ -1,0 +1,9 @@
+export interface PriceValue {
+  amount: number;
+  currencyCode: string;
+}
+
+export interface PriceRange {
+  minVariantPrice: PriceValue;
+  maxVariantPrice: PriceValue;
+}

--- a/types/product.ts
+++ b/types/product.ts
@@ -1,4 +1,9 @@
 import type { Product as PrismaProduct } from '@prisma/client';
+import type { Category } from './category';
+import type { Vendor } from './vendor';
+import type { Brand } from './brand';
+import type { Image } from './image';
+import type { PriceRange } from './price';
 
 export interface Product {
   id: string;
@@ -6,36 +11,27 @@ export interface Product {
   slug: string;
   sku: PrismaProduct['sku'];
   title: string;
-  vendor?: string;
   description?: string;
   productType?: string;
   tags?: string;
-  category?: string;
-  images?: string[];
-  totalInventory?: number;
-  priceRange?: {
-    minVariantPrice: { amount: number; currencyCode: string };
-    maxVariantPrice: { amount: number; currencyCode: string };
-  };
+  quantity?: number;
+  priceRange?: PriceRange;
+  images?: Image[];
   soldCount: number;
   reviewCount: number;
   averageRating: number;
-  featuredImage?: { url: string };
+  featuredImage?: Image;
   minPrice: number;
   maxPrice: number;
   currency: string;
   descriptionText?: string;
   bodyHtmlText?: string;
-  quantity?: number;
-  vendorId?: number;
-  categoryId?: number;
-  vendorBrandName?: string | null;
-  categoryName?: string | null;
-  imagesUrls?: string[];
-  imagesAltText?: string[];
   status?: string;
   createdAt?: Date | string;
   updatedAt?: Date | string;
+  vendor?: Vendor | string;
+  brand?: Brand | string;
+  category?: Category | string;
 }
 
 export type ProductResponse = Product;
@@ -44,11 +40,11 @@ export interface ProductInput {
   sku: PrismaProduct['sku'];
   title: string;
   description?: string;
-  vendor?: string;
+  vendor?: Vendor;
   productType?: string;
   tags?: string;
-  category?: string;
-  images?: string[];
+  category?: Category;
+  images?: Image[];
   quantity?: number;
   price?: number;
 }
@@ -59,7 +55,6 @@ export interface ProductDbRow {
   slug: string | null;
   sku: PrismaProduct['sku'] | null;
   title: string;
-  vendorId?: number | undefined;
-  vendor?: { brandName: string | null } | null;
-  category?: { name: string | null } | null;
-};
+  vendor?: Vendor | null;
+  category?: Category | null;
+}

--- a/types/vendor.ts
+++ b/types/vendor.ts
@@ -2,6 +2,8 @@ export interface Vendor {
   id?: number;
   uuid?: string;
   name?: string;
+  /** Display name used for the brand */
+  brandName?: string;
   email: string;
   company?: string;
   phoneNumber?: string;


### PR DESCRIPTION
## Summary
- introduce `Image` and `PriceRange` helper types
- extend `Vendor` with `brandName`
- overhaul `Product` interface to use relational types
- export the new types from the index
- update product utilities to work with new types

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'jest' and 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68566ca5e6ec832fa1c11a850e0b4c54