### PR TITLE
Fix typings for form fields

### DIFF
--- a/components/form-fields/Checkbox.tsx
+++ b/components/form-fields/Checkbox.tsx
@@ -18,23 +18,26 @@ export interface CheckboxProps<T extends FieldValues>
   disabled?: boolean;
   className?: string;
   register?: UseFormRegister<T>;
-  rules?: RegisterOptions;
+  rules?: RegisterOptions<T, Path<T>>;
 }
 
-const Checkbox = <T extends FieldValues>({
-  label,
-  name,
-  checked,
-  onChange,
-  onBlur,
-  error,
-  required = false,
-  disabled = false,
-  className = '',
-  register,
-  rules,
-  ...rest
-}) => {
+const Checkbox = <T extends FieldValues>(
+  props: CheckboxProps<T>
+) => {
+  const {
+    label,
+    name,
+    checked,
+    onChange,
+    onBlur,
+    error,
+    required = false,
+    disabled = false,
+    className = '',
+    register,
+    rules,
+    ...rest
+  } = props;
   const inputId = rest.id || name;
   const registration = register ? register(name, rules) : {};
   return (

--- a/components/form-fields/DatePicker.tsx
+++ b/components/form-fields/DatePicker.tsx
@@ -18,23 +18,26 @@ export interface DatePickerProps<T extends FieldValues>
   disabled?: boolean;
   className?: string;
   register?: UseFormRegister<T>;
-  rules?: RegisterOptions;
+  rules?: RegisterOptions<T, Path<T>>;
 }
 
-const DatePicker = <T extends FieldValues>({
-  label,
-  name,
-  value,
-  onChange,
-  onBlur,
-  error,
-  required = false,
-  disabled = false,
-  className = '',
-  register,
-  rules,
-  ...rest
-}) => {
+const DatePicker = <T extends FieldValues>(
+  props: DatePickerProps<T>
+) => {
+  const {
+    label,
+    name,
+    value,
+    onChange,
+    onBlur,
+    error,
+    required = false,
+    disabled = false,
+    className = '',
+    register,
+    rules,
+    ...rest
+  } = props;
   const inputId = rest.id || name;
   const registration = register ? register(name, rules) : {};
 

--- a/components/form-fields/EmailInput.tsx
+++ b/components/form-fields/EmailInput.tsx
@@ -21,26 +21,29 @@ export interface EmailInputProps<T extends FieldValues>
   leftAddon?: React.ReactNode;
   rightAddon?: React.ReactNode;
   register?: UseFormRegister<T>;
-  rules?: RegisterOptions;
+  rules?: RegisterOptions<T, Path<T>>;
 }
 
-const EmailInput = <T extends FieldValues>({
-  label,
-  name,
-  placeholder,
-  value,
-  onChange,
-  onBlur,
-  error,
-  required = false,
-  disabled = false,
-  className = '',
-  leftAddon,
-  rightAddon,
-  register,
-  rules,
-  ...rest
-}) => {
+const EmailInput = <T extends FieldValues>(
+  props: EmailInputProps<T>
+) => {
+  const {
+    label,
+    name,
+    placeholder,
+    value,
+    onChange,
+    onBlur,
+    error,
+    required = false,
+    disabled = false,
+    className = '',
+    leftAddon,
+    rightAddon,
+    register,
+    rules,
+    ...rest
+  } = props;
   const inputId = rest.id || name;
   const registration = register ? register(name, rules) : {};
 

--- a/components/form-fields/FileUpload.tsx
+++ b/components/form-fields/FileUpload.tsx
@@ -17,22 +17,25 @@ export interface FileUploadProps<T extends FieldValues>
   disabled?: boolean;
   className?: string;
   register?: UseFormRegister<T>;
-  rules?: RegisterOptions;
+  rules?: RegisterOptions<T, Path<T>>;
 }
 
-const FileUpload = <T extends FieldValues>({
-  label,
-  name,
-  onChange,
-  onBlur,
-  error,
-  required = false,
-  disabled = false,
-  className = '',
-  register,
-  rules,
-  ...rest
-}) => {
+const FileUpload = <T extends FieldValues>(
+  props: FileUploadProps<T>
+) => {
+  const {
+    label,
+    name,
+    onChange,
+    onBlur,
+    error,
+    required = false,
+    disabled = false,
+    className = '',
+    register,
+    rules,
+    ...rest
+  } = props;
   const inputId = rest.id || name;
   const registration = register ? register(name, rules) : {};
 

--- a/components/form-fields/PasswordInput.tsx
+++ b/components/form-fields/PasswordInput.tsx
@@ -20,25 +20,28 @@ export interface PasswordInputProps<T extends FieldValues>
   className?: string;
   leftAddon?: React.ReactNode;
   register?: UseFormRegister<T>;
-  rules?: RegisterOptions;
+  rules?: RegisterOptions<T, Path<T>>;
 }
 
-const PasswordInput = <T extends FieldValues>({
-  label,
-  name,
-  placeholder,
-  value,
-  onChange,
-  onBlur,
-  error,
-  required = false,
-  disabled = false,
-  className = '',
-  leftAddon,
-  register,
-  rules,
-  ...rest
-}) => {
+const PasswordInput = <T extends FieldValues>(
+  props: PasswordInputProps<T>
+) => {
+  const {
+    label,
+    name,
+    placeholder,
+    value,
+    onChange,
+    onBlur,
+    error,
+    required = false,
+    disabled = false,
+    className = '',
+    leftAddon,
+    register,
+    rules,
+    ...rest
+  } = props;
   const [show, setShow] = useState(false);
   const inputId = rest.id || name;
   const registration = register ? register(name, rules) : {};

--- a/components/form-fields/RadioGroup.tsx
+++ b/components/form-fields/RadioGroup.tsx
@@ -23,23 +23,26 @@ export interface RadioGroupProps<T extends FieldValues> {
   disabled?: boolean;
   className?: string;
   register?: UseFormRegister<T>;
-  rules?: RegisterOptions;
+  rules?: RegisterOptions<T, Path<T>>;
 }
 
-const RadioGroup = <T extends FieldValues>({
-  label,
-  name,
-  value,
-  onChange,
-  onBlur,
-  options,
-  error,
-  required = false,
-  disabled = false,
-  className = '',
-  register,
-  rules,
-}) => {
+const RadioGroup = <T extends FieldValues>(
+  props: RadioGroupProps<T>
+) => {
+  const {
+    label,
+    name,
+    value,
+    onChange,
+    onBlur,
+    options,
+    error,
+    required = false,
+    disabled = false,
+    className = '',
+    register,
+    rules,
+  } = props;
   const groupName = name;
   const registration = register ? register(name, rules) : {};
 

--- a/components/form-fields/SelectDropdown.tsx
+++ b/components/form-fields/SelectDropdown.tsx
@@ -28,28 +28,31 @@ export interface SelectDropdownProps<T extends FieldValues> {
   icon?: React.ReactNode;
   components?: any;
   control?: Control<T>;
-  rules?: RegisterOptions;
+  rules?: RegisterOptions<T, Path<T>>;
   [key: string]: unknown;
 }
 
-const SelectDropdown = <T extends FieldValues>({
-  label,
-  name,
-  value,
-  onChange,
-  options,
-  placeholder,
-  isSearchable = true,
-  isDisabled = false,
-  isMulti = false,
-  error,
-  className = '',
-  icon,
-  components: selectComponents,
-  control,
-  rules,
-  ...rest
-}) => {
+const SelectDropdown = <T extends FieldValues>(
+  props: SelectDropdownProps<T>
+) => {
+  const {
+    label,
+    name,
+    value,
+    onChange,
+    options,
+    placeholder,
+    isSearchable = true,
+    isDisabled = false,
+    isMulti = false,
+    error,
+    className = '',
+    icon,
+    components: selectComponents,
+    control,
+    rules,
+    ...rest
+  } = props;
   const inputId: string = typeof rest.id === 'string' ? rest.id : String(name);
 
   return (

--- a/components/form-fields/TextInput.tsx
+++ b/components/form-fields/TextInput.tsx
@@ -21,26 +21,29 @@ export interface TextInputProps<T extends FieldValues>
   leftAddon?: React.ReactNode;
   rightAddon?: React.ReactNode;
   register?: UseFormRegister<T>;
-  rules?: RegisterOptions;
+  rules?: RegisterOptions<T, Path<T>>;
 }
 
-const TextInput = <T extends FieldValues>({
-  label,
-  name,
-  placeholder,
-  value,
-  onChange,
-  onBlur,
-  error,
-  required = false,
-  disabled = false,
-  className = '',
-  leftAddon,
-  rightAddon,
-  register,
-  rules,
-  ...rest
-}) => {
+const TextInput = <T extends FieldValues>(
+  props: TextInputProps<T>
+) => {
+  const {
+    label,
+    name,
+    placeholder,
+    value,
+    onChange,
+    onBlur,
+    error,
+    required = false,
+    disabled = false,
+    className = '',
+    leftAddon,
+    rightAddon,
+    register,
+    rules,
+    ...rest
+  } = props;
   const inputId = rest.id || name;
   const registration = register ? register(name, rules) : {};
 

--- a/components/form-fields/Textarea.tsx
+++ b/components/form-fields/Textarea.tsx
@@ -19,24 +19,27 @@ export interface TextareaProps<T extends FieldValues>
   disabled?: boolean;
   className?: string;
   register?: UseFormRegister<T>;
-  rules?: RegisterOptions;
+  rules?: RegisterOptions<T, Path<T>>;
 }
 
-const Textarea = <T extends FieldValues>({
-  label,
-  name,
-  placeholder,
-  value,
-  onChange,
-  onBlur,
-  error,
-  required = false,
-  disabled = false,
-  className = '',
-  register,
-  rules,
-  ...rest
-}) => {
+const Textarea = <T extends FieldValues>(
+  props: TextareaProps<T>
+) => {
+  const {
+    label,
+    name,
+    placeholder,
+    value,
+    onChange,
+    onBlur,
+    error,
+    required = false,
+    disabled = false,
+    className = '',
+    register,
+    rules,
+    ...rest
+  } = props;
   const inputId = rest.id || name;
   const registration = register ? register(name, rules) : {};
 

--- a/types/custom/formidable.d.ts
+++ b/types/custom/formidable.d.ts
@@ -1,0 +1,1 @@
+declare module 'formidable';

--- a/types/custom/react-select-country-list.d.ts
+++ b/types/custom/react-select-country-list.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-select-country-list';

--- a/types/custom/react-world-flags.d.ts
+++ b/types/custom/react-world-flags.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-world-flags';

--- a/types/product.ts
+++ b/types/product.ts
@@ -42,7 +42,7 @@ export interface Product extends ProductBase {
 
 type ProductResponse = Product;
 
-type ProductInput = Pick<
+export type ProductInput = Pick<
   PrismaProduct,
   | 'sku'
   | 'title'


### PR DESCRIPTION
## Summary
- add props typing for generic form field components
- export `ProductInput` type
- add module stubs for third-party packages

## Testing
- `npx tsc --noEmit` *(fails: Module '@prisma/client' has no exported member 'Category')*

------
https://chatgpt.com/codex/tasks/task_e_6856952bbbe0832f861ab56c0c22d1c9