### PR TITLE
Refactor order types

### DIFF
--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -7,36 +7,28 @@ function mapOrderRow(row: OrderRow): Order {
     id: row.id,
     uuid: row.uuid,
     userId: row.userId,
-    items: [
-      {
-        ...mapDbRowToProduct({
-          id: row.product.id,
-          slug: row.product.slug,
-          title: row.product.title,
-          vendor: row.product.vendor?.brandName ?? String(row.product.vendorId),
-          description: row.product.description,
-          product_type: row.product.productType,
-          tags: Array.isArray(row.product.tags)
-            ? row.product.tags
-            : typeof row.product.tags === 'string'
-            ? row.product.tags.split(',').map((t) => t.trim()).filter(Boolean)
-            : [],
-          category: row.product.category?.name,
-          images: row.product.images,
-          quantity: row.product.quantity,
-          min_price: row.product.minPrice,
-          max_price: row.product.maxPrice,
-          currency: row.product.currency,
-        }),
-        qty: row.quantity,
-      },
-    ],
+    productId: row.productId,
+    quantity: row.quantity,
     total: row.total,
-    status: row.status,
+    status: row.status as Order['status'],
+    user: row.user,
+    product: mapDbRowToProduct({
+      id: row.product.id,
+      slug: row.product.slug,
+      title: row.product.title,
+      vendor: row.product.vendor?.brandName ?? String(row.product.vendorId),
+      description: row.product.description,
+      product_type: row.product.productType,
+      tags: row.product.tags,
+      category: row.product.category?.name,
+      images: row.product.images,
+      quantity: row.product.quantity,
+      min_price: row.product.minPrice,
+      max_price: row.product.maxPrice,
+      currency: row.product.currency,
+    }),
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
-    paymentMethod: undefined,
-    shippingAddress: undefined,
   };
 }
 

--- a/pages/api/admin/analytics.ts
+++ b/pages/api/admin/analytics.ts
@@ -21,9 +21,7 @@ async function handler(
     const counts: Record<string, number> = {};
     orders.forEach((o) => {
       summary.totalRevenue += o.total || 0;
-      o.items.forEach((i) => {
-        counts[i.id] = (counts[i.id] || 0) + i.qty;
-      });
+      counts[o.product.id] = (counts[o.product.id] || 0) + o.quantity;
     });
     summary.topProducts = Object.entries(counts)
       .sort((a, b) => (b[1] as number) - (a[1] as number))

--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -20,11 +20,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const counts: Record<string, number> = {};
     orders.forEach((o) => {
       summary.totalRevenue += o.total || 0;
-      o.items
-        .filter((i) => i.vendor === vendor)
-        .forEach((i) => {
-          counts[i.id] = (counts[i.id] || 0) + i.qty;
-        });
+      if (o.product.vendor === vendor) {
+        counts[o.product.id] = (counts[o.product.id] || 0) + o.quantity;
+      }
     });
     summary.topProducts = Object.entries(counts)
       .sort((a, b) => (b[1] as number) - (a[1] as number))

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -42,15 +42,13 @@ const Orders: React.FC<OrdersProps> = (_props) => {
             <p>
               Order #{o.id} - {o.status}
             </p>
-            {o.shippingAddress && (
-              <p className="text-sm">Address: {o.shippingAddress}</p>
+            {o.shipping?.address && (
+              <p className="text-sm">Address: {o.shipping.address}</p>
             )}
             <ul className="list-disc pl-4 text-sm mb-1">
-              {o.items.map((item) => (
-                <li key={item.id}>
-                  {item.title} x {item.qty}
-                </li>
-              ))}
+              <li>
+                {o.product.title} x {o.quantity}
+              </li>
             </ul>
             <p>Total: £{o.total}</p>
           </li>

--- a/pages/user/orders.tsx
+++ b/pages/user/orders.tsx
@@ -39,15 +39,13 @@ const UserOrders: React.FC = () => {
             <p>
               Order #{o.id} - {o.status}
             </p>
-            {o.shippingAddress && (
-              <p className="text-sm">Address: {o.shippingAddress}</p>
+            {o.shipping?.address && (
+              <p className="text-sm">Address: {o.shipping.address}</p>
             )}
             <ul className="list-disc pl-4 text-sm mb-1">
-              {o.items.map((item) => (
-                <li key={item.id}>
-                  {item.title} x {item.qty}
-                </li>
-              ))}
+              <li>
+                {o.product.title} x {o.quantity}
+              </li>
             </ul>
             <p>Total: £{o.total}</p>
           </li>

--- a/types/order.ts
+++ b/types/order.ts
@@ -1,18 +1,24 @@
-import { Product } from './product';
+import type { User } from './user';
+import type { Product, ProductDbRow } from './product';
+import type { Coupon } from './coupon';
 
-export interface OrderItem extends Product {
-  qty: number;
+export interface ShippingInfo {
+  name: string;
+  address: string;
 }
 
 export interface Order {
   id: number;
-  uuid?: string;
+  uuid: string;
   userId: number;
-  items: OrderItem[];
+  productId: number;
+  quantity: number;
   total: number;
-  status: string;
-  paymentMethod?: string;
-  shippingAddress?: string;
+  status: 'pending' | 'shipped' | 'completed';
+  user: User;
+  product: Product;
+  coupon?: Coupon;
+  shipping?: ShippingInfo;
   createdAt: string;
   updatedAt: string;
 }
@@ -21,39 +27,37 @@ export type OrderResponse = Order;
 
 export interface OrderInput {
   userId: number;
-  items: OrderItem[];
+  productId: number;
+  quantity: number;
   total: number;
-  paymentMethod?: string;
-  shippingAddress?: string;
+  couponId?: number;
+  shipping?: ShippingInfo;
+}
+
+export interface OrderProductRow extends ProductDbRow {
+  description: string;
+  productType: string;
+  tags: string[] | string;
+  images: string[];
+  quantity: number;
+  minPrice: number;
+  maxPrice: number;
+  currency: string;
+  vendor?: { brandName: string | null } | null;
+  category?: { name: string | null } | null;
 }
 
 export interface OrderRow {
   id: number;
-  uuid?: string;
+  uuid: string;
   userId: number;
-  user: {
-    id: number;
-    email: string;
-  };
-  product: {
-    id: number;
-    slug: string;
-    title: string;
-    vendorId: number;
-    vendor?: { brandName?: string | null };
-    description: string;
-    productType: string;
-    tags: string[];
-    category?: { name: string };
-    images: string[];
-    quantity: number;
-    minPrice: number;
-    maxPrice: number;
-    currency: string;
-  };
+  productId: number;
   quantity: number;
   total: number;
   status: string;
   createdAt: Date;
   updatedAt: Date;
+  user: User;
+  product: OrderProductRow;
+  coupon?: Coupon | null;
 }


### PR DESCRIPTION
## Summary
- refactor `Order` types to use referenced models and full fields
- update order mapping and analytics code
- adjust order display pages for new type

## Testing
- `npx --yes jest` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run type-check` *(fails: Cannot find type definition file for 'jest' and 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68566cf4f3a4832fa641372b5cbc8d13