### PR TITLE
Fix image type handling

### DIFF
--- a/components/ProductImageSlider.tsx
+++ b/components/ProductImageSlider.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Image from 'next/image';
 
 export interface ProductImageSliderProps {
-  images?: string[];
+  images?: Array<string | { url: string }>;
   className?: string;
   imgClass?: string;
   placeholderSeed?: number;
@@ -15,7 +15,10 @@ export default function ProductImageSlider({
   placeholderSeed = 1,
 }: ProductImageSliderProps) {
   const [idx, setIdx] = useState(0);
-  if (!images || images.length === 0) {
+  const urls = images.map((img) =>
+    typeof img === 'string' ? img : img.url
+  );
+  if (!urls || urls.length === 0) {
     return (
       <div className={`relative aspect-[4/5] ${className}`}>
         <Image
@@ -27,17 +30,17 @@ export default function ProductImageSlider({
       </div>
     );
   }
-  const next = () => setIdx((i) => (i + 1) % images.length);
-  const prev = () => setIdx((i) => (i - 1 + images.length) % images.length);
+  const next = () => setIdx((i) => (i + 1) % urls.length);
+  const prev = () => setIdx((i) => (i - 1 + urls.length) % urls.length);
   return (
     <div className={`relative aspect-[4/5] ${className}`}>
       <Image
-        src={images[idx]}
+        src={urls[idx]}
         alt={`Image ${idx + 1}`}
         fill
         className={`object-cover ${imgClass}`}
       />
-      {images.length > 1 && (
+      {urls.length > 1 && (
         <>
           <button
             type="button"

--- a/types/category.ts
+++ b/types/category.ts
@@ -15,5 +15,5 @@ export interface Category {
 export interface CategoryInput {
   name: string;
   parentId?: number | null;
-  image?: string;
+  image?: string | null;
 }


### PR DESCRIPTION
## Summary
- adjust ProductImageSlider to accept objects or strings
- allow CategoryInput.image to be null

## Testing
- `npx prisma generate` *(fails: binaries.prisma.sh blocked)*
- `npm run type-check` *(fails: missing jest and node types)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856807c97d4832fadebb9b88d1e263d