### PR TITLE
Refactor API Auth – Use Session Instead of Query Params

### DIFF
--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -14,7 +14,8 @@ import {
 import { withRole } from '../../lib/withRole';
 import { sendOrderConfirmation } from '../../lib/email';
 import { handleApiError } from '../../lib/utils/handleApiError';
-import { getQueryParam } from '../../lib/utils/getQueryParam';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
 import type { Order, OrderPlacedResponse, ApiMessage } from '../../types';
 
 async function handler(
@@ -56,8 +57,9 @@ async function handler(
   }
 
   if (req.method === 'GET') {
-    const email = getQueryParam(req.query.email);
-    if (!email) return res.status(400).json({ message: 'email required' });
+    const session = await getServerSession(req, res, authOptions);
+    const email = session?.user?.email;
+    if (!email) return res.status(401).json({ message: 'Unauthorized' });
     const user = await findUser(email);
     if (!user) return res.status(404).json({ message: 'user not found' });
     if (user.role === 'SUPER_ADMIN') {


### PR DESCRIPTION
## Summary
- fetch the email for order queries from the authenticated session

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568b4bd9ac832f912bdb36b0ebeb8e