### PR TITLE
refactor: unify form fields

### DIFF
--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { AppContext } from '../../contexts/AppContext';
 import { Category, CategoryInput, ApiMessage } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
+import { TextInput } from '../../components/form-fields';
 
 export default function Categories() {
   const { user } = useContext(AppContext)!;
@@ -79,17 +80,17 @@ export default function Categories() {
       <h1 className="text-2xl font-bold mb-4">Categories</h1>
       {message && <div className="mb-4 text-green-600">{message}</div>}
       <div className="flex gap-2 mb-4">
-        <input
+        <TextInput
           value={newCat}
           onChange={(e) => setNewCat(e.target.value)}
           placeholder="New category"
-          className="input input-bordered flex-1"
+          className="flex-1"
         />
-        <input
+        <TextInput
           value={newImage}
           onChange={(e) => setNewImage(e.target.value)}
           placeholder="Image URL (optional)"
-          className="input input-bordered flex-1"
+          className="flex-1"
         />
         <select
           className="select select-bordered"
@@ -117,7 +118,9 @@ export default function Categories() {
     </div>
   );
 
-  function buildTree(list: Category[]): (Category & { children: Category[] })[] {
+  function buildTree(
+    list: Category[]
+  ): (Category & { children: Category[] })[] {
     const map: Record<number, Category & { children: Category[] }> =
       {} as Record<number, Category & { children: Category[] }>;
     list.forEach((c) => {
@@ -141,13 +144,13 @@ export default function Categories() {
         <div className="flex items-center gap-2">
           {editing === cat.id ? (
             <>
-              <input
-                className="input input-bordered flex-1"
+              <TextInput
+                className="flex-1"
                 value={editName}
                 onChange={(e) => setEditName(e.target.value)}
               />
-              <input
-                className="input input-bordered flex-1"
+              <TextInput
+                className="flex-1"
                 value={editImage}
                 onChange={(e) => setEditImage(e.target.value)}
                 placeholder="Image URL (optional)"

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,8 +1,15 @@
-import { useState, useEffect, useContext, useCallback, ChangeEvent } from 'react';
+import {
+  useState,
+  useEffect,
+  useContext,
+  useCallback,
+  ChangeEvent,
+} from 'react';
 import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
 import { Product, ProductInput, ApiMessage } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
+import { TextInput } from '../../components/form-fields';
 
 export default function Admin() {
   const { user } = useContext(AppContext)!;
@@ -178,26 +185,19 @@ export default function Admin() {
                 'maxPrice',
                 'currency',
               ].map((field) => (
-                <div key={field}>
-                  <label className="label capitalize">
-                    <span className="label-text">
-                      {field.replace('_', ' ')}
-                    </span>
-                  </label>
-                  <input
-                    name={field}
-                    value={
-                      field === 'vendor'
-                        ? form.vendor?.brandName || ''
-                        : field === 'category'
+                <TextInput
+                  key={field}
+                  name={field as keyof FormState}
+                  value={
+                    field === 'vendor'
+                      ? form.vendor?.brandName || ''
+                      : field === 'category'
                         ? form.category?.name || ''
                         : (form as any)[field]
-                    }
-                    onChange={handleChange}
-                    placeholder={field}
-                    className="input input-bordered w-full"
-                  />
-                </div>
+                  }
+                  onChange={handleChange}
+                  placeholder={field}
+                />
               ))}
               <div>
                 <label className="label">

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -9,11 +9,11 @@ import React, {
 import { AppContext } from '../../contexts/AppContext';
 import type { User } from '../../types/user';
 import type { Product, ProductInput } from '../../types/product';
+import { TextInput } from '../../components/form-fields';
 
 type ProductForm = Partial<ProductInput> & { id?: string };
 
 type ProductApi = Product;
-
 
 const emptyForm: ProductForm = {
   id: '',
@@ -179,7 +179,7 @@ const BrandDashboard: React.FC = () => {
         {(
           [
             'id',
-              'sku',
+            'sku',
             'title',
             'vendor',
             'description',
@@ -192,31 +192,26 @@ const BrandDashboard: React.FC = () => {
             'currency',
           ] as (keyof ProductForm)[]
         ).map((field) => (
-          <div key={field}>
-            <label className="label capitalize">
-              <span className="label-text">{field.replace('_', ' ')}</span>
-            </label>
-            <input
-              name={field}
-              value={
-                field === 'vendor'
-                  ? form.vendor?.brandName || ''
-                  : field === 'category'
+          <TextInput
+            key={field}
+            name={field as keyof ProductForm}
+            value={
+              field === 'vendor'
+                ? form.vendor?.brandName || ''
+                : field === 'category'
                   ? form.category?.name || ''
                   : (form as any)[field]
-              }
-              onChange={handleChange}
-              placeholder={field}
-              className="input input-bordered w-full"
-              type={
-                field === 'quantity' ||
-                field === 'minPrice' ||
-                field === 'maxPrice'
-                  ? 'number'
-                  : 'text'
-              }
-            />
-          </div>
+            }
+            onChange={handleChange as any}
+            placeholder={field}
+            type={
+              field === 'quantity' ||
+              field === 'minPrice' ||
+              field === 'maxPrice'
+                ? 'number'
+                : 'text'
+            }
+          />
         ))}
         <div className="flex gap-2">
           {editingId && (

--- a/pages/brand/profile.tsx
+++ b/pages/brand/profile.tsx
@@ -1,16 +1,29 @@
-import React, { useContext, useState, useEffect, ChangeEvent, FormEvent } from 'react';
+import React, {
+  useContext,
+  useState,
+  useEffect,
+  ChangeEvent,
+  FormEvent,
+} from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import type { User, Vendor } from '../../types';
+import { TextInput, Textarea } from '../../components/form-fields';
 
 export const BrandProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
   const [brandName, setBrandName] = useState<string>(user?.brandName || '');
-  const [phoneNumber, setPhoneNumber] = useState<string>(user?.phoneNumber || '');
-  const [businessAddress, setBusinessAddress] = useState<string>(user?.businessAddress || '');
+  const [phoneNumber, setPhoneNumber] = useState<string>(
+    user?.phoneNumber || ''
+  );
+  const [businessAddress, setBusinessAddress] = useState<string>(
+    user?.businessAddress || ''
+  );
   const [city, setCity] = useState<string>(user?.city || '');
   const [country, setCountry] = useState<string>(user?.country || '');
   const [website, setWebsite] = useState<string>(user?.website || '');
-  const [businessDescription, setBusinessDescription] = useState<string>(user?.businessDescription || '');
+  const [businessDescription, setBusinessDescription] = useState<string>(
+    user?.businessDescription || ''
+  );
   const [taxId, setTaxId] = useState<string>(user?.taxId || '');
   const [message, setMessage] = useState<string>('');
 
@@ -74,52 +87,60 @@ export const BrandProfile: React.FC = () => {
       <h1 className="text-2xl font-bold mb-4">Brand Profile</h1>
       {message && <div className="mb-2 text-green-600">{message}</div>}
       <form onSubmit={submit} className="space-y-2">
-        <input
-          className="input input-bordered w-full"
+        <TextInput
           value={brandName}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setBrandName(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setBrandName(e.target.value)
+          }
           placeholder="Brand Name"
         />
-        <input
-          className="input input-bordered w-full"
+        <TextInput
           value={phoneNumber}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setPhoneNumber(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setPhoneNumber(e.target.value)
+          }
           placeholder="Phone Number"
         />
-        <input
-          className="input input-bordered w-full"
+        <TextInput
           value={businessAddress}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setBusinessAddress(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setBusinessAddress(e.target.value)
+          }
           placeholder="Business Address"
         />
-        <input
-          className="input input-bordered w-full"
+        <TextInput
           value={city}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setCity(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setCity(e.target.value)
+          }
           placeholder="City"
         />
-        <input
-          className="input input-bordered w-full"
+        <TextInput
           value={country}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setCountry(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setCountry(e.target.value)
+          }
           placeholder="Country"
         />
-        <input
-          className="input input-bordered w-full"
+        <TextInput
           value={website}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setWebsite(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setWebsite(e.target.value)
+          }
           placeholder="Website"
         />
-        <textarea
-          className="textarea textarea-bordered w-full"
+        <Textarea
           value={businessDescription}
-          onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setBusinessDescription(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+            setBusinessDescription(e.target.value)
+          }
           placeholder="Business Description"
         />
-        <input
-          className="input input-bordered w-full"
+        <TextInput
           value={taxId}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setTaxId(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setTaxId(e.target.value)
+          }
           placeholder="Tax ID"
         />
         <button className="btn btn-primary w-full" type="submit">

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { AppContext, AppContextValue } from '../contexts/AppContext';
 import type { User } from '../types/user';
 import type { Coupon } from '../types';
+import { TextInput, Textarea } from '../components/form-fields';
 
 // Types for cart item and user
 type CartItem = {
@@ -114,9 +115,9 @@ const Checkout: React.FC = () => {
             Coupon Code
           </label>
           <div className="flex gap-2">
-            <input
+            <TextInput
               id="coupon"
-              className="input input-bordered flex-1"
+              className="flex-1"
               value={coupon}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 setCoupon(e.target.value)
@@ -157,9 +158,9 @@ const Checkout: React.FC = () => {
           <label className="label" htmlFor="name">
             Name
           </label>
-          <input
+          <TextInput
             id="name"
-            className="input input-bordered w-full"
+            className="w-full"
             value={name}
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
               setName(e.target.value)
@@ -171,9 +172,9 @@ const Checkout: React.FC = () => {
           <label className="label" htmlFor="address">
             Address
           </label>
-          <textarea
+          <Textarea
             id="address"
-            className="textarea textarea-bordered w-full"
+            className="w-full"
             value={address}
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
               setAddress(e.target.value)

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -13,6 +13,7 @@ import {
 } from '../../lib/db';
 import { mapDbRowToProduct } from '../../lib/products';
 import { Product, Review } from '../../types';
+import { SelectDropdown, Textarea } from '../../components/form-fields';
 
 type ProductDetailProps = {
   product: Product;
@@ -58,9 +59,11 @@ export default function ProductDetail({
   const [averageRating, setAverageRating] = useState<number>(initialAverage);
   const [reviewCount, setReviewCount] = useState<number>(initialCount);
   type ReviewForm = { rating: number; comment: string };
-  const { register, handleSubmit, reset, watch } = useForm<ReviewForm>({
-    defaultValues: { rating: 5, comment: '' },
-  });
+  const { register, handleSubmit, reset, watch, control } = useForm<ReviewForm>(
+    {
+      defaultValues: { rating: 5, comment: '' },
+    }
+  );
   const myRating = watch('rating');
   const id = product.id;
 
@@ -188,21 +191,22 @@ export default function ProductDetail({
           >
             <div>
               <label className="mr-2">Rating</label>
-              <select
-                className="select select-bordered"
-                {...register('rating', { valueAsNumber: true })}
-              >
-                {[1, 2, 3, 4, 5].map((n) => (
-                  <option key={n} value={n}>
-                    {n}
-                  </option>
-                ))}
-              </select>
+              <SelectDropdown
+                name="rating"
+                control={control}
+                options={[1, 2, 3, 4, 5].map((n) => ({
+                  label: String(n),
+                  value: String(n),
+                }))}
+                rules={{ valueAsNumber: true }}
+                className="max-w-xs"
+              />
             </div>
-            <textarea
-              className="textarea textarea-bordered w-full"
+            <Textarea
+              className="w-full"
               placeholder="Write a review"
-              {...register('comment')}
+              register={register}
+              name="comment"
             />
             <button
               className="btn btn-sm btn-primary transition-all duration-200"

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -5,7 +5,12 @@ import Link from 'next/link';
 import Head from 'next/head';
 import ProductImageSlider from '../../components/ProductImageSlider';
 import type { Product } from '../../types';
-import type { Review, ReviewsResponse, ReviewAddedResponse } from '../../types/review';
+import type {
+  Review,
+  ReviewsResponse,
+  ReviewAddedResponse,
+} from '../../types/review';
+import { SelectDropdown, Textarea } from '../../components/form-fields';
 
 interface ProductDetailProps {}
 
@@ -22,7 +27,8 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
   const [myRating, setMyRating] = useState<number>(5);
   const [comment, setComment] = useState<string>('');
 
-  const { addToCart, addToWishlist, removeFromWishlist, wishlist, user } = appContext ?? {};
+  const { addToCart, addToWishlist, removeFromWishlist, wishlist, user } =
+    appContext ?? {};
 
   useEffect(() => {
     if (!id) return;
@@ -95,8 +101,8 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
             product.images && product.images.length > 0
               ? product.images
               : product.featuredImage
-              ? [product.featuredImage]
-              : []
+                ? [product.featuredImage]
+                : []
           }
           imgClass="hover:scale-110 transition"
         />
@@ -112,7 +118,9 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
         {product.currency || ''}{' '}
         {product.minPrice ? product.minPrice.toFixed(2) : 'N/A'}
       </p>
-      <p className="mb-2">Rating: {averageRating.toFixed(1)} ({reviewCount})</p>
+      <p className="mb-2">
+        Rating: {averageRating.toFixed(1)} ({reviewCount})
+      </p>
       <div className="flex gap-2">
         <button
           className="btn btn-primary"
@@ -129,7 +137,11 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
             Remove Wishlist
           </button>
         ) : (
-          <button className="btn" onClick={() => addToWishlist?.(product)} disabled={!addToWishlist}>
+          <button
+            className="btn"
+            onClick={() => addToWishlist?.(product)}
+            disabled={!addToWishlist}
+          >
             Add Wishlist
           </button>
         )}
@@ -172,20 +184,25 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
           >
             <div>
               <label className="mr-2">Rating</label>
-              <select
-                value={myRating}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setMyRating(parseInt(e.target.value))}
-                className="select select-bordered"
-              >
-                {[1, 2, 3, 4, 5].map((n) => (
-                  <option key={n} value={n}>{n}</option>
-                ))}
-              </select>
+              <SelectDropdown
+                name="rating"
+                value={{ label: String(myRating), value: String(myRating) }}
+                onChange={(opt) =>
+                  setMyRating(opt ? parseInt((opt as any).value) : 5)
+                }
+                options={[1, 2, 3, 4, 5].map((n) => ({
+                  label: String(n),
+                  value: String(n),
+                }))}
+                className="max-w-xs"
+              />
             </div>
-            <textarea
-              className="textarea textarea-bordered w-full"
+            <Textarea
+              className="w-full"
               value={comment}
-              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setComment(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                setComment(e.target.value)
+              }
               placeholder="Write a review"
             />
             <button className="btn btn-sm btn-primary" type="submit">

--- a/pages/reset.tsx
+++ b/pages/reset.tsx
@@ -1,4 +1,5 @@
 import { useState, FormEvent, ChangeEvent } from 'react';
+import { TextInput } from '../components/form-fields';
 
 const RequestReset: React.FC = () => {
   const [email, setEmail] = useState<string>('');
@@ -20,10 +21,12 @@ const RequestReset: React.FC = () => {
     <div className="max-w-sm mx-auto">
       <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
       <form onSubmit={submit} className="space-y-2">
-        <input
-          className="input input-bordered w-full"
+        <TextInput
+          className="w-full"
           value={email}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setEmail(e.target.value)
+          }
           placeholder="Email"
         />
         <button className="btn btn-primary w-full" type="submit">
@@ -33,6 +36,6 @@ const RequestReset: React.FC = () => {
       {message && <p className="mt-2">{message}</p>}
     </div>
   );
-}
+};
 
 export default RequestReset;

--- a/pages/reset/[token].tsx
+++ b/pages/reset/[token].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
+import { PasswordInput } from '../../components/form-fields';
 
 const ResetToken: React.FC = () => {
   const router = useRouter();
@@ -26,11 +27,12 @@ const ResetToken: React.FC = () => {
     <div className="max-w-sm mx-auto">
       <h1 className="text-2xl font-bold mb-4">Set New Password</h1>
       <form onSubmit={handleSubmit(submit)} className="space-y-2">
-        <input
-          className="input input-bordered w-full"
-          type="password"
+        <PasswordInput
+          className="w-full"
           placeholder="New Password"
-          {...register('password', { required: true })}
+          register={register}
+          name="password"
+          rules={{ required: true }}
         />
         <button className="btn btn-primary w-full" type="submit">
           Reset Password

--- a/pages/vendor/index.tsx
+++ b/pages/vendor/index.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import type { Product } from '../../types';
+import { TextInput } from '../../components/form-fields';
 
 export default function VendorDashboard() {
   const { user } = useContext(AppContext)!;
@@ -137,18 +138,13 @@ export default function VendorDashboard() {
           'maxPrice',
           'currency',
         ].map((field) => (
-          <div key={field}>
-            <label className="label capitalize">
-              <span className="label-text">{field.replace('_', ' ')}</span>
-            </label>
-            <input
-              name={field}
-              value={form[field]}
-              onChange={handleChange}
-              placeholder={field}
-              className="input input-bordered w-full"
-            />
-          </div>
+          <TextInput
+            key={field}
+            name={field as keyof FormState}
+            value={String(form[field] ?? '')}
+            onChange={handleChange}
+            placeholder={field}
+          />
         ))}
         <div className="flex gap-2">
           {editingId && (


### PR DESCRIPTION
## Summary
- switch vendor dashboard to use `TextInput`
- refactor brand dashboard and profile to shared form components
- use generic fields in admin product and category forms
- update checkout and reset pages for unified inputs
- apply generic dropdown and textarea in product review forms

## Testing
- `npx prettier --write pages/vendor/index.tsx pages/brand/dashboard.tsx pages/brand/profile.tsx pages/admin/index.tsx pages/admin/categories.tsx pages/checkout.tsx pages/reset.tsx pages/reset/[token].tsx pages/product/[slug].tsx pages/products/[id].tsx`
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: downloads blocked)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856915bb1a8832f9caa83ee4192a7fa