### PR TITLE
Standardize product images

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -30,8 +30,8 @@ const ProductCard: React.FC<ProductCardProps> = ({
           images={
             product.images && product.images.length > 0
               ? product.images
-              : product.featuredImage?.url
-              ? [product.featuredImage.url]
+              : product.featuredImage
+              ? [product.featuredImage]
               : []
           }
           placeholderSeed={Number(product.id)}

--- a/components/ProductImageSlider.tsx
+++ b/components/ProductImageSlider.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
+import type { Image as ProductImage } from '../types/image';
 
 export interface ProductImageSliderProps {
-  images?: string[];
+  images?: ProductImage[];
   className?: string;
   imgClass?: string;
   placeholderSeed?: number;
@@ -32,8 +33,8 @@ export default function ProductImageSlider({
   return (
     <div className={`relative aspect-[4/5] ${className}`}>
       <Image
-        src={images[idx]}
-        alt={`Image ${idx + 1}`}
+        src={images[idx].url}
+        alt={images[idx].alt || `Image ${idx + 1}`}
         fill
         className={`object-cover ${imgClass}`}
       />

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -1,5 +1,4 @@
 import { Order, Product } from '../types';
-import type { ProductDbRow } from '../types/product';
 import { getDb } from './db';
 import { mapDbRowToProduct } from './products';
 import type { Prisma } from '@prisma/client';
@@ -138,23 +137,5 @@ export async function getBestSellingProducts(limit = 8): Promise<Product[]> {
     include: { category: true, vendor: true },
   });
 
-  return products.map((p) =>
-    mapDbRowToProduct({
-      id: p.id,
-      uuid: p.uuid,
-      slug: p.slug,
-      sku: p.sku,
-      title: p.title,
-      vendor: p.vendor ?? null,
-      description: p.description,
-      productType: p.productType,
-      tags: p.tags,
-      category: p.category ?? null,
-      images: p.images,
-      quantity: p.quantity,
-      minPrice: p.minPrice,
-      maxPrice: p.maxPrice,
-      currency: p.currency,
-    } as ProductDbRow)
-  );
+  return products.map((p) => mapDbRowToProduct(p));
 }

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,6 +1,7 @@
 import { JSDOM } from 'jsdom';
 import { getDb } from './db';
-import type { Product, ProductDbRow } from '../types/product';
+import type { Product } from '../types/product';
+import { parseImages } from './utils/parseImages';
 import type { Category } from '../types/category';
 import type { Prisma } from '@prisma/client';
 
@@ -92,9 +93,7 @@ async function loadProductsData(): Promise<Product[]> {
         productType: row.productType,
         tags: row.tags,
         category: row.category ?? null,
-        images: row.images
-          ? (JSON.parse(row.images) as string[]).map((u) => ({ url: u }))
-          : [],
+        images: parseImages(row.images),
         totalInventory: row.quantity,
         priceRange: {
           minVariantPrice: {
@@ -113,7 +112,7 @@ async function loadProductsData(): Promise<Product[]> {
   }
 }
 
-export function mapDbRowToProduct(row: ProductDbRow): Product {
+export function mapDbRowToProduct(row: { images: string | null } & Record<string, any>): Product {
   return processProductRow({
     id: row.id,
     uuid: row.uuid,
@@ -125,9 +124,7 @@ export function mapDbRowToProduct(row: ProductDbRow): Product {
     productType: row.productType,
     tags: row.tags,
     category: row.category,
-    images: row.images
-      ? (JSON.parse(row.images as unknown as string) as string[]).map((u) => ({ url: u }))
-      : [],
+    images: parseImages(row.images),
     totalInventory: row.quantity,
     priceRange: {
       minVariantPrice: {
@@ -226,9 +223,7 @@ export async function getPendingProducts(): Promise<Product[]> {
       productType: row.productType,
       tags: row.tags,
       category: row.category ?? null,
-      images: row.images
-        ? (JSON.parse(row.images) as string[]).map((u) => ({ url: u }))
-        : [],
+      images: parseImages(row.images),
       totalInventory: row.quantity,
       priceRange: {
         minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },

--- a/lib/utils/parseImages.ts
+++ b/lib/utils/parseImages.ts
@@ -1,0 +1,16 @@
+import type { Image } from '../../types';
+
+export function parseImages(raw: string | null): Image[] {
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(raw);
+    if (Array.isArray(arr)) {
+      return arr.map((img) =>
+        typeof img === 'string' ? { url: img } : (img as Image)
+      );
+    }
+  } catch {
+    // ignore parsing errors
+  }
+  return [];
+}

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { Product, ApiMessage } from '../../../types';
+import { parseImages } from '../../../lib/utils/parseImages';
 
 function slugify(text) {
   return text
@@ -177,7 +178,7 @@ async function handler(
         productType: p.productType,
         tags: p.tags,
         category: p.category?.name,
-        images: p.images ? JSON.parse(p.images) : [],
+        images: parseImages(p.images),
         totalInventory: p.quantity,
         priceRange: {
           minVariantPrice: { amount: p.minPrice, currencyCode: p.currency },

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -81,8 +81,8 @@ export default function ProductDetail({
             images={
               product.images && product.images.length > 0
                 ? product.images
-                : product.featuredImage?.url
-                ? [product.featuredImage.url]
+                : product.featuredImage
+                ? [product.featuredImage]
                 : []
             }
             imgClass="hover:scale-110 transition"

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -94,7 +94,9 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
           images={
             product.images && product.images.length > 0
               ? product.images
-              : [product.featuredImage?.url || '/placeholder.png']
+              : product.featuredImage
+              ? [product.featuredImage]
+              : []
           }
           imgClass="hover:scale-110 transition"
         />

--- a/types/order.ts
+++ b/types/order.ts
@@ -1,5 +1,5 @@
 import type { User } from './user';
-import type { Product, ProductDbRow } from './product';
+import type { Product } from './product';
 import type { Coupon } from './coupon';
 
 export interface ShippingInfo {
@@ -35,7 +35,7 @@ export interface OrderInput {
   shippingAddress?: string;
 }
 
-export type OrderProductRow = ProductDbRow;
+export type OrderProductRow = Product;
 
 export interface OrderRow {
   id: number;

--- a/types/product.ts
+++ b/types/product.ts
@@ -51,20 +51,3 @@ export interface ProductInput {
   price?: number;
 }
 
-export interface ProductDbRow {
-  id: number;
-  uuid: string;
-  slug: string;
-  sku: PrismaProduct['sku'];
-  title: string;
-  description: string;
-  productType: string;
-  tags: string | null;
-  images: string | null;
-  quantity: number;
-  minPrice: number;
-  maxPrice: number;
-  currency: string;
-  vendor: Vendor | null;
-  category: Category | null;
-}


### PR DESCRIPTION
## Summary
- add helper to parse stored image data
- convert image arrays to `Image[]` across components and pages
- remove deprecated `ProductDbRow` type usage
- update admin products API to return `Image[]`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685681541b0c832f9a187908f29360e7