### PR TITLE
Refactor forms to use typed react-hook-form

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,37 +1,69 @@
-import Link from 'next/link'
-import type { FC } from 'react'
+import Link from 'next/link';
+import type { FC } from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
 
 const Footer: FC = () => {
+  type NewsletterForm = { email: string };
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<NewsletterForm>();
+
+  const submit: SubmitHandler<NewsletterForm> = (data) => {
+    // TODO: send to newsletter API
+    console.log(data);
+  };
   return (
     <footer className="bg-base-300 mt-12 py-8 text-base-content">
       <div className="w-full px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-3 gap-8">
         <div>
           <h3 className="font-bold mb-2">Organic Store</h3>
-          <p className="text-sm text-gray-600">Quality products for healthy living.</p>
+          <p className="text-sm text-gray-600">
+            Quality products for healthy living.
+          </p>
         </div>
         <div>
           <h4 className="font-semibold mb-2">Quick Links</h4>
           <ul className="space-y-1">
-            <li><Link href="/">Home</Link></li>
-            <li><Link href="/products">Products</Link></li>
-            <li><Link href="/categories">Categories</Link></li>
+            <li>
+              <Link href="/">Home</Link>
+            </li>
+            <li>
+              <Link href="/products">Products</Link>
+            </li>
+            <li>
+              <Link href="/categories">Categories</Link>
+            </li>
           </ul>
         </div>
         <div>
           <h4 className="font-semibold mb-2">Newsletter</h4>
-          <form className="form-control">
+          <form onSubmit={handleSubmit(submit)} className="form-control">
             <label className="label">
               <span className="label-text">Email</span>
             </label>
             <div className="join">
-              <input type="email" placeholder="you@example.com" className="input input-bordered join-item" />
-              <button type="submit" className="btn join-item">Subscribe</button>
+              <input
+                type="email"
+                placeholder="you@example.com"
+                className="input input-bordered join-item"
+                {...register('email', { required: 'Email is required' })}
+              />
+              <button type="submit" className="btn join-item">
+                Subscribe
+              </button>
             </div>
+            {errors.email && (
+              <p className="text-red-500 text-sm mt-1">
+                {errors.email.message}
+              </p>
+            )}
           </form>
         </div>
       </div>
     </footer>
-  )
-}
+  );
+};
 
-export default Footer
+export default Footer;

--- a/components/form-fields/Checkbox.tsx
+++ b/components/form-fields/Checkbox.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { UseFormRegister, RegisterOptions } from 'react-hook-form';
+import {
+  UseFormRegister,
+  RegisterOptions,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
 
-export interface CheckboxProps
+export interface CheckboxProps<T extends FieldValues>
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  name: string;
+  name: Path<T>;
   checked?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
@@ -12,11 +17,11 @@ export interface CheckboxProps
   required?: boolean;
   disabled?: boolean;
   className?: string;
-  register?: UseFormRegister<any>;
+  register?: UseFormRegister<T>;
   rules?: RegisterOptions;
 }
 
-const Checkbox: React.FC<CheckboxProps> = ({
+const Checkbox = <T extends FieldValues>({
   label,
   name,
   checked,

--- a/components/form-fields/DatePicker.tsx
+++ b/components/form-fields/DatePicker.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { UseFormRegister, RegisterOptions } from 'react-hook-form';
+import {
+  UseFormRegister,
+  RegisterOptions,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
 
-export interface DatePickerProps
+export interface DatePickerProps<T extends FieldValues>
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  name: string;
+  name: Path<T>;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
@@ -12,11 +17,11 @@ export interface DatePickerProps
   required?: boolean;
   disabled?: boolean;
   className?: string;
-  register?: UseFormRegister<any>;
+  register?: UseFormRegister<T>;
   rules?: RegisterOptions;
 }
 
-const DatePicker: React.FC<DatePickerProps> = ({
+const DatePicker = <T extends FieldValues>({
   label,
   name,
   value,

--- a/components/form-fields/EmailInput.tsx
+++ b/components/form-fields/EmailInput.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { UseFormRegister, RegisterOptions } from 'react-hook-form';
+import {
+  UseFormRegister,
+  RegisterOptions,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
 
-export interface EmailInputProps
+export interface EmailInputProps<T extends FieldValues>
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  name: string;
+  name: Path<T>;
   placeholder?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -15,11 +20,11 @@ export interface EmailInputProps
   className?: string;
   leftAddon?: React.ReactNode;
   rightAddon?: React.ReactNode;
-  register?: UseFormRegister<any>;
+  register?: UseFormRegister<T>;
   rules?: RegisterOptions;
 }
 
-const EmailInput: React.FC<EmailInputProps> = ({
+const EmailInput = <T extends FieldValues>({
   label,
   name,
   placeholder,

--- a/components/form-fields/FileUpload.tsx
+++ b/components/form-fields/FileUpload.tsx
@@ -1,21 +1,26 @@
 import React from 'react';
-import { UseFormRegister, RegisterOptions } from 'react-hook-form';
+import {
+  UseFormRegister,
+  RegisterOptions,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
 
-export interface FileUploadProps
+export interface FileUploadProps<T extends FieldValues>
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  name: string;
+  name: Path<T>;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   error?: string;
   required?: boolean;
   disabled?: boolean;
   className?: string;
-  register?: UseFormRegister<any>;
+  register?: UseFormRegister<T>;
   rules?: RegisterOptions;
 }
 
-const FileUpload: React.FC<FileUploadProps> = ({
+const FileUpload = <T extends FieldValues>({
   label,
   name,
   onChange,

--- a/components/form-fields/PasswordInput.tsx
+++ b/components/form-fields/PasswordInput.tsx
@@ -1,10 +1,15 @@
 import React, { useState } from 'react';
-import { UseFormRegister, RegisterOptions } from 'react-hook-form';
+import {
+  UseFormRegister,
+  RegisterOptions,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
 
-export interface PasswordInputProps
+export interface PasswordInputProps<T extends FieldValues>
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  name: string;
+  name: Path<T>;
   placeholder?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -14,11 +19,11 @@ export interface PasswordInputProps
   disabled?: boolean;
   className?: string;
   leftAddon?: React.ReactNode;
-  register?: UseFormRegister<any>;
+  register?: UseFormRegister<T>;
   rules?: RegisterOptions;
 }
 
-const PasswordInput: React.FC<PasswordInputProps> = ({
+const PasswordInput = <T extends FieldValues>({
   label,
   name,
   placeholder,

--- a/components/form-fields/RadioGroup.tsx
+++ b/components/form-fields/RadioGroup.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
-import { UseFormRegister, RegisterOptions } from 'react-hook-form';
+import {
+  UseFormRegister,
+  RegisterOptions,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
 
 export interface RadioOption {
   label: string;
   value: string;
 }
 
-export interface RadioGroupProps {
+export interface RadioGroupProps<T extends FieldValues> {
   label?: string;
-  name: string;
+  name: Path<T>;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
@@ -17,11 +22,11 @@ export interface RadioGroupProps {
   required?: boolean;
   disabled?: boolean;
   className?: string;
-  register?: UseFormRegister<any>;
+  register?: UseFormRegister<T>;
   rules?: RegisterOptions;
 }
 
-const RadioGroup: React.FC<RadioGroupProps> = ({
+const RadioGroup = <T extends FieldValues>({
   label,
   name,
   value,

--- a/components/form-fields/SelectDropdown.tsx
+++ b/components/form-fields/SelectDropdown.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Control, Controller, RegisterOptions } from 'react-hook-form';
+import {
+  Control,
+  Controller,
+  RegisterOptions,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
 import Select from 'react-select';
 
 export interface SelectOption {
@@ -7,9 +13,9 @@ export interface SelectOption {
   value: string;
 }
 
-export interface SelectDropdownProps {
+export interface SelectDropdownProps<T extends FieldValues> {
   label?: string;
-  name: string;
+  name: Path<T>;
   value?: SelectOption | SelectOption[] | null;
   onChange?: (option: SelectOption | SelectOption[] | null) => void;
   options: SelectOption[];
@@ -21,12 +27,12 @@ export interface SelectDropdownProps {
   className?: string;
   icon?: React.ReactNode;
   components?: any;
-  control?: Control<any>;
+  control?: Control<T>;
   rules?: RegisterOptions;
   [key: string]: unknown;
 }
 
-const SelectDropdown: React.FC<SelectDropdownProps> = ({
+const SelectDropdown = <T extends FieldValues>({
   label,
   name,
   value,

--- a/components/form-fields/TextInput.tsx
+++ b/components/form-fields/TextInput.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { UseFormRegister, RegisterOptions } from 'react-hook-form';
+import {
+  UseFormRegister,
+  RegisterOptions,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
 
-export interface TextInputProps
+export interface TextInputProps<T extends FieldValues>
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  name: string;
+  name: Path<T>;
   placeholder?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -15,11 +20,11 @@ export interface TextInputProps
   className?: string;
   leftAddon?: React.ReactNode;
   rightAddon?: React.ReactNode;
-  register?: UseFormRegister<any>;
+  register?: UseFormRegister<T>;
   rules?: RegisterOptions;
 }
 
-const TextInput: React.FC<TextInputProps> = ({
+const TextInput = <T extends FieldValues>({
   label,
   name,
   placeholder,

--- a/components/form-fields/Textarea.tsx
+++ b/components/form-fields/Textarea.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { UseFormRegister, RegisterOptions } from 'react-hook-form';
+import {
+  UseFormRegister,
+  RegisterOptions,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
 
-export interface TextareaProps
+export interface TextareaProps<T extends FieldValues>
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   label?: string;
-  name: string;
+  name: Path<T>;
   placeholder?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
@@ -13,11 +18,11 @@ export interface TextareaProps
   required?: boolean;
   disabled?: boolean;
   className?: string;
-  register?: UseFormRegister<any>;
+  register?: UseFormRegister<T>;
   rules?: RegisterOptions;
 }
 
-const Textarea: React.FC<TextareaProps> = ({
+const Textarea = <T extends FieldValues>({
   label,
   name,
   placeholder,

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -1,14 +1,18 @@
-import { useContext, useState, useEffect, FormEvent, ChangeEvent } from 'react';
+import { useContext, useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
 import Head from 'next/head';
 import Link from 'next/link';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { AppContext } from '../../contexts/AppContext';
 import ProductImageSlider from '../../components/ProductImageSlider';
 import RecommendedProducts from '../../components/RecommendedProducts';
-import { getProductBySlug, getReviewsForProduct, getAverageRating } from '../../lib/db';
+import {
+  getProductBySlug,
+  getReviewsForProduct,
+  getAverageRating,
+} from '../../lib/db';
 import { mapDbRowToProduct } from '../../lib/products';
 import { Product, Review } from '../../types';
-
 
 type ProductDetailProps = {
   product: Product;
@@ -18,7 +22,9 @@ type ProductDetailProps = {
 };
 
 // --- getServerSideProps ---
-export const getServerSideProps: GetServerSideProps<ProductDetailProps> = async (context: GetServerSidePropsContext) => {
+export const getServerSideProps: GetServerSideProps<
+  ProductDetailProps
+> = async (context: GetServerSidePropsContext) => {
   const { params } = context;
   if (!params || typeof params.slug !== 'string') {
     return { notFound: true };
@@ -51,28 +57,40 @@ export default function ProductDetail({
   const [reviews, setReviews] = useState<Review[]>(initialReviews);
   const [averageRating, setAverageRating] = useState<number>(initialAverage);
   const [reviewCount, setReviewCount] = useState<number>(initialCount);
-  const [myRating, setMyRating] = useState<number>(5);
-  const [comment, setComment] = useState<string>('');
+  type ReviewForm = { rating: number; comment: string };
+  const { register, handleSubmit, reset, watch } = useForm<ReviewForm>({
+    defaultValues: { rating: 5, comment: '' },
+  });
+  const myRating = watch('rating');
   const id = product.id;
 
   useEffect(() => {
     try {
-      const stored: string[] = JSON.parse(localStorage.getItem('browse-history') || '[]');
+      const stored: string[] = JSON.parse(
+        localStorage.getItem('browse-history') || '[]'
+      );
       const updated = [id, ...stored.filter((v) => v !== id)];
-      localStorage.setItem('browse-history', JSON.stringify(updated.slice(0, 20)));
+      localStorage.setItem(
+        'browse-history',
+        JSON.stringify(updated.slice(0, 20))
+      );
     } catch {
       // ignore
     }
   }, [id]);
 
   if (!appCtx) return null;
-  const { addToCart, addToWishlist, removeFromWishlist, wishlist, user } = appCtx;
+  const { addToCart, addToWishlist, removeFromWishlist, wishlist, user } =
+    appCtx;
 
   return (
     <div className="p-6 max-w-screen-2xl mx-auto bg-base-100 rounded-box shadow-md min-h-screen">
       <Head>
         <title>{product.title} - Product</title>
-        <meta name="description" content={product.descriptionText?.slice(0, 150)} />
+        <meta
+          name="description"
+          content={product.descriptionText?.slice(0, 150)}
+        />
       </Head>
       <div className="flex flex-col md:flex-row gap-8">
         <div className="md:w-1/2 flex justify-center">
@@ -82,8 +100,8 @@ export default function ProductDetail({
               product.images && product.images.length > 0
                 ? product.images
                 : product.featuredImage
-                ? [product.featuredImage]
-                : []
+                  ? [product.featuredImage]
+                  : []
             }
             imgClass="hover:scale-110 transition"
           />
@@ -94,7 +112,9 @@ export default function ProductDetail({
           <p className="mb-2">SKU: {product.sku}</p>
           <p className="mb-2">Type: {product.productType}</p>
           <p className="mb-4">
-            {product.descriptionText || product.bodyHtmlText || 'No description available.'}
+            {product.descriptionText ||
+              product.bodyHtmlText ||
+              'No description available.'}
           </p>
           <p className="text-lg font-bold mb-4">
             {product.currency}{' '}
@@ -146,34 +166,31 @@ export default function ProductDetail({
         {reviews.length === 0 && <p>No reviews yet.</p>}
         {user && (
           <form
-            onSubmit={async (e: FormEvent<HTMLFormElement>) => {
-              e.preventDefault();
+            onSubmit={handleSubmit(async (data) => {
               const res = await fetch(`/api/products/${id}/reviews`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ rating: myRating, comment }),
+                body: JSON.stringify(data),
               });
               if (res.ok) {
-                const data = await res.json();
-                setAverageRating(data.averageRating);
-                setReviewCount(data.reviewCount);
+                const response = await res.json();
+                setAverageRating(response.averageRating);
+                setReviewCount(response.reviewCount);
                 const rres = await fetch(`/api/products/${id}/reviews`);
                 if (rres.ok) {
                   const rdata = await rres.json();
                   setReviews(rdata.reviews);
                 }
-                setComment('');
-                setMyRating(5);
+                reset({ rating: 5, comment: '' });
               }
-            }}
+            })}
             className="mt-4 space-y-2"
           >
             <div>
               <label className="mr-2">Rating</label>
               <select
-                value={myRating}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setMyRating(parseInt(e.target.value))}
                 className="select select-bordered"
+                {...register('rating', { valueAsNumber: true })}
               >
                 {[1, 2, 3, 4, 5].map((n) => (
                   <option key={n} value={n}>
@@ -184,11 +201,13 @@ export default function ProductDetail({
             </div>
             <textarea
               className="textarea textarea-bordered w-full"
-              value={comment}
-              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setComment(e.target.value)}
               placeholder="Write a review"
+              {...register('comment')}
             />
-            <button className="btn btn-sm btn-primary transition-all duration-200" type="submit">
+            <button
+              className="btn btn-sm btn-primary transition-all duration-200"
+              type="submit"
+            >
               Submit Review
             </button>
           </form>

--- a/pages/reset/[token].tsx
+++ b/pages/reset/[token].tsx
@@ -1,14 +1,15 @@
 import { useRouter } from 'next/router';
-import { FormEvent, useState } from 'react';
+import { useState } from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
 
 const ResetToken: React.FC = () => {
   const router = useRouter();
   const { token } = router.query as { token?: string };
-  const [password, setPassword] = useState<string>('');
+  type ResetForm = { password: string };
+  const { register, handleSubmit } = useForm<ResetForm>();
   const [message, setMessage] = useState<string>('');
 
-  const submit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const submit: SubmitHandler<ResetForm> = async ({ password }) => {
     const res = await fetch('/api/reset-password', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -24,13 +25,12 @@ const ResetToken: React.FC = () => {
   return (
     <div className="max-w-sm mx-auto">
       <h1 className="text-2xl font-bold mb-4">Set New Password</h1>
-      <form onSubmit={submit} className="space-y-2">
+      <form onSubmit={handleSubmit(submit)} className="space-y-2">
         <input
           className="input input-bordered w-full"
           type="password"
-          value={password}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
           placeholder="New Password"
+          {...register('password', { required: true })}
         />
         <button className="btn btn-primary w-full" type="submit">
           Reset Password

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -1,31 +1,48 @@
-import React, { useContext, useState, useEffect, FormEvent } from 'react';
+import React, { useContext, useEffect } from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
 import { AppContext } from '../../contexts/AppContext';
 import type { User } from '../../types/user';
 
 export const UserProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
-  const [phoneNumber, setPhoneNumber] = useState<string>(user?.phoneNumber || '');
-  const [address, setAddress] = useState<string>(user?.address || '');
-  const [city, setCity] = useState<string>(user?.city || '');
-  const [country, setCountry] = useState<string>(user?.country || '');
-  const [message, setMessage] = useState<string>('');
+  type ProfileForm = {
+    phoneNumber: string;
+    address: string;
+    city: string;
+    country: string;
+  };
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ProfileForm>({
+    defaultValues: {
+      phoneNumber: '',
+      address: '',
+      city: '',
+      country: '',
+    },
+  });
+  const [message, setMessage] = React.useState<string>('');
 
   useEffect(() => {
     if (user) {
-      setPhoneNumber(user.phoneNumber || '');
-      setAddress(user.address || '');
-      setCity(user.city || '');
-      setCountry(user.country || '');
+      reset({
+        phoneNumber: user.phoneNumber || '',
+        address: user.address || '',
+        city: user.city || '',
+        country: user.country || '',
+      });
     }
-  }, [user]);
+  }, [user, reset]);
 
-  const submit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const submit: SubmitHandler<ProfileForm> = async (data) => {
     setMessage('');
     const res = await fetch('/api/user/profile', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ phoneNumber, address, city, country }),
+      body: JSON.stringify(data),
     });
     if (res.ok) setMessage('Profile updated');
     else setMessage('Update failed');
@@ -39,30 +56,26 @@ export const UserProfile: React.FC = () => {
     <div className="max-w-sm mx-auto">
       <h1 className="text-2xl font-bold mb-4">My Profile</h1>
       {message && <div className="mb-2 text-green-600">{message}</div>}
-      <form onSubmit={submit} className="space-y-2">
+      <form onSubmit={handleSubmit(submit)} className="space-y-2">
         <input
           className="input input-bordered w-full"
-          value={phoneNumber}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPhoneNumber(e.target.value)}
           placeholder="Phone Number"
+          {...register('phoneNumber')}
         />
         <input
           className="input input-bordered w-full"
-          value={address}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAddress(e.target.value)}
           placeholder="Address"
+          {...register('address')}
         />
         <input
           className="input input-bordered w-full"
-          value={city}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCity(e.target.value)}
           placeholder="City"
+          {...register('city')}
         />
         <input
           className="input input-bordered w-full"
-          value={country}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCountry(e.target.value)}
           placeholder="Country"
+          {...register('country')}
         />
         <button className="btn btn-primary w-full" type="submit">
           Update


### PR DESCRIPTION
## Summary
- enforce generics on form field components
- refactor newsletter, profile, reset password and review forms to use `react-hook-form`

## Testing
- `npm run format`
- `npm run type-check` *(fails: Cannot find type definition file for 'jest', 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68568b3b5148832fbc820c0f235be49e