### PR TITLE
Fix API typings

### DIFF
--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -1,8 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { AnalyticsData, ApiMessage } from '../../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<AnalyticsData | ApiMessage>
+): Promise<void> {
   try {
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -1,8 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoriesFlat, createCategory } from '../../../lib/products';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { ApiMessage } from '../../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
   try {
     if (req.method !== 'POST') {
       return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/api/brand/low-stock.ts
+++ b/pages/api/brand/low-stock.ts
@@ -1,8 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { loadAndIndexProducts } from '../../../lib/products';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { Product, ApiMessage } from '../../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Product[] | ApiMessage>
+): Promise<void> {
   try {
     const { vendor } = req.query;
     if (!vendor) return res.status(400).json({ message: 'vendor required' });

--- a/pages/api/brand/orders.ts
+++ b/pages/api/brand/orders.ts
@@ -1,8 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { Order, ApiMessage } from '../../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Order[] | ApiMessage>
+): Promise<void> {
   try {
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -3,8 +3,12 @@ import { updateProduct, deleteProduct, loadAndIndexProducts } from '../../../../
 import { getProductByUuid } from '../../../../lib/db';
 import { hasOrdersForProduct } from '../../../../lib/orders';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
+import type { ApiMessage } from '../../../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
   try {
     const { uuid } = req.query;
     if (!uuid) return res.status(400).json({ message: 'uuid required' });

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { addProduct, loadAndIndexProducts } from '../../../../lib/products';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
+import type { Product, ApiMessage } from '../../../../types';
 
 function slugify(text) {
   return text
@@ -11,7 +12,10 @@ function slugify(text) {
     .replace(/-+/g, '-');
 }
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Product[] | ApiMessage>
+): Promise<void> {
   try {
     if (req.method === 'GET') {
       const { vendor } = req.query;

--- a/pages/api/brand/profile.ts
+++ b/pages/api/brand/profile.ts
@@ -1,14 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateUserProfile, findUser } from '../../../lib/users';
-import type { Vendor } from '../../../types';
+import type { Vendor, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Vendor | { message: string }>
-) {
+  res: NextApiResponse<Vendor | ApiMessage>
+): Promise<void> {
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {

--- a/pages/api/cart.ts
+++ b/pages/api/cart.ts
@@ -3,12 +3,12 @@ import { getCart, setCart } from '../../lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import { handleApiError } from '../../lib/utils/handleApiError';
-import type { CartItem } from '../../types';
+import type { CartItem, ApiMessage } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<CartItem[] | { message: string }>
-) {
+  res: NextApiResponse<CartItem[] | ApiMessage>
+): Promise<void> {
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -1,12 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '../../lib/products';
 import { handleApiError } from '../../lib/utils/handleApiError';
-import type { CategoriesResponse } from '../../types';
+import type { CategoriesResponse, ApiMessage } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<CategoriesResponse | { message: string }>
- ) {
+  res: NextApiResponse<CategoriesResponse | ApiMessage>
+): Promise<void> {
   try {
     if (req.method === 'GET') {
       const data = await getCategoryTree();

--- a/pages/api/category-tree.ts
+++ b/pages/api/category-tree.ts
@@ -1,12 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '../../lib/products';
 import { handleApiError } from '../../lib/utils/handleApiError';
-import type { CategoriesResponse } from '../../types';
+import type { CategoriesResponse, ApiMessage } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<CategoriesResponse | { message: string }>
- ) {
+  res: NextApiResponse<CategoriesResponse | ApiMessage>
+): Promise<void> {
   try {
     if (req.method === 'GET') {
       const data = await getCategoryTree();

--- a/pages/api/check-email.ts
+++ b/pages/api/check-email.ts
@@ -1,11 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser } from '../../lib/users';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { ApiMessage } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ exists: boolean } | { message: string }>
-) {
+  res: NextApiResponse<{ exists: boolean } | ApiMessage>
+): Promise<void> {
   try {
     const { email } = req.query;
     if (!email) {

--- a/pages/api/checkout/complete.ts
+++ b/pages/api/checkout/complete.ts
@@ -3,12 +3,16 @@ import Stripe from 'stripe';
 import { addOrder } from '../../../lib/orders';
 import { sendOrderConfirmation } from '../../../lib/email';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { OrderIdResponse, ApiMessage } from '../../../types';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2023-10-16',
 });
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<OrderIdResponse | ApiMessage>
+): Promise<void> {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/checkout/create-session.ts
+++ b/pages/api/checkout/create-session.ts
@@ -1,12 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { CheckoutSessionResponse, ApiMessage } from '../../../types';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2023-10-16',
 });
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CheckoutSessionResponse | ApiMessage>
+): Promise<void> {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/coupons/[code].ts
+++ b/pages/api/coupons/[code].ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { handleApiError } from '../../../lib/utils/handleApiError';
-import type { Coupon } from '../../../types';
+import type { Coupon, ApiMessage } from '../../../types';
 
 const coupons: Record<string, Coupon> = {
   SAVE10: {
@@ -27,8 +27,8 @@ const coupons: Record<string, Coupon> = {
 
 export default function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Coupon | { message: string }>
-) {
+  res: NextApiResponse<Coupon | ApiMessage>
+): void {
   try {
     const { code } = req.query;
     const coupon = coupons[code?.toUpperCase() as string];

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -2,12 +2,12 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser } from '../../lib/users';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '../../lib/utils/handleApiError';
-import type { User } from '../../types';
+import type { LoginResponse } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ message: string; user?: User }>
-) {
+  res: NextApiResponse<LoginResponse>
+): Promise<void> {
   try {
     if (req.method !== 'POST') {
       return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -14,8 +14,12 @@ import {
 import { withRole } from '../../lib/withRole';
 import { sendOrderConfirmation } from '../../lib/email';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { Order, OrderPlacedResponse, ApiMessage } from '../../types';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Order[] | OrderPlacedResponse | ApiMessage>
+): Promise<void> {
   try {
     if (req.method === 'POST') {
       const { email, items, total, shippingName, shippingAddress } = req.body;

--- a/pages/api/orders/[uuid].ts
+++ b/pages/api/orders/[uuid].ts
@@ -3,8 +3,12 @@ import { getOrderByUuid, updateOrderStatus } from '../../../lib/orders';
 import { sendOrderStatusUpdate } from '../../../lib/email';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { Order, ApiMessage } from '../../../types';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Order | ApiMessage>
+): Promise<void> {
   try {
     const { uuid } = req.query;
     if (!uuid) {

--- a/pages/api/products/[uuid].ts
+++ b/pages/api/products/[uuid].ts
@@ -3,6 +3,7 @@ import { getProductByUuid, getAverageRating } from '../../../lib/db.js';
 import { mapDbRowToProduct } from '../../../lib/products.js';
 import { Product } from '../../../types/product';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { ApiMessage } from '../../../types';
 
 export type ProductResponse = Product & {
   AVERAGE_RATING: number;
@@ -11,8 +12,8 @@ export type ProductResponse = Product & {
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ProductResponse | { message: string }>
-) {
+  res: NextApiResponse<ProductResponse | ApiMessage>
+): Promise<void> {
   const { uuid } = req.query;
   if (!uuid) {
     return res.status(400).json({ message: 'uuid required' });

--- a/pages/api/products/[uuid]/reviews.ts
+++ b/pages/api/products/[uuid]/reviews.ts
@@ -6,12 +6,17 @@ import {
   getAverageRating,
 } from '../../../../lib/db.js';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
-import type { Review, ReviewsResponse, ReviewAddedResponse } from '../../../../types/review';
+import type {
+  Review,
+  ReviewsResponse,
+  ReviewAddedResponse,
+} from '../../../../types/review';
+import type { ApiMessage } from '../../../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ReviewsResponse | ReviewAddedResponse | { message: string }>
-) {
+  res: NextApiResponse<ReviewsResponse | ReviewAddedResponse | ApiMessage>
+): Promise<void> {
   const {
     query: { uuid },
     method,

--- a/pages/api/request-reset.ts
+++ b/pages/api/request-reset.ts
@@ -2,8 +2,12 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser, setResetToken } from '../../lib/users';
 import crypto from 'crypto';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { ResetTokenResponse, ApiMessage } from '../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResetTokenResponse | ApiMessage>
+): Promise<void> {
   try {
     if (req.method !== 'POST')
       return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/api/reset-password.ts
+++ b/pages/api/reset-password.ts
@@ -1,8 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { resetPassword } from '../../lib/users';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { ApiMessage } from '../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
   if (req.method !== 'POST')
     return res.status(405).json({ message: 'Method Not Allowed' });
   const { token, password } = req.body;

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getBestSellingProducts } from '../../lib/orders';
 import { getDb } from '../../lib/db';
 import type { Product } from '../../types/product';
+import type { SearchApiResponse, ApiMessage } from '../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import client from '../../lib/typesenseClient';
@@ -48,8 +49,8 @@ function buildSort(sort?: string) {
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
-) {
+  res: NextApiResponse<SearchApiResponse | ApiMessage>
+): Promise<void> {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -3,8 +3,12 @@ import { addUser, findUser } from '../../lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { SignupResponse, ApiMessage } from '../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SignupResponse | ApiMessage>
+): Promise<void> {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/signup/brand.ts
+++ b/pages/api/signup/brand.ts
@@ -3,11 +3,12 @@ import { addUser, findUser } from '../../../lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { SignupTokenResponse, ApiMessage } from '../../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ token: string } | { message: string }>
-) {
+  res: NextApiResponse<SignupTokenResponse | ApiMessage>
+): Promise<void> {
   try {
     if (req.method !== 'POST') {
       return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/api/signup/user.ts
+++ b/pages/api/signup/user.ts
@@ -3,11 +3,12 @@ import { addUser, findUser } from '../../../lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { SignupTokenResponse, ApiMessage } from '../../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ token: string } | { message: string }>
-) {
+  res: NextApiResponse<SignupTokenResponse | ApiMessage>
+): Promise<void> {
   try {
     if (req.method !== 'POST') {
       return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/api/suggest.ts
+++ b/pages/api/suggest.ts
@@ -1,8 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { host, port, protocol, apiKey } from '../../lib/typesenseClient';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { SuggestionsResponse, ApiMessage } from '../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SuggestionsResponse | ApiMessage>
+): Promise<void> {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }

--- a/pages/api/trending.ts
+++ b/pages/api/trending.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { TrendingResponse } from '../../types';
 
 const trendingKeywords = [
   'iPhone 14',
@@ -11,8 +12,8 @@ const trendingKeywords = [
 
 export default function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ keywords: string[] }>
-) {
+  res: NextApiResponse<TrendingResponse>
+): void {
   try {
     if (req.method !== 'GET') {
       return res.status(405).json({ keywords: [] });

--- a/pages/api/user/orders.ts
+++ b/pages/api/user/orders.ts
@@ -3,8 +3,12 @@ import { getOrdersForUser } from '../../../lib/orders';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { Order, ApiMessage } from '../../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Order[] | ApiMessage>
+): Promise<void> {
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {

--- a/pages/api/user/profile.ts
+++ b/pages/api/user/profile.ts
@@ -3,8 +3,12 @@ import { updateUserProfile, findUser } from '../../../lib/users';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { User, ApiMessage } from '../../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<User | ApiMessage>
+): Promise<void> {
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {

--- a/pages/api/vendor/orders.ts
+++ b/pages/api/vendor/orders.ts
@@ -2,8 +2,12 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { Order, ApiMessage } from '../../../types';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Order[] | ApiMessage>
+): Promise<void> {
   try {
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });

--- a/pages/api/verify-email.ts
+++ b/pages/api/verify-email.ts
@@ -1,8 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { verifyUser } from '../../lib/users';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import type { ApiMessage } from '../../types';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
   const { token } = req.query;
   if (!token) return res.status(400).json({ message: 'token required' });
   try {

--- a/pages/api/wishlist.ts
+++ b/pages/api/wishlist.ts
@@ -3,12 +3,12 @@ import { getWishlist, setWishlist } from '../../lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import { handleApiError } from '../../lib/utils/handleApiError';
-import type { Product } from '../../types';
+import type { Product, ApiMessage } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Product[] | { message: string }>
-) {
+  res: NextApiResponse<Product[] | ApiMessage>
+): Promise<void> {
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {

--- a/types/api.ts
+++ b/types/api.ts
@@ -6,6 +6,16 @@ export interface SuggestionsResponse {
   suggestions: string[];
 }
 
+export interface SearchApiResponse {
+  results: import('./product').Product[];
+  total: number;
+  page: number;
+  totalPages: number;
+  brands: string[];
+  categories: string[];
+  fallback: import('./product').Product[];
+}
+
 export interface TrendingResponse {
   keywords: string[];
 }
@@ -13,6 +23,35 @@ export interface TrendingResponse {
 export interface CheckoutSessionResponse {
   url: string;
   message?: string;
+  id?: string;
+}
+
+export interface OrderIdResponse {
+  id: string;
+}
+
+export interface OrderPlacedResponse extends OrderIdResponse {
+  message: string;
+}
+
+export interface LoginResponse {
+  message: string;
+  user?: import('./user').User;
+}
+
+export interface SignupResponse {
+  message: string;
+  user: import('./user').User;
+  token: string;
+}
+
+export interface SignupTokenResponse {
+  token: string;
+}
+
+export interface ResetTokenResponse {
+  message: string;
+  token: string;
 }
 
 export type CouponResponse = import('./coupon').Coupon;


### PR DESCRIPTION
## Summary
- refactor API handlers to use shared interfaces
- ensure request and response typing for all endpoints
- add interfaces to `types/api.ts`

## Testing
- `npm run type-check` *(fails: missing node/jest types)*

------
https://chatgpt.com/codex/tasks/task_e_68567c9300ac832f8759b41de8abded6