### PR TITLE
Centralize slugify util & fix formidable types

### DIFF
--- a/lib/slugify.ts
+++ b/lib/slugify.ts
@@ -1,0 +1,8 @@
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -1,23 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getDb } from '../../../lib/db';
 import { hasOrdersForProduct } from '../../../lib/orders';
-import formidable from 'formidable';
+import formidable, { type Fields, type Files } from 'formidable';
 import fs from 'fs';
 import path from 'path';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { slugify } from '../../../lib/slugify';
 import { Product, ApiMessage } from '../../../types';
 import { parseImages } from '../../../lib/utils/parseImages';
-
-function slugify(text) {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-');
-}
 
 export const config = {
   api: {
@@ -25,7 +17,7 @@ export const config = {
   },
 };
 
-async function parseBody(req: NextApiRequest) {
+async function parseBody(req: NextApiRequest): Promise<{ fields: Fields; files: Files }> {
   const type = req.headers['content-type'] || '';
   if (type.includes('application/json')) {
     const buffers: Uint8Array[] = [];
@@ -33,10 +25,10 @@ async function parseBody(req: NextApiRequest) {
     const body = Buffer.concat(buffers).toString();
     return { fields: JSON.parse(body || '{}'), files: {} } as {
       fields: Record<string, any>;
-      files: formidable.Files;
+      files: Files;
     };
   }
-  return new Promise<{ fields: formidable.Fields; files: formidable.Files }>(
+  return new Promise<{ fields: Fields; files: Files }>(
     (resolve, reject) => {
       const form = formidable({ multiples: true });
       form.parse(req, (err, fields, files) => {

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -2,16 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { addProduct, loadAndIndexProducts } from '../../../../lib/products';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../../lib/utils/getQueryParam';
+import { slugify } from '../../../../lib/slugify';
 import type { Product, ProductInput, ApiMessage } from '../../../../types';
-
-function slugify(text) {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-');
-}
 
 export default async function handler(
   req: NextApiRequest,

--- a/types/custom/formidable.d.ts
+++ b/types/custom/formidable.d.ts
@@ -1,1 +1,30 @@
-declare module 'formidable';
+declare module 'formidable' {
+  import { IncomingMessage } from 'http';
+
+  interface File {
+    filepath: string;
+    originalFilename?: string;
+    mimetype?: string;
+    size?: number;
+  }
+
+  export interface Files {
+    [key: string]: File | File[];
+  }
+
+  export interface Fields {
+    [key: string]: any;
+  }
+
+  interface IncomingForm {
+    parse(
+      req: IncomingMessage,
+      callback: (err: any, fields: Fields, files: Files) => void
+    ): void;
+  }
+
+  function formidable(options?: Record<string, any>): IncomingForm;
+
+  export default formidable;
+  export { File };
+}


### PR DESCRIPTION
## Summary
- refactor slugify logic into `lib/slugify.ts`
- reuse slugify in brand and admin product APIs
- type formidable usage via custom declaration and typed imports

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6856983b74b4832f9d263988e3bbfd18