### PR TITLE
Standardize User types

### DIFF
--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,67 +1,48 @@
 import { getDb } from './db';
 import type { Prisma, Role } from '@prisma/client';
+import type { UserInput } from '../types/user';
 
 const prisma = getDb();
-
-interface AddUserInput {
-  email: string;
-  password: string;
-  first_name: string;
-  last_name: string;
-  brand_name?: string;
-  gender?: string;
-  phone_number?: string;
-  address?: string;
-  city?: string;
-  country?: string;
-  business_address?: string;
-  website?: string;
-  business_description?: string;
-  logo?: string;
-  tax_id?: string;
-  role?: Role;
-  verification_token?: string;
-}
 
 export async function addUser({
   email,
   password,
-  first_name,
-  last_name,
-  brand_name,
+  firstName,
+  lastName,
+  brandName,
   gender = 'OTHER',
-  phone_number,
+  phoneNumber,
   address,
   city,
   country,
-  business_address,
+  businessAddress,
   website,
-  business_description,
+  businessDescription,
   logo,
-  tax_id,
+  taxId,
   role = 'USER',
-  verification_token,
-}: AddUserInput): Promise<void> {
+  verificationToken,
+}: UserInput): Promise<void> {
   await prisma.user.create({
     data: {
       email,
       password,
-      firstName: first_name,
-      lastName: last_name,
-      brandName: brand_name,
+      firstName,
+      lastName,
+      brandName,
       gender,
-      phoneNumber: phone_number,
+      phoneNumber,
       address,
       city,
       country,
-      businessAddress: business_address,
+      businessAddress,
       website,
-      businessDescription: business_description,
+      businessDescription,
       logo,
-      taxId: tax_id,
+      taxId,
       role: role as Role,
       disabled: false,
-      verificationToken: verification_token,
+      verificationToken,
     },
   });
 }
@@ -103,7 +84,11 @@ export function verifyUser(token: string) {
   });
 }
 
-export function setResetToken(email: string, token: string, expires: string | number | Date) {
+export function setResetToken(
+  email: string,
+  token: string,
+  expires: string | number | Date
+) {
   return prisma.user.update({
     where: { email },
     data: { resetToken: token, resetExpires: new Date(expires) },

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -42,30 +42,23 @@ async function handler(
       return res.status(200).json({ message: 'status updated' });
     }
     if (req.method === 'DELETE') {
-        const email = getQueryParam(req.query.email);
-        if (!email) return res.status(400).json({ message: 'email required' });
-        await deleteUser(email);
+      const email = getQueryParam(req.query.email);
+      if (!email) return res.status(400).json({ message: 'email required' });
+      await deleteUser(email);
       return res.status(200).json({ message: 'user deleted' });
     }
     if (req.method === 'POST') {
-      const {
-        email,
-        password,
-        firstName,
-        lastName,
-        brandName,
-        gender,
-        role,
-      } = req.body as CreateUserRequest;
+      const { email, password, firstName, lastName, brandName, gender, role } =
+        req.body as CreateUserRequest;
       if (!email || !password || !firstName || !lastName || !gender) {
         return res.status(400).json({ message: 'missing required fields' });
       }
       await addUser({
         email,
         password,
-        first_name: firstName,
-        last_name: lastName,
-        brand_name: brandName,
+        firstName,
+        lastName,
+        brandName,
         gender,
         role: (role || 'USER') as Role,
       });

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -68,7 +68,10 @@ export const authOptions: AuthOptions = {
   ],
   callbacks: {
     async signIn({ user, account, profile }) {
-      if (account && (account.provider === 'google' || account.provider === 'github')) {
+      if (
+        account &&
+        (account.provider === 'google' || account.provider === 'github')
+      ) {
         if (!user.email) {
           return false;
         }
@@ -81,9 +84,9 @@ export const authOptions: AuthOptions = {
           await addUser({
             email: user.email,
             password: '',
-            first_name: nameParts[0] || '',
-            last_name: nameParts.slice(1).join(' ') || '',
-            brand_name: '',
+            firstName: nameParts[0] || '',
+            lastName: nameParts.slice(1).join(' ') || '',
+            brandName: '',
             gender: '',
             role: 'USER',
           });

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -26,12 +26,12 @@ export default async function handler(
     await addUser({
       email,
       password: hashed,
-      first_name: firstName,
-      last_name: lastName,
-      brand_name: brandName,
+      firstName,
+      lastName,
+      brandName,
       gender,
       role: role || 'USER',
-      verification_token: token,
+      verificationToken: token,
     });
     return res.status(201).json({
       message: 'User created',

--- a/pages/api/signup/brand.ts
+++ b/pages/api/signup/brand.ts
@@ -63,18 +63,18 @@ export default async function handler(
     await addUser({
       email,
       password: hashed,
-      first_name: firstName,
-      last_name: lastName,
-      brand_name: brandName,
-      phone_number: phoneNumber,
-      business_address: businessAddress,
+      firstName,
+      lastName,
+      brandName,
+      phoneNumber,
+      businessAddress,
       city,
       country,
       website: website || null,
-      business_description: businessDescription || null,
-      tax_id: taxId || null,
+      businessDescription: businessDescription || null,
+      taxId: taxId || null,
       role: 'BRAND',
-      verification_token: token,
+      verificationToken: token,
     });
     return res.status(201).json({ token });
   } catch (error) {

--- a/pages/api/signup/user.ts
+++ b/pages/api/signup/user.ts
@@ -45,15 +45,15 @@ export default async function handler(
     await addUser({
       email,
       password: hashed,
-      first_name: firstName,
-      last_name: lastName,
+      firstName,
+      lastName,
       gender: gender || '',
-      phone_number: phoneNumber || null,
+      phoneNumber: phoneNumber || null,
       address: address || null,
       city: city || null,
       country: country || null,
       role: 'USER',
-      verification_token: token,
+      verificationToken: token,
     });
     return res.status(201).json({ token });
   } catch (error) {

--- a/types/user.ts
+++ b/types/user.ts
@@ -13,6 +13,14 @@ export interface User {
   country?: string;
   brandName?: string;
   gender?: string;
+  businessAddress?: string;
+  website?: string;
+  businessDescription?: string;
+  logo?: string;
+  taxId?: string;
+  verificationToken?: string;
+  resetToken?: string;
+  resetExpires?: Date;
   verified?: boolean;
   disabled?: boolean;
   createdAt?: Date;
@@ -28,4 +36,15 @@ export interface UserInput {
   lastName?: string;
   brandName?: string;
   gender?: string;
+  phoneNumber?: string;
+  address?: string;
+  city?: string;
+  country?: string;
+  businessAddress?: string;
+  website?: string;
+  businessDescription?: string;
+  logo?: string;
+  taxId?: string;
+  role?: Role;
+  verificationToken?: string;
 }


### PR DESCRIPTION
## Summary
- extend `User` interface with brand fields and tokens
- remove duplicate `AddUserInput` type
- use shared `UserInput` throughout API handlers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6856914329d8832f83280395f83824ce