### PR TITLE
Standardize timestamp types

### DIFF
--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -37,8 +37,8 @@ function mapOrderRow(row: OrderWithRelations): Order {
     status: row.status as Order['status'],
     user: row.user,
     product: mapDbRowToProduct(row.product),
-    createdAt: row.createdAt.toISOString(),
-    updatedAt: row.updatedAt.toISOString(),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
   };
 }
 

--- a/pages/api/brand/profile.ts
+++ b/pages/api/brand/profile.ts
@@ -32,8 +32,8 @@ export default async function handler(
         description: userData.businessDescription ?? undefined,
         taxId: userData.taxId ?? undefined,
         status: userData.disabled ? 'disabled' : 'active',
-        createdAt: userData.createdAt?.toISOString(),
-        updatedAt: userData.updatedAt?.toISOString(),
+        createdAt: userData.createdAt ?? undefined,
+        updatedAt: userData.updatedAt ?? undefined,
       };
       return res.status(200).json(vendor);
     }

--- a/types/brand.ts
+++ b/types/brand.ts
@@ -5,6 +5,6 @@ export interface Brand {
   slug?: string;
   logo?: string;
   description?: string;
-  createdAt?: string;
-  updatedAt?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
 }

--- a/types/category.ts
+++ b/types/category.ts
@@ -6,8 +6,8 @@ export interface Category {
   parentId?: number | null;
   description?: string | null;
   image?: string | null;
-  createdAt?: Date | string;
-  updatedAt?: Date | string;
+  createdAt?: Date;
+  updatedAt?: Date;
   children?: Category[];
   subcategories?: string[];
 }

--- a/types/coupon.ts
+++ b/types/coupon.ts
@@ -7,5 +7,5 @@ export interface Coupon {
   expiresAt?: string;
   minOrderAmount?: number;
   usageLimit?: number;
-  createdAt?: string;
+  createdAt?: Date;
 }

--- a/types/order.ts
+++ b/types/order.ts
@@ -19,8 +19,8 @@ export interface Order {
   product: Product;
   coupon?: Coupon;
   shipping?: ShippingInfo;
-  createdAt: string;
-  updatedAt: string;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export type OrderResponse = Order;

--- a/types/product.ts
+++ b/types/product.ts
@@ -29,8 +29,8 @@ export interface Product {
   descriptionText?: string;
   bodyHtmlText?: string;
   status?: string;
-  createdAt?: Date | string;
-  updatedAt?: Date | string;
+  createdAt?: Date;
+  updatedAt?: Date;
   vendor: Vendor;
   brand?: Brand;
   category: Category;

--- a/types/user.ts
+++ b/types/user.ts
@@ -15,8 +15,8 @@ export interface User {
   gender?: string;
   verified?: boolean;
   disabled?: boolean;
-  createdAt?: Date | string;
-  updatedAt?: Date | string;
+  createdAt?: Date;
+  updatedAt?: Date;
 }
 
 export type UserResponse = User;

--- a/types/vendor.ts
+++ b/types/vendor.ts
@@ -14,6 +14,6 @@ export interface Vendor {
   description?: string;
   taxId?: string;
   status?: string;
-  createdAt?: string;
-  updatedAt?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
 }


### PR DESCRIPTION
## Summary
- use `Date` for all `createdAt`/`updatedAt` fields across entity types
- adjust order mapping to return `Date` objects
- simplify vendor profile API output

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685682e201e4832fa2a16cf49fb47578