### PR TITLE
Add reset password link and page

### DIFF
--- a/pages/auth/forgot-password.tsx
+++ b/pages/auth/forgot-password.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { EmailInput } from '../../components/form-fields';
+
+interface ForgotPasswordForm {
+  email: string;
+}
+
+const ForgotPasswordPage: React.FC = () => {
+  const { register, handleSubmit, formState: { errors } } = useForm<ForgotPasswordForm>();
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const onSubmit: SubmitHandler<ForgotPasswordForm> = async ({ email }) => {
+    setLoading(true);
+    setMessage('');
+    try {
+      const res = await fetch('/api/request-reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+      const data = await res.json();
+      if (res.ok) setMessage('Check your email for reset link');
+      else setMessage(data.message || 'Error');
+    } catch (_) {
+      setMessage('Error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <div className="max-w-sm mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
+        <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+          <EmailInput
+            name="email"
+            placeholder="Email"
+            register={register}
+            required
+            rules={{
+              required: 'Email is required',
+              pattern: { value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/, message: 'Invalid email format' }
+            }}
+            error={errors.email?.message as string}
+            className="w-full"
+          />
+          <button className="btn btn-primary w-full" type="submit" disabled={loading}>
+            {loading && <span className="loading loading-spinner mr-2" />}
+            Request Reset
+          </button>
+        </form>
+        {message && <p className="mt-2">{message}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -100,6 +100,11 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
             rules={{ required: 'Password is required' }}
             error={errors.password?.message as string}
           />
+          <div className="text-right -mt-2 mb-2">
+            <Link href="/auth/forgot-password" className="link text-sm">
+              Forgot Password?
+            </Link>
+          </div>
           <button
             className="btn btn-primary w-full"
             type="submit"


### PR DESCRIPTION
## Summary
- add forgot password page under `/auth`
- link login page to the new forgot password flow

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a4bf3928832f96079589c507b8b3