### PR TITLE
Standardize Product Module – Types, Handlers, API, UI

### DIFF
--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,13 +1,32 @@
 import { JSDOM } from 'jsdom';
 import { getDb } from './db';
-import type { Product } from '../types/product';
+import type { Product, ProductInput } from '../types/product';
 import { parseImages } from './utils/parseImages';
 import type { Category } from '../types/category';
+import type { Vendor } from '../types/vendor';
 import type { Prisma } from '@prisma/client';
 
 type ProductWithRelations = Prisma.ProductGetPayload<{
   include: { category: true; vendor: true };
 }>;
+
+interface ProductRow {
+  id: number | string;
+  uuid?: string | null;
+  slug?: string | null;
+  sku: string;
+  title: string;
+  vendor?: Vendor | null;
+  description?: string | null;
+  productType?: string | null;
+  tags?: string | null;
+  category?: Category | null;
+  images: string | null;
+  quantity: number;
+  minPrice: number;
+  maxPrice: number;
+  currency: string;
+}
 
 /**
  * Simplified representation of a product row returned from the database.
@@ -112,7 +131,7 @@ async function loadProductsData(): Promise<Product[]> {
   }
 }
 
-export function mapDbRowToProduct(row: { images: string | null } & Record<string, any>): Product {
+export function mapDbRowToProduct(row: ProductRow): Product {
   return processProductRow({
     id: row.id,
     uuid: row.uuid,
@@ -144,7 +163,7 @@ export async function loadAndIndexProducts(): Promise<{ products: Product[] }> {
   return { products };
 }
 
-export async function addProduct(product: Product): Promise<void> {
+export async function addProduct(product: ProductInput): Promise<void> {
   const db = getDb();
   const vendor = product.vendor?.brandName
     ? await db.user.findFirst({ where: { brandName: product.vendor.brandName } })
@@ -177,7 +196,9 @@ export async function addProduct(product: Product): Promise<void> {
   await db.product.create({ data });
 }
 
-export async function updateProduct(product: Product): Promise<void> {
+export async function updateProduct(
+  product: ProductInput & { id?: string | number }
+): Promise<void> {
   const db = getDb();
   const vendor = product.vendor?.brandName
     ? await db.user.findFirst({ where: { brandName: product.vendor.brandName } })

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,17 +1,17 @@
 import { useState, useEffect, useContext, useCallback, ChangeEvent } from 'react';
 import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
-import { Product, ApiMessage } from '../../types';
+import { Product, ProductInput, ApiMessage } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
 
 export default function Admin() {
   const { user } = useContext(AppContext)!;
-  type FormState = Partial<Product>;
+  type FormState = Partial<ProductInput> & { id?: string };
   const emptyForm: FormState = {
     id: '',
     sku: '',
     title: '',
-    vendor: '',
+    vendor: { email: '', brandName: '' },
     description: '',
     productType: '',
     tags: '',
@@ -19,6 +19,7 @@ export default function Admin() {
     minPrice: 0,
     maxPrice: 0,
     currency: 'USD',
+    category: { name: '', slug: '' },
   };
   const [form, setForm] = useState<FormState>(emptyForm);
   const [products, setProducts] = useState<Product[]>([]);
@@ -40,14 +41,40 @@ export default function Admin() {
   }, [fetchProducts]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const { name, value } = e.target;
+    setForm((prev) => {
+      if (name === 'vendor') {
+        return {
+          ...prev,
+          vendor: { ...(prev.vendor || { email: '' }), brandName: value },
+        };
+      }
+      if (name === 'category') {
+        return {
+          ...prev,
+          category: { ...(prev.category || { slug: '' }), name: value },
+        };
+      }
+      return { ...prev, [name]: value };
+    });
   };
 
   const submit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const fd = new FormData();
     const payload = editingId ? { ...form, id: editingId } : form;
-    Object.entries(payload).forEach(([k, v]) => fd.append(k, v));
+    fd.append('id', payload.id || '');
+    fd.append('sku', payload.sku || '');
+    fd.append('title', payload.title || '');
+    fd.append('vendor', payload.vendor?.brandName || '');
+    fd.append('description', payload.description || '');
+    fd.append('product_type', payload.productType || '');
+    fd.append('tags', payload.tags || '');
+    fd.append('category', payload.category?.name || '');
+    fd.append('quantity', String(payload.quantity ?? 0));
+    fd.append('min_price', String(payload.minPrice ?? 0));
+    fd.append('max_price', String(payload.maxPrice ?? 0));
+    fd.append('currency', payload.currency || '');
     photos.forEach((file) => fd.append('photos', file));
     try {
       await fetchJson<ApiMessage>('/api/admin/products', {
@@ -66,14 +93,21 @@ export default function Admin() {
   };
 
   const handleEdit = (p: Product) => {
-      setForm({
+    setForm({
       id: p.id,
       sku: p.sku || '',
       title: p.title || '',
-      vendor: p.vendor || '',
+      vendor:
+        typeof p.vendor === 'string'
+          ? { email: '', brandName: p.vendor }
+          : p.vendor || { email: '', brandName: '' },
       description: p.description || '',
       productType: p.productType || '',
       tags: p.tags || '',
+      category:
+        typeof p.category === 'string'
+          ? { name: p.category, slug: '' }
+          : p.category || { name: '', slug: '' },
       quantity: p.totalInventory || 0,
       minPrice: p.minPrice || 0,
       maxPrice: p.maxPrice || 0,
@@ -138,6 +172,7 @@ export default function Admin() {
                 'description',
                 'productType',
                 'tags',
+                'category',
                 'quantity',
                 'minPrice',
                 'maxPrice',
@@ -151,7 +186,13 @@ export default function Admin() {
                   </label>
                   <input
                     name={field}
-                    value={form[field]}
+                    value={
+                      field === 'vendor'
+                        ? form.vendor?.brandName || ''
+                        : field === 'category'
+                        ? form.category?.name || ''
+                        : (form as any)[field]
+                    }
                     onChange={handleChange}
                     placeholder={field}
                     className="input input-bordered w-full"

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -4,7 +4,7 @@ import { getProductByUuid } from '../../../../lib/db';
 import { hasOrdersForProduct } from '../../../../lib/orders';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../../lib/utils/getQueryParam';
-import type { ApiMessage } from '../../../../types';
+import type { ApiMessage, ProductInput } from '../../../../types';
 
 export default async function handler(
   req: NextApiRequest,
@@ -30,23 +30,24 @@ export default async function handler(
       max_price,
       currency,
     } = req.body || {};
-    await updateProduct({
-      id: String(uuid),
+    const payload: ProductInput & { id?: string } = {
+      uuid: String(uuid),
       sku: sku ?? existing.sku,
       title: title ?? existing.title,
-      vendor: vendor ?? existing.vendor,
+      vendor: { email: '', brandName: vendor ?? existing.vendor },
       description: description ?? existing.description,
-      product_type: product_type ?? existing.product_type,
+      productType: product_type ?? existing.product_type,
       tags: tags ?? existing.tags,
-      category: category ?? existing.category,
+      category: { name: category ?? existing.category, slug: '' },
       quantity:
         typeof quantity !== 'undefined' ? parseInt(quantity, 10) : existing.quantity,
-      min_price: typeof min_price !== 'undefined' ? parseFloat(min_price) : existing.min_price,
-      max_price: typeof max_price !== 'undefined' ? parseFloat(max_price) : existing.max_price,
+      minPrice: typeof min_price !== 'undefined' ? parseFloat(min_price) : existing.min_price,
+      maxPrice: typeof max_price !== 'undefined' ? parseFloat(max_price) : existing.max_price,
       currency: currency ?? existing.currency,
       status: existing.status,
-      images: existing.images,
-    });
+      images: [],
+    };
+    await updateProduct(payload);
       await loadAndIndexProducts();
       return res.status(200).json({ message: 'product updated' });
     }

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { addProduct, loadAndIndexProducts } from '../../../../lib/products';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../../lib/utils/getQueryParam';
-import type { Product, ApiMessage } from '../../../../types';
+import type { Product, ProductInput, ApiMessage } from '../../../../types';
 
 function slugify(text) {
   return text
@@ -44,23 +44,24 @@ export default async function handler(
     if (!id || !sku || !title || !vendor) {
       return res.status(400).json({ message: 'id, sku, title, vendor required' });
     }
-    await addProduct({
-      id: String(id),
-      slug: slugify(title || String(id)),
+    const payload: ProductInput = {
       sku,
       title,
-      vendor,
+      slug: slugify(title || String(id)),
+      uuid: String(id),
+      vendor: { email: '', brandName: vendor },
       description,
-      product_type,
+      productType: product_type,
       tags,
-      category,
+      category: { name: category, slug: '' },
       quantity: quantity ? parseInt(quantity, 10) : 0,
-      min_price: parseFloat(min_price || 0),
-      max_price: parseFloat(max_price || 0),
+      minPrice: parseFloat(min_price || '0'),
+      maxPrice: parseFloat(max_price || '0'),
       currency: currency || 'USD',
       status: 'approved',
-      images: JSON.stringify([]),
-      });
+      images: [],
+    };
+    await addProduct(payload);
       await loadAndIndexProducts();
       return res.status(201).json({ message: 'product created' });
     }

--- a/pages/api/products/[uuid].ts
+++ b/pages/api/products/[uuid].ts
@@ -6,13 +6,17 @@ import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
+export interface ProductParams {
+  uuid?: string | string[];
+}
+
 export type ProductResponse = Product & {
   AVERAGE_RATING: number;
   REVIEW_COUNT: number;
 };
 
 export default async function handler(
-  req: NextApiRequest,
+  req: NextApiRequest & { query: ProductParams },
   res: NextApiResponse<ProductResponse | ApiMessage>
 ): Promise<void> {
   const uuid = getQueryParam(req.query.uuid);

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -1,8 +1,16 @@
-import React, { useState, useEffect, useContext, useCallback, ChangeEvent, FormEvent } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useContext,
+  useCallback,
+  ChangeEvent,
+  FormEvent,
+} from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import type { User } from '../../types/user';
+import type { Product, ProductInput } from '../../types/product';
 
-type ProductForm = Partial<Product>;
+type ProductForm = Partial<ProductInput> & { id?: string };
 
 type ProductApi = Product;
 
@@ -11,11 +19,11 @@ const emptyForm: ProductForm = {
   id: '',
   sku: '',
   title: '',
-  vendor: '',
+  vendor: { email: '', brandName: '' },
   description: '',
   productType: '',
   tags: '',
-  category: '',
+  category: { name: '', slug: '' },
   quantity: 0,
   minPrice: 0,
   maxPrice: 0,
@@ -52,13 +60,27 @@ const BrandDashboard: React.FC = () => {
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setForm((prev) => ({
-      ...prev,
-      [name]:
-        name === 'quantity' || name === 'minPrice' || name === 'maxPrice'
-          ? Number(value)
-          : value,
-    }));
+    setForm((prev) => {
+      if (name === 'vendor') {
+        return {
+          ...prev,
+          vendor: { ...(prev.vendor || { email: '' }), brandName: value },
+        };
+      }
+      if (name === 'category') {
+        return {
+          ...prev,
+          category: { ...(prev.category || { slug: '' }), name: value },
+        };
+      }
+      return {
+        ...prev,
+        [name]:
+          name === 'quantity' || name === 'minPrice' || name === 'maxPrice'
+            ? Number(value)
+            : value,
+      };
+    });
   };
 
   const submit = async (e: FormEvent<HTMLFormElement>) => {
@@ -75,11 +97,11 @@ const BrandDashboard: React.FC = () => {
         id: payload.id,
         sku: payload.sku,
         title: payload.title,
-        vendor: payload.vendor,
+        vendor: payload.vendor?.brandName,
         description: payload.description,
         product_type: payload.productType,
         tags: payload.tags,
-        category: payload.category,
+        category: payload.category?.name,
         quantity: payload.quantity,
         min_price: payload.minPrice,
         max_price: payload.maxPrice,
@@ -102,11 +124,17 @@ const BrandDashboard: React.FC = () => {
       id: p.id,
       sku: p.sku || '',
       title: p.title || '',
-      vendor: p.vendor || '',
+      vendor:
+        typeof p.vendor === 'string'
+          ? { email: '', brandName: p.vendor }
+          : p.vendor || { email: '', brandName: '' },
       description: p.description || '',
       productType: p.productType || '',
       tags: p.tags || '',
-      category: p.category || '',
+      category:
+        typeof p.category === 'string'
+          ? { name: p.category, slug: '' }
+          : p.category || { name: '', slug: '' },
       quantity: p.totalInventory || 0,
       minPrice: p.minPrice || 0,
       maxPrice: p.maxPrice || 0,
@@ -170,7 +198,13 @@ const BrandDashboard: React.FC = () => {
             </label>
             <input
               name={field}
-              value={form[field]}
+              value={
+                field === 'vendor'
+                  ? form.vendor?.brandName || ''
+                  : field === 'category'
+                  ? form.category?.name || ''
+                  : (form as any)[field]
+              }
               onChange={handleChange}
               placeholder={field}
               className="input input-bordered w-full"


### PR DESCRIPTION
## Summary
- add `ProductRow` interface and strong typing in product helpers
- tighten `/api/products/[uuid]` parameters
- standardize brand and admin forms on `ProductInput`
- ensure brand product APIs use `ProductInput`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest' and 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685689c60f58832f8314c12f0537ea0e