### PR TITLE
Refactor admin API routes with explicit types

### DIFF
--- a/pages/api/admin/analytics.ts
+++ b/pages/api/admin/analytics.ts
@@ -2,34 +2,35 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getAllOrders } from '../../../lib/orders';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
-import { AnalyticsData, ApiMessage } from '../../../types';
+import { AnalyticsData, ApiMessage, Order } from '../../../types';
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<AnalyticsData | ApiMessage>
-) {
+): Promise<void> {
   if (req.method !== 'GET') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: 'Method Not Allowed' });
+    return;
   }
   try {
-    const orders = await getAllOrders();
+    const orders: Order[] = await getAllOrders();
     const summary: AnalyticsData = {
       totalOrders: orders.length,
       totalRevenue: 0,
       topProducts: [],
     };
     const counts: Record<string, number> = {};
-    orders.forEach((o) => {
-      summary.totalRevenue += o.total || 0;
-      counts[o.product.id] = (counts[o.product.id] || 0) + o.quantity;
-    });
+    for (const o of orders) {
+      summary.totalRevenue += o.total ?? 0;
+      counts[o.product.id] = (counts[o.product.id] ?? 0) + o.quantity;
+    }
     summary.topProducts = Object.entries(counts)
-      .sort((a, b) => (b[1] as number) - (a[1] as number))
+      .sort(([, a], [, b]) => b - a)
       .slice(0, 5)
-      .map(([id, qty]) => ({ id, qty }));
-    return res.status(200).json(summary);
+      .map(([id, qty]): { id: string; qty: number } => ({ id, qty }));
+    res.status(200).json(summary);
   } catch (error) {
-    return handleApiError(res, error, 'Failed to load analytics');
+    handleApiError(res, error, 'Failed to load analytics');
   }
 }
 

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -14,24 +14,26 @@ import { Category, CategoryInput, ApiMessage } from '../../../types';
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Category[] | ApiMessage>
-) {
+): Promise<void> {
   try {
     if (req.method === 'GET') {
-      const cats = await getCategoriesFlat();
-      return res.status(200).json(cats as Category[]);
+      const cats: Category[] = await getCategoriesFlat();
+      res.status(200).json(cats);
+      return;
     }
     if (req.method === 'POST') {
       const { name } = req.body as CategoryInput;
       if (!name) return res.status(400).json({ message: 'name required' });
       const exists = (await getCategoriesFlat()).find(
-        (c) => c.name.toLowerCase() === name.toLowerCase()
+        (c: Category) => c.name.toLowerCase() === name.toLowerCase()
       );
       if (exists) {
         return res.status(409).json({ message: 'category exists' });
       }
       await createCategory(name);
       logAudit('create_category', { name });
-      return res.status(201).json({ message: 'category created' });
+      res.status(201).json({ message: 'category created' });
+      return;
     }
     if (req.method === 'PUT') {
       const { uuid, name } = req.body as CategoryInput & { uuid: string };
@@ -39,7 +41,8 @@ async function handler(
         return res.status(400).json({ message: 'uuid and name required' });
       await renameCategory(uuid, name);
       logAudit('rename_category', { uuid, name });
-      return res.status(200).json({ message: 'category updated' });
+      res.status(200).json({ message: 'category updated' });
+      return;
     }
     if (req.method === 'DELETE') {
       const uuid = getQueryParam(req.query.uuid);
@@ -47,7 +50,8 @@ async function handler(
       try {
         await removeCategory(String(uuid));
         logAudit('delete_category', { uuid });
-        return res.status(200).json({ message: 'category deleted' });
+        res.status(200).json({ message: 'category deleted' });
+        return;
       } catch (e: unknown) {
         if (e instanceof Error && e.message === 'category in use') {
           return res
@@ -57,9 +61,10 @@ async function handler(
         throw e;
       }
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: 'Method Not Allowed' });
+    return;
   } catch (error) {
-    return handleApiError(res, error, 'Failed to manage categories');
+    handleApiError(res, error, 'Failed to manage categories');
   }
 }
 

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -23,10 +23,7 @@ async function parseBody(req: NextApiRequest): Promise<{ fields: Fields; files: 
     const buffers: Uint8Array[] = [];
     for await (const chunk of req) buffers.push(chunk);
     const body = Buffer.concat(buffers).toString();
-    return { fields: JSON.parse(body || '{}'), files: {} } as {
-      fields: Record<string, any>;
-      files: Files;
-    };
+    return { fields: JSON.parse(body || '{}') as Fields, files: {} as Files };
   }
   return new Promise<{ fields: Fields; files: Files }>(
     (resolve, reject) => {
@@ -42,7 +39,7 @@ async function parseBody(req: NextApiRequest): Promise<{ fields: Fields; files: 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Product[] | ApiMessage>
-) {
+): Promise<void> {
   try {
     const db = getDb();
 
@@ -55,37 +52,37 @@ async function handler(
         vendor,
         description,
         product_type,
-      tags,
-      category,
-      quantity,
-      min_price,
-      max_price,
-      currency,
-      } = fields as Record<string, any>;
+        tags,
+        category,
+        quantity,
+        min_price,
+        max_price,
+        currency,
+      } = fields as Record<string, unknown>;
       if (!id || !title || !sku) {
-        return res
-          .status(400)
-          .json({ message: 'id, sku and title are required' });
+        res.status(400).json({ message: 'id, sku and title are required' });
+        return;
       }
-    const photos = files.photos
-      ? Array.isArray(files.photos)
-        ? files.photos
-        : [files.photos]
-      : [];
+      const photos: formidable.File[] = files.photos
+        ? Array.isArray(files.photos)
+          ? (files.photos as formidable.File[])
+          : [files.photos as formidable.File]
+        : [];
       const destDir = path.join(process.cwd(), 'public', 'uploads', String(id));
       fs.mkdirSync(destDir, { recursive: true });
-    const imagePaths = [];
-    for (const file of photos) {
-      const name = Date.now() + '-' + file.originalFilename;
-      const destPath = path.join(destDir, name);
-      fs.renameSync(file.filepath, destPath);
-      imagePaths.push(`/uploads/${id}/${name}`);
-    }
+      const imagePaths: string[] = [];
+      for (const file of photos) {
+        const name = Date.now() + '-' + file.originalFilename;
+        const destPath = path.join(destDir, name);
+        fs.renameSync(file.filepath, destPath);
+        imagePaths.push(`/uploads/${id}/${name}`);
+      }
       let existing = null;
       if (req.method === 'PUT') {
         existing = await db.product.findUnique({ where: { id: Number(id) } });
         if (!existing) {
-          return res.status(404).json({ message: 'Not found' });
+          res.status(404).json({ message: 'Not found' });
+          return;
         }
         const existingImages = existing.images ? JSON.parse(existing.images) : [];
         imagePaths.push(...existingImages);
@@ -128,29 +125,35 @@ async function handler(
 
       if (req.method === 'POST') {
         await db.product.create({ data });
-        return res.status(201).json({ message: 'Product added' });
+        res.status(201).json({ message: 'Product added' });
+        return;
       }
 
       await db.product.update({ where: { id: Number(id) }, data });
-      return res.status(200).json({ message: 'Product updated' });
+      res.status(200).json({ message: 'Product updated' });
+      return;
     }
 
     if (req.method === 'DELETE') {
       const uuid = getQueryParam(req.query.uuid);
       if (!uuid) {
-        return res.status(400).json({ message: 'uuid required' });
+        res.status(400).json({ message: 'uuid required' });
+        return;
       }
       const existing = await db.product.findUnique({ where: { uuid } });
       if (!existing) {
-        return res.status(404).json({ message: 'Not found' });
+        res.status(404).json({ message: 'Not found' });
+        return;
       }
       if (existing.quantity > 0 || (await hasOrdersForProduct(String(uuid)))) {
-        return res
+        res
           .status(400)
           .json({ message: 'cannot delete product with stock or orders' });
+        return;
       }
       await db.product.delete({ where: { uuid } });
-      return res.status(200).json({ message: 'Product deleted' });
+      res.status(200).json({ message: 'Product deleted' });
+      return;
     }
 
     if (req.method === 'GET') {
@@ -161,7 +164,7 @@ async function handler(
         where,
         include: { category: true, vendor: true },
       });
-      const data: Product[] = rows.map((p) => ({
+      const data: Product[] = rows.map((p): Product => ({
         ID: String(p.id),
         SLUG: p.slug,
         sku: p.sku,
@@ -184,12 +187,14 @@ async function handler(
         reviewCount: 0,
         averageRating: 0,
       }));
-      return res.status(200).json(data);
+      res.status(200).json(data);
+      return;
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: 'Method Not Allowed' });
+    return;
   } catch (error) {
-    return handleApiError(res, error, 'Failed to process product');
+    handleApiError(res, error, 'Failed to process product');
   }
 }
 

--- a/pages/api/admin/search-analytics.ts
+++ b/pages/api/admin/search-analytics.ts
@@ -4,37 +4,44 @@ import { getDb } from '../../../lib/db';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 
+interface SearchLog {
+  query: string;
+  noResults?: boolean | null;
+}
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<SearchAnalyticsResponse | ApiMessage>
-) {
+): Promise<void> {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      res.status(405).json({ message: 'Method Not Allowed' });
+      return;
     }
 
     const db = getDb();
-    const logs = await db.searchLog.findMany();
+    const logs: SearchLog[] = await db.searchLog.findMany();
     const counts: Record<string, number> = {};
     const fails: Record<string, number> = {};
     for (const log of logs) {
-      counts[log.query] = (counts[log.query] || 0) + 1;
+      counts[log.query] = (counts[log.query] ?? 0) + 1;
       if (log.noResults) {
-        fails[log.query] = (fails[log.query] || 0) + 1;
+        fails[log.query] = (fails[log.query] ?? 0) + 1;
       }
     }
     const topSearches = Object.entries(counts)
-      .sort((a, b) => (b[1] as number) - (a[1] as number))
+      .sort(([, a], [, b]) => b - a)
       .slice(0, 10)
-      .map(([query, count]) => ({ query, count }));
+      .map(([query, count]): { query: string; count: number } => ({ query, count }));
     const failedSearches = Object.entries(fails)
-      .sort((a, b) => (b[1] as number) - (a[1] as number))
+      .sort(([, a], [, b]) => b - a)
       .slice(0, 10)
-      .map(([query, count]) => ({ query, count }));
+      .map(([query, count]): { query: string; count: number } => ({ query, count }));
 
-    return res.status(200).json({ topSearches, failedSearches });
+    res.status(200).json({ topSearches, failedSearches });
+    return;
   } catch (error) {
-    return handleApiError(res, error, 'Failed to load analytics');
+    handleApiError(res, error, 'Failed to load analytics');
   }
 }
 

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -21,31 +21,35 @@ import {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<AdminUser[] | ApiMessage>
-) {
+): Promise<void> {
   try {
     if (req.method === 'GET') {
-      const users = await getAllUsers();
-      return res.status(200).json(users as AdminUser[]);
+      const users: AdminUser[] = await getAllUsers();
+      res.status(200).json(users);
+      return;
     }
     if (req.method === 'PUT') {
       const { email, role } = req.body as UserRoleUpdateRequest;
       if (!email || !role)
         return res.status(400).json({ message: 'email and role required' });
       await updateUserRole(email, role as Role);
-      return res.status(200).json({ message: 'role updated' });
+      res.status(200).json({ message: 'role updated' });
+      return;
     }
     if (req.method === 'PATCH') {
       const { email, disabled } = req.body as UserDisabledUpdateRequest;
       if (typeof disabled !== 'boolean' || !email)
         return res.status(400).json({ message: 'email and disabled required' });
       await setUserDisabled(email, disabled);
-      return res.status(200).json({ message: 'status updated' });
+      res.status(200).json({ message: 'status updated' });
+      return;
     }
     if (req.method === 'DELETE') {
       const email = getQueryParam(req.query.email);
       if (!email) return res.status(400).json({ message: 'email required' });
       await deleteUser(email);
-      return res.status(200).json({ message: 'user deleted' });
+      res.status(200).json({ message: 'user deleted' });
+      return;
     }
     if (req.method === 'POST') {
       const { email, password, firstName, lastName, brandName, gender, role } =
@@ -62,11 +66,13 @@ async function handler(
         gender,
         role: (role || 'USER') as Role,
       });
-      return res.status(201).json({ message: 'user created' });
+      res.status(201).json({ message: 'user created' });
+      return;
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: 'Method Not Allowed' });
+    return;
   } catch (error) {
-    return handleApiError(res, error, 'Failed to manage users');
+    handleApiError(res, error, 'Failed to manage users');
   }
 }
 

--- a/pages/api/admin/vendor-products.ts
+++ b/pages/api/admin/vendor-products.ts
@@ -11,29 +11,37 @@ import { PendingProduct, ApiMessage } from '../../../types';
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<PendingProduct[] | ApiMessage>
-) {
+): Promise<void> {
   try {
     if (req.method === 'GET') {
-      const list = await getPendingProducts();
-      return res.status(200).json(list as PendingProduct[]);
+      const list: PendingProduct[] = await getPendingProducts();
+      res.status(200).json(list);
+      return;
     }
     if (req.method === 'PUT') {
-      const { uuid, action } = req.body as { uuid?: string; action?: string };
+      const { uuid, action } = req.body as {
+        uuid?: string;
+        action?: 'approve' | 'reject';
+      };
       if (!uuid || !action)
         return res.status(400).json({ message: 'uuid and action required' });
       if (action === 'approve') {
         await approveProduct(uuid);
-        return res.status(200).json({ message: 'approved' });
+        res.status(200).json({ message: 'approved' });
+        return;
       }
       if (action === 'reject') {
         await rejectProduct(uuid);
-        return res.status(200).json({ message: 'rejected' });
+        res.status(200).json({ message: 'rejected' });
+        return;
       }
-      return res.status(400).json({ message: 'invalid action' });
+      res.status(400).json({ message: 'invalid action' });
+      return;
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: 'Method Not Allowed' });
+    return;
   } catch (error) {
-    return handleApiError(res, error, 'Failed to process vendor products');
+    handleApiError(res, error, 'Failed to process vendor products');
   }
 }
 


### PR DESCRIPTION
## Summary
- strengthen admin API route type safety
- type parameters and loops for analytics, categories, vendor products, users and products
- ensure API handlers always return typed responses

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685699b711f8832faf13ae74324b24da