### PR TITLE
Refactor API handlers for safe query params

### DIFF
--- a/lib/utils/getQueryParam.ts
+++ b/lib/utils/getQueryParam.ts
@@ -1,0 +1,5 @@
+export function getQueryParam(value: string | string[] | undefined): string | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value[0];
+  return undefined;
+}

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -8,6 +8,7 @@ import {
 import { withRole } from '../../../lib/withRole';
 import { logAudit } from '../../../lib/audit';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import { Category, CategoryInput, ApiMessage } from '../../../types';
 
 async function handler(
@@ -48,7 +49,7 @@ async function handler(
       return res.status(200).json({ message: 'category updated' });
     }
     if (req.method === 'DELETE') {
-      const { uuid } = req.query;
+      const uuid = getQueryParam(req.query.uuid);
       if (!uuid) return res.status(400).json({ message: 'uuid required' });
       try {
         await removeCategory(String(uuid));

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import { Product, ApiMessage } from '../../../types';
 import { parseImages } from '../../../lib/utils/parseImages';
 
@@ -143,7 +144,7 @@ async function handler(
     }
 
     if (req.method === 'DELETE') {
-      const { uuid } = req.query;
+      const uuid = getQueryParam(req.query.uuid);
       if (!uuid) {
         return res.status(400).json({ message: 'uuid required' });
       }
@@ -161,9 +162,9 @@ async function handler(
     }
 
     if (req.method === 'GET') {
-      const { vendor } = req.query;
+      const vendor = getQueryParam(req.query.vendor);
       const where: Record<string, unknown> = {};
-      if (vendor) where.vendor = { brandName: String(vendor) };
+      if (vendor) where.vendor = { brandName: vendor };
       const rows = await db.product.findMany({
         where,
         include: { category: true, vendor: true },

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -9,6 +9,7 @@ import {
 import type { Role } from '@prisma/client';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import {
   AdminUser,
   UserRoleUpdateRequest,
@@ -41,9 +42,9 @@ async function handler(
       return res.status(200).json({ message: 'status updated' });
     }
     if (req.method === 'DELETE') {
-      const { email } = req.query;
-      if (!email) return res.status(400).json({ message: 'email required' });
-      await deleteUser(String(email));
+        const email = getQueryParam(req.query.email);
+        if (!email) return res.status(400).json({ message: 'email required' });
+        await deleteUser(email);
       return res.status(200).json({ message: 'user deleted' });
     }
     if (req.method === 'POST') {

--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { AnalyticsData, ApiMessage } from '../../../types';
 
 export default async function handler(
@@ -11,11 +12,11 @@ export default async function handler(
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const { vendor } = req.query;
+    const vendor = getQueryParam(req.query.vendor);
     if (!vendor) {
       return res.status(400).json({ message: 'vendor required' });
     }
-    const orders = await getOrdersForVendor(vendor as string);
+    const orders = await getOrdersForVendor(vendor);
     const summary = {
       totalOrders: orders.length,
       totalRevenue: 0,

--- a/pages/api/brand/low-stock.ts
+++ b/pages/api/brand/low-stock.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { loadAndIndexProducts } from '../../../lib/products';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { Product, ApiMessage } from '../../../types';
 
 export default async function handler(
@@ -8,7 +9,7 @@ export default async function handler(
   res: NextApiResponse<Product[] | ApiMessage>
 ): Promise<void> {
   try {
-    const { vendor } = req.query;
+    const vendor = getQueryParam(req.query.vendor);
     if (!vendor) return res.status(400).json({ message: 'vendor required' });
     const { products } = await loadAndIndexProducts();
     const low = products.filter(

--- a/pages/api/brand/orders.ts
+++ b/pages/api/brand/orders.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
 
 export default async function handler(
@@ -11,11 +12,11 @@ export default async function handler(
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const { vendor } = req.query;
+    const vendor = getQueryParam(req.query.vendor);
     if (!vendor) {
       return res.status(400).json({ message: 'vendor required' });
     }
-    const orders = await getOrdersForVendor(vendor as string);
+    const orders = await getOrdersForVendor(vendor);
     return res.status(200).json(orders);
   } catch (error) {
     return handleApiError(res, error, 'Failed to get orders');

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -3,6 +3,7 @@ import { updateProduct, deleteProduct, loadAndIndexProducts } from '../../../../
 import { getProductByUuid } from '../../../../lib/db';
 import { hasOrdersForProduct } from '../../../../lib/orders';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../../../types';
 
 export default async function handler(
@@ -10,7 +11,7 @@ export default async function handler(
   res: NextApiResponse<ApiMessage>
 ): Promise<void> {
   try {
-    const { uuid } = req.query;
+    const uuid = getQueryParam(req.query.uuid);
     if (!uuid) return res.status(400).json({ message: 'uuid required' });
 
     if (req.method === 'PUT') {

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { addProduct, loadAndIndexProducts } from '../../../../lib/products';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../../lib/utils/getQueryParam';
 import type { Product, ApiMessage } from '../../../../types';
 
 function slugify(text) {
@@ -18,7 +19,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method === 'GET') {
-      const { vendor } = req.query;
+      const vendor = getQueryParam(req.query.vendor);
       if (!vendor) return res.status(400).json({ message: 'vendor required' });
       const { products } = await loadAndIndexProducts();
       const filtered = products.filter((p) => p.VENDOR === vendor);

--- a/pages/api/check-email.ts
+++ b/pages/api/check-email.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { findUser } from '../../lib/users';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import { getQueryParam } from '../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../types';
 
 export default async function handler(
@@ -8,7 +9,7 @@ export default async function handler(
   res: NextApiResponse<{ exists: boolean } | ApiMessage>
 ): Promise<void> {
   try {
-    const { email } = req.query;
+    const email = getQueryParam(req.query.email);
     if (!email) {
       return res.status(400).json({ message: 'email required' });
     }

--- a/pages/api/coupons/[code].ts
+++ b/pages/api/coupons/[code].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { Coupon, ApiMessage } from '../../../types';
 
 const coupons: Record<string, Coupon> = {
@@ -30,8 +31,8 @@ export default function handler(
   res: NextApiResponse<Coupon | ApiMessage>
 ): void {
   try {
-    const { code } = req.query;
-    const coupon = coupons[code?.toUpperCase() as string];
+  const code = getQueryParam(req.query.code);
+  const coupon = code ? coupons[code.toUpperCase()] : undefined;
     if (!coupon) return res.status(404).json({ message: 'Invalid code' });
     res.status(200).json(coupon);
   } catch (error) {

--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -14,6 +14,7 @@ import {
 import { withRole } from '../../lib/withRole';
 import { sendOrderConfirmation } from '../../lib/email';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import { getQueryParam } from '../../lib/utils/getQueryParam';
 import type { Order, OrderPlacedResponse, ApiMessage } from '../../types';
 
 async function handler(
@@ -55,7 +56,7 @@ async function handler(
   }
 
   if (req.method === 'GET') {
-    const { email } = req.query;
+    const email = getQueryParam(req.query.email);
     if (!email) return res.status(400).json({ message: 'email required' });
     const user = await findUser(email);
     if (!user) return res.status(404).json({ message: 'user not found' });

--- a/pages/api/orders/[uuid].ts
+++ b/pages/api/orders/[uuid].ts
@@ -3,6 +3,7 @@ import { getOrderByUuid, updateOrderStatus } from '../../../lib/orders';
 import { sendOrderStatusUpdate } from '../../../lib/email';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
 
 async function handler(
@@ -10,7 +11,7 @@ async function handler(
   res: NextApiResponse<Order | ApiMessage>
 ): Promise<void> {
   try {
-    const { uuid } = req.query;
+    const uuid = getQueryParam(req.query.uuid);
     if (!uuid) {
       return res.status(400).json({ message: 'uuid required' });
     }

--- a/pages/api/products/[uuid].ts
+++ b/pages/api/products/[uuid].ts
@@ -3,6 +3,7 @@ import { getProductByUuid, getAverageRating } from '../../../lib/db.js';
 import { mapDbRowToProduct } from '../../../lib/products.js';
 import { Product } from '../../../types/product';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 export type ProductResponse = Product & {
@@ -14,7 +15,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ProductResponse | ApiMessage>
 ): Promise<void> {
-  const { uuid } = req.query;
+  const uuid = getQueryParam(req.query.uuid);
   if (!uuid) {
     return res.status(400).json({ message: 'uuid required' });
   }

--- a/pages/api/products/[uuid]/reviews.ts
+++ b/pages/api/products/[uuid]/reviews.ts
@@ -6,6 +6,7 @@ import {
   getAverageRating,
 } from '../../../../lib/db.js';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../../lib/utils/getQueryParam';
 import type {
   Review,
   ReviewsResponse,
@@ -18,9 +19,9 @@ export default async function handler(
   res: NextApiResponse<ReviewsResponse | ReviewAddedResponse | ApiMessage>
 ): Promise<void> {
   const {
-    query: { uuid },
     method,
   } = req;
+  const uuid = getQueryParam(req.query.uuid);
   try {
     if (!uuid) return res.status(400).json({ message: 'uuid required' });
 

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -7,6 +7,7 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import client from '../../lib/typesenseClient';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import { getQueryParam } from '../../lib/utils/getQueryParam';
 
 interface SearchParams {
   q: string;
@@ -66,16 +67,14 @@ export default async function handler(
     if (user) userId = user.id;
   }
 
-  const {
-    q = '',
-    category,
-    brand,
-    minPrice,
-    maxPrice,
-    sort,
-    page = '1',
-    perPage = '20',
-  } = req.query as { [key: string]: string };
+  const q = getQueryParam(req.query.q) ?? '';
+  const category = getQueryParam(req.query.category);
+  const brand = getQueryParam(req.query.brand);
+  const minPrice = getQueryParam(req.query.minPrice);
+  const maxPrice = getQueryParam(req.query.maxPrice);
+  const sort = getQueryParam(req.query.sort);
+  const page = getQueryParam(req.query.page) ?? '1';
+  const perPage = getQueryParam(req.query.perPage) ?? '20';
 
   const searchParams: SearchParams = {
     q: q || '*',

--- a/pages/api/vendor/orders.ts
+++ b/pages/api/vendor/orders.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendor } from '../../../lib/orders';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
 
 async function handler(
@@ -12,11 +13,11 @@ async function handler(
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const { vendor } = req.query;
+    const vendor = getQueryParam(req.query.vendor);
     if (!vendor) {
       return res.status(400).json({ message: 'vendor required' });
     }
-    const orders = await getOrdersForVendor(vendor as string);
+    const orders = await getOrdersForVendor(vendor);
     return res.status(200).json(orders);
   } catch (error) {
     return handleApiError(res, error, 'Failed to get orders');

--- a/pages/api/verify-email.ts
+++ b/pages/api/verify-email.ts
@@ -1,13 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { verifyUser } from '../../lib/users';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import { getQueryParam } from '../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ApiMessage>
 ): Promise<void> {
-  const { token } = req.query;
+  const token = getQueryParam(req.query.token);
   if (!token) return res.status(400).json({ message: 'token required' });
   try {
     await verifyUser(token);


### PR DESCRIPTION
## Summary
- add `getQueryParam` utility
- use helper to read query strings in API routes
- ensure vendor/product/order handlers validate query params

## Testing
- `npm install` *(fails: ERROR: Failed to set up chrome v131.0.6778.204!)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568724cf88832fa3f9cf73e6bf2ddd