### PR TITLE
Standardize Category Module

### DIFF
--- a/__tests__/categories.api.test.ts
+++ b/__tests__/categories.api.test.ts
@@ -5,14 +5,14 @@ jest.mock('../lib/products', () => ({
   getCategoryTree: jest.fn(),
 }));
 
-test('returns categories with subcategories', async () => {
-  const data = [{ name: 'Electronics', subcategories: ['Phones'] }];
-  getCategoryTree.mockResolvedValue(data);
+test('returns categories list', async () => {
+  const data = [{ id: 1, uuid: 'u1', name: 'Electronics', slug: 'electronics', createdAt: new Date(), updatedAt: new Date() }];
+  (getCategoryTree as jest.Mock).mockResolvedValue(data);
   const json = jest.fn();
   const status = jest.fn(() => ({ json }));
-  const req = { method: 'GET' };
-  const res = { status };
+  const req = { method: 'GET' } as any;
+  const res = { status } as any;
   await handler(req, res);
   expect(status).toHaveBeenCalledWith(200);
-  expect(json).toHaveBeenCalledWith(data);
+  expect(json).toHaveBeenCalledWith({ categories: data });
 });

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import { useContext, useState, useEffect, useRef } from 'react';
-import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useSession, signOut } from 'next-auth/react';
 import type { FC, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
@@ -195,15 +194,8 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
   };
 
   const renderCat = (cat: Category): JSX.Element => (
-    <li key={cat.id} className={cat.parentId ? 'ml-4' : ''}>
-      <Link href={`/categories/${encodeURIComponent(cat.name)}`}>
-        {cat.name}
-      </Link>
-      {cat.children && cat.children.length > 0 && (
-        <ul className="ml-4">
-          {cat.children.map((child) => renderCat(child))}
-        </ul>
-      )}
+    <li key={cat.id}>
+      <Link href={`/categories/${encodeURIComponent(cat.name)}`}>{cat.name}</Link>
     </li>
   );
   return (
@@ -250,34 +242,9 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                             href={`/categories/${encodeURIComponent(cat.name)}`}
                             className="flex items-center font-semibold mb-1 transition-colors duration-200 hover:text-primary"
                           >
-                            {cat.image ? (
-                              <Image
-                                src={cat.image}
-                                alt=""
-                                width={16}
-                                height={16}
-                                className="w-4 h-4 mr-1 object-cover"
-                              />
-                            ) : (
-                              iconMap[cat.name] || null
-                            )}
+                            {iconMap[cat.name] || null}
                             {cat.name}
                           </Link>
-                          {cat.subcategories &&
-                            cat.subcategories.length > 0 && (
-                              <ul className="ml-4 space-y-1">
-                                {cat.subcategories.slice(0, 5).map((sub) => (
-                                  <li key={sub} className="text-sm">
-                                    <Link
-                                      href={`/categories/${encodeURIComponent(cat.name)}?type=${encodeURIComponent(sub)}`}
-                                      className="transition-colors duration-200 hover:text-primary"
-                                    >
-                                      {sub}
-                                    </Link>
-                                  </li>
-                                ))}
-                              </ul>
-                            )}
                         </div>
                       ))
                     ) : (
@@ -518,37 +485,9 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                       categories.map((cat) => (
                         <li key={cat.name}>
                           <div className="flex items-center gap-1">
-                            {cat.image ? (
-                              <Image
-                                src={cat.image}
-                                alt=""
-                                width={16}
-                                height={16}
-                                className="w-4 h-4 object-cover"
-                              />
-                            ) : (
-                              iconMap[cat.name] || null
-                            )}
-                            <Link
-                              href={`/categories/${encodeURIComponent(cat.name)}`}
-                            >
-                              {cat.name}
-                            </Link>
+                            {iconMap[cat.name] || null}
+                            <Link href={`/categories/${encodeURIComponent(cat.name)}`}>{cat.name}</Link>
                           </div>
-                          {cat.subcategories &&
-                            cat.subcategories.length > 0 && (
-                              <ul className="ml-4">
-                                {cat.subcategories.slice(0, 5).map((sub) => (
-                                  <li key={sub}>
-                                    <Link
-                                      href={`/categories/${encodeURIComponent(cat.name)}?type=${encodeURIComponent(sub)}`}
-                                    >
-                                      {sub}
-                                    </Link>
-                                  </li>
-                                ))}
-                              </ul>
-                            )}
                         </li>
                       ))
                     ) : (

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -269,51 +269,11 @@ export async function getCategoriesFlat(): Promise<Category[]> {
   return db.category.findMany({ orderBy: { name: 'asc' } });
 }
 
-export async function getCategoryTree(): Promise<{ name: string; subcategories: string[]; image?: string }[]> {
-  const flat = await getCategoriesFlat();
-  if (flat.length > 0) {
-    const map: Record<number, { name: string; image?: string; subcategories: string[] }> = {};
-    flat.forEach((c) => {
-      if (typeof c.id === 'number') {
-        map[c.id] = { name: c.name, image: c.image ?? undefined, subcategories: [] };
-      }
-    });
-    flat.forEach((c) => {
-      if (typeof c.parentId === 'number') {
-        map[c.parentId]?.subcategories.push(c.name);
-      }
-    });
-    return flat
-      .filter((c) => typeof c.id === 'number' && !c.parentId)
-      .map((c) => ({
-        name: c.name,
-        image: c.image ?? undefined,
-        subcategories: (map[c.id as number]?.subcategories ?? []).sort((a, b) =>
-          a.localeCompare(b)
-        ),
-      }))
-      .sort((a, b) => a.name.localeCompare(b.name));
-  }
-
-  const db = getDb();
-  const rows = await db.product.findMany({ include: { category: true } });
-  const map = {} as Record<string, Set<string>>;
-  for (const row of rows) {
-    const categoryName = row.category?.name;
-    if (!categoryName) continue;
-    if (!map[categoryName]) map[categoryName] = new Set();
-    if (row.productType) map[categoryName].add(row.productType);
-  }
-  return Object.entries(map)
-    .map(([name, set]) => ({ name, subcategories: Array.from(set).sort() }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+export async function getCategoryTree(): Promise<Category[]> {
+  return getCategoriesFlat();
 }
 
-export async function createCategory(
-  name: string,
-  parentId: number | null = null,
-  image: string | null = null
-): Promise<void> {
+export async function createCategory(name: string): Promise<void> {
   const db = getDb();
   const existing = await db.category.findFirst({ where: { name } });
   if (existing) return;
@@ -322,9 +282,7 @@ export async function createCategory(
 
 export async function renameCategory(
   uuid: string,
-  name: string,
-  _parentId: number | null = null,
-  _image: string | null = null
+  name: string
 ): Promise<void> {
   const db = getDb();
   await db.category.update({ where: { uuid }, data: { name } });

--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -1,5 +1,4 @@
 import { useContext, useEffect, useState, useCallback } from 'react';
-import Image from 'next/image';
 import { AppContext } from '../../contexts/AppContext';
 import { Category, CategoryInput, ApiMessage } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
@@ -8,12 +7,9 @@ export default function Categories() {
   const { user } = useContext(AppContext)!;
   const [categories, setCategories] = useState<Category[]>([]);
   const [newCat, setNewCat] = useState<string>('');
-  const [newParent, setNewParent] = useState<string>('');
-  const [newImage, setNewImage] = useState<string>('');
   const [message, setMessage] = useState<string>('');
-  const [editing, setEditing] = useState<number | null>(null);
+  const [editing, setEditing] = useState<string | null>(null);
   const [editName, setEditName] = useState<string>('');
-  const [editImage, setEditImage] = useState<string>('');
 
   const load = useCallback(async () => {
     if (!user) return;
@@ -29,8 +25,6 @@ export default function Categories() {
     if (!newCat.trim()) return;
     const payload: CategoryInput = {
       name: newCat,
-      parentId: newParent ? Number(newParent) : null,
-      image: newImage || undefined,
     };
     await fetchJson<ApiMessage>('/api/admin/categories', {
       method: 'POST',
@@ -38,16 +32,14 @@ export default function Categories() {
       body: JSON.stringify(payload),
     });
     setNewCat('');
-    setNewImage('');
     setMessage('Category added');
     load();
   };
 
   const update = async () => {
-    const payload: CategoryInput & { id: number } = {
-      id: editing as number,
+    const payload: CategoryInput & { uuid: string } = {
+      uuid: editing as string,
       name: editName,
-      image: editImage || undefined,
     };
     await fetchJson<ApiMessage>('/api/admin/categories', {
       method: 'PUT',
@@ -56,7 +48,6 @@ export default function Categories() {
     });
     setEditing(null);
     setEditName('');
-    setEditImage('');
     setMessage('Category updated');
     load();
   };
@@ -85,59 +76,21 @@ export default function Categories() {
           placeholder="New category"
           className="input input-bordered flex-1"
         />
-        <input
-          value={newImage}
-          onChange={(e) => setNewImage(e.target.value)}
-          placeholder="Image URL (optional)"
-          className="input input-bordered flex-1"
-        />
-        <select
-          className="select select-bordered"
-          value={newParent}
-          onChange={(e) => setNewParent(e.target.value)}
-        >
-          <option value="">No parent</option>
-          {categories
-            .filter((c) => !c.parentId)
-            .map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name}
-              </option>
-            ))}
-        </select>
         <button onClick={add} className="btn btn-primary">
           Add
         </button>
       </div>
       <ul className="space-y-2">
-        {buildTree(categories).map((c) => (
+        {categories.map((c) => (
           <CategoryItem key={c.id} cat={c} />
         ))}
       </ul>
     </div>
   );
 
-  function buildTree(list: Category[]): (Category & { children: Category[] })[] {
-    const map: Record<number, Category & { children: Category[] }> =
-      {} as Record<number, Category & { children: Category[] }>;
-    list.forEach((c) => {
-      map[c.id!] = { ...c, children: [] };
-    });
-    const tree: (Category & { children: Category[] })[] = [];
-    list.forEach((c) => {
-      if (c.parentId) {
-        map[c.parentId]?.children.push(map[c.id!]);
-      } else {
-        tree.push(map[c.id!]);
-      }
-    });
-    return tree;
-  }
-
-  function CategoryItem({ cat }: { cat: Category & { children: Category[] } }) {
-    const hasChildren = cat.children && cat.children.length > 0;
+  function CategoryItem({ cat }: { cat: Category }) {
     return (
-      <li className={cat.parentId ? 'ml-4' : ''}>
+      <li>
         <div className="flex items-center gap-2">
           {editing === cat.id ? (
             <>
@@ -145,12 +98,6 @@ export default function Categories() {
                 className="input input-bordered flex-1"
                 value={editName}
                 onChange={(e) => setEditName(e.target.value)}
-              />
-              <input
-                className="input input-bordered flex-1"
-                value={editImage}
-                onChange={(e) => setEditImage(e.target.value)}
-                placeholder="Image URL (optional)"
               />
               <button onClick={update} className="btn btn-sm">
                 Save
@@ -161,23 +108,11 @@ export default function Categories() {
             </>
           ) : (
             <>
-              <span className="flex-1 flex items-center gap-2">
-                {cat.image && (
-                  <Image
-                    src={cat.image}
-                    alt=""
-                    width={24}
-                    height={24}
-                    className="w-6 h-6 object-cover"
-                  />
-                )}
-                {cat.name}
-              </span>
+              <span className="flex-1">{cat.name}</span>
               <button
                 onClick={() => {
-                  setEditing(cat.id ?? null);
+                  setEditing(cat.uuid ?? null);
                   setEditName(cat.name);
-                  setEditImage(cat.image || '');
                 }}
                 className="btn btn-sm"
               >
@@ -189,13 +124,6 @@ export default function Categories() {
             </>
           )}
         </div>
-        {hasChildren && (
-          <ul className="ml-4 space-y-2">
-            {cat.children.map((child) => (
-              <CategoryItem key={child.id} cat={child} />
-            ))}
-          </ul>
-        )}
       </li>
     );
   }

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -21,7 +21,7 @@ async function handler(
       return res.status(200).json(cats as Category[]);
     }
     if (req.method === 'POST') {
-      const { name, parentId, image } = req.body as CategoryInput;
+      const { name } = req.body as CategoryInput;
       if (!name) return res.status(400).json({ message: 'name required' });
       const exists = (await getCategoriesFlat()).find(
         (c) => c.name.toLowerCase() === name.toLowerCase()
@@ -29,23 +29,16 @@ async function handler(
       if (exists) {
         return res.status(409).json({ message: 'category exists' });
       }
-      try {
-        await createCategory(name, parentId || null, image || null);
-      } catch (e: unknown) {
-        if (e instanceof Error && e.message === 'depth') {
-          return res.status(400).json({ message: 'max depth exceeded' });
-        }
-        throw e;
-      }
-      logAudit('create_category', { name, parentId, image });
+      await createCategory(name);
+      logAudit('create_category', { name });
       return res.status(201).json({ message: 'category created' });
     }
     if (req.method === 'PUT') {
-      const { uuid, name, parentId, image } = req.body as CategoryInput & { uuid: string };
+      const { uuid, name } = req.body as CategoryInput & { uuid: string };
       if (!uuid || !name)
         return res.status(400).json({ message: 'uuid and name required' });
-      await renameCategory(uuid, name, parentId || null, image || null);
-      logAudit('rename_category', { uuid, name, parentId, image });
+      await renameCategory(uuid, name);
+      logAudit('rename_category', { uuid, name });
       return res.status(200).json({ message: 'category updated' });
     }
     if (req.method === 'DELETE') {

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -11,20 +11,13 @@ export default async function handler(
     if (req.method !== 'POST') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const { name, parentId } = req.body || {};
+    const { name } = req.body || {};
     if (!name) return res.status(400).json({ message: 'name required' });
     const exists = (await getCategoriesFlat()).find(
       (c) => c.name.toLowerCase() === name.toLowerCase()
     );
     if (!exists) {
-      try {
-        await createCategory(name, parentId || null);
-      } catch (e: unknown) {
-        if (e instanceof Error && e.message === 'depth') {
-          return res.status(400).json({ message: 'max depth exceeded' });
-        }
-        throw e;
-      }
+      await createCategory(name);
     }
     return res.status(201).json({ message: 'ok' });
   } catch (error) {

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -9,8 +9,8 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method === 'GET') {
-      const data = await getCategoryTree();
-      return res.status(200).json(data);
+      const categories = await getCategoryTree();
+      return res.status(200).json({ categories });
     }
     return res.status(405).json({ message: 'Method Not Allowed' });
   } catch (error) {

--- a/pages/api/category-tree.ts
+++ b/pages/api/category-tree.ts
@@ -9,8 +9,8 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method === 'GET') {
-      const data = await getCategoryTree();
-      return res.status(200).json(data);
+      const categories = await getCategoryTree();
+      return res.status(200).json({ categories });
     }
     return res.status(405).json({ message: 'Method Not Allowed' });
   } catch (error) {

--- a/pages/categories/[name].tsx
+++ b/pages/categories/[name].tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import Image from 'next/image';
 import ProductCard from '../../components/ProductCard';
 import Head from 'next/head';
 import React from 'react';
@@ -12,7 +11,6 @@ const CategoryPage: React.FC = () => {
   const { name, type } = router.query;
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
-  const [catImage, setCatImage] = useState<string>('');
 
   useEffect(() => {
     if (!name || Array.isArray(name)) return;
@@ -28,20 +26,7 @@ const CategoryPage: React.FC = () => {
       }
       setLoading(false);
     }
-    async function loadCat() {
-      const res = await fetch('/api/categories');
-      if (res.ok) {
-        const cats: Category[] = await res.json();
-        const found = typeof name === 'string'
-          ? cats.find(
-              (c) => c.name.toLowerCase() === name.toLowerCase()
-            )
-          : undefined;
-        if (found && found.image) setCatImage(found.image);
-      }
-    }
     load();
-    loadCat();
   }, [name, type]);
 
   if (!name || Array.isArray(name)) return <div className="p-4">Loading...</div>;
@@ -62,18 +47,9 @@ const CategoryPage: React.FC = () => {
           }}
         />
       </Head>
-      <h1 className="text-2xl font-bold mb-4 flex items-center gap-2">
-        <Image
-          src={catImage || '/placeholder.png'}
-          alt=""
-          width={32}
-          height={32}
-          className="w-8 h-8 object-cover"
-        />
-        <span>
-          Category: {name}
-          {type && typeof type === 'string' && ` - ${type}`}
-        </span>
+      <h1 className="text-2xl font-bold mb-4">
+        Category: {name}
+        {type && typeof type === 'string' && ` - ${type}`}
       </h1>
       {loading && <div>Loading...</div>}
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 sm:gap-6">

--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import { Category } from '../../types';
 
 const Categories: React.FC = () => {
@@ -8,20 +7,13 @@ const Categories: React.FC = () => {
 
   useEffect(() => {
     fetch('/api/categories')
-      .then((res) => (res.ok ? res.json() : []))
-      .then((data: Category[]) => setCategories(data));
+      .then((res) => (res.ok ? res.json() : { categories: [] }))
+      .then((data: { categories: Category[] }) => setCategories(data.categories));
   }, []);
 
   const renderCat = (cat: Category): React.ReactNode => (
-    <li key={cat.id} className={cat.parentId ? 'ml-4 list-disc' : ''}>
-      <Link href={`/categories/${encodeURIComponent(cat.name)}`}>
-        {cat.name}
-      </Link>
-      {cat.children && cat.children.length > 0 && (
-        <ul className="ml-4 space-y-1 list-disc">
-          {cat.children.map((child) => renderCat(child))}
-        </ul>
-      )}
+    <li key={cat.id}>
+      <Link href={`/categories/${encodeURIComponent(cat.name)}`}>{cat.name}</Link>
     </li>
   );
 
@@ -29,20 +21,7 @@ const Categories: React.FC = () => {
     <div className="max-w-2xl mx-auto min-h-screen p-4">
       <h1 className="text-2xl font-bold mb-4">Categories</h1>
       <ul className="list-disc pl-4 space-y-2">
-        {categories.map((c) => (
-          <li key={c.name} className="flex items-center gap-2">
-            {c.image && (
-              <Image
-                src={c.image}
-                alt={c.name}
-                width={32}
-                height={32}
-                className="w-8 h-8 object-cover"
-              />
-            )}
-            <Link href={`/categories/${encodeURIComponent(c.name)}`}>{c.name}</Link>
-          </li>
-        ))}
+        {categories.map((c) => renderCat(c))}
         {categories.length === 0 && <li>No categories found.</li>}
       </ul>
     </div>

--- a/types/category.ts
+++ b/types/category.ts
@@ -1,19 +1,5 @@
-export interface Category {
-  id?: number;
-  uuid?: string;
-  name: string;
-  slug: string;
-  parentId?: number | null;
-  description?: string | null;
-  image?: string | null;
-  createdAt?: Date;
-  updatedAt?: Date;
-  children?: Category[];
-  subcategories?: string[];
-}
+import type { Category as PrismaCategory } from '@prisma/client';
 
-export interface CategoryInput {
-  name: string;
-  parentId?: number | null;
-  image?: string | null;
-}
+export type Category = PrismaCategory;
+
+export type CategoryInput = Pick<PrismaCategory, 'name'>;


### PR DESCRIPTION
## Summary
- align `Category` interface with Prisma
- refactor product helpers and category CRUD
- simplify category API responses
- streamline category admin page and header usage
- update tests

## Testing
- `npm ci --ignore-scripts`
- `npx tsc -p tsconfig.json` *(fails: Could not find declaration file for 'react-select-country-list' etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856913aa0d0832f8e4367735ef95bee