### PR TITLE
Add category products page with filters

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -218,7 +218,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
     </li>
   );
   return (
-    <header className="bg-base-300 mb-6">
+    <header className="relative bg-base-300 mb-6">
       <div className="w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-4 gap-y-2">
         <div className="flex items-center gap-2">
           <Link href="/" className="btn btn-ghost normal-case text-xl">
@@ -234,7 +234,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
               <li className="relative">
                 <button
                   type="button"
-                  className="flex items-center gap-1 font-semibold transition-colors duration-200 hover:text-primary"
+                  className="flex items-center gap-1 font-semibold transition-colors duration-200 hover:text-primary hover:bg-base-200 px-2 py-1 rounded"
                   onMouseEnter={() => setMenuOpen(true)}
                   onClick={() => setMenuOpen((o) => !o)}
                   aria-expanded={menuOpen}
@@ -245,7 +245,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                 {menuOpen && (
                   <div
                     id="mega-menu"
-                    className="absolute left-0 top-full mt-1 z-40 p-4 bg-base-100 shadow-lg rounded w-screen max-w-3xl"
+                    className="absolute left-0 top-full mt-1 z-50 p-4 bg-base-100 shadow-lg rounded w-screen max-w-3xl"
                   >
                     <div
                       className="grid grid-cols-2 md:grid-cols-3 gap-4"

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -45,13 +45,7 @@ const stripHtml = (html: string | null | undefined): string => {
 
 function processProductRow(row: Record<string, unknown>): Product {
   const processed: Record<string, unknown> & Partial<Product> = { ...row };
-  const jsonFields = [
-    'SEO',
-    'OPTIONS',
-    'VARIANTS',
-    'priceRange',
-    'METAFIELDS',
-  ];
+  const jsonFields = ['SEO', 'OPTIONS', 'VARIANTS', 'priceRange', 'METAFIELDS'];
   jsonFields.forEach((field) => {
     if (processed[field]) {
       try {
@@ -65,17 +59,31 @@ function processProductRow(row: Record<string, unknown>): Product {
     }
   });
 
-  processed.descriptionText = stripHtml(processed.description as string | null | undefined);
-  processed.bodyHtmlText = stripHtml(processed.bodyHtml as string | null | undefined);
+  processed.descriptionText = stripHtml(
+    processed.description as string | null | undefined
+  );
+  processed.bodyHtmlText = stripHtml(
+    processed.bodyHtml as string | null | undefined
+  );
   processed.minPrice = processed.priceRange?.minVariantPrice?.amount || 0;
   processed.maxPrice = processed.priceRange?.maxVariantPrice?.amount || 0;
-  processed.currency = processed.priceRange?.minVariantPrice?.currencyCode || 'GBP';
+  processed.currency =
+    processed.priceRange?.minVariantPrice?.currencyCode || 'GBP';
   const meta = processed.METAFIELDS as
-    | { stoked_inventory_sold_count?: { value?: string }; yotpo_reviews_count?: { value?: string }; yotpo_reviews_average?: { value?: string } }
+    | {
+        stoked_inventory_sold_count?: { value?: string };
+        yotpo_reviews_count?: { value?: string };
+        yotpo_reviews_average?: { value?: string };
+      }
     | undefined;
-  processed.soldCount = parseInt(meta?.stoked_inventory_sold_count?.value ?? '0', 10);
+  processed.soldCount = parseInt(
+    meta?.stoked_inventory_sold_count?.value ?? '0',
+    10
+  );
   processed.reviewCount = parseInt(meta?.yotpo_reviews_count?.value ?? '0', 10);
-  processed.averageRating = parseFloat(meta?.yotpo_reviews_average?.value ?? '0');
+  processed.averageRating = parseFloat(
+    meta?.yotpo_reviews_average?.value ?? '0'
+  );
   processed.id = String(processed.id);
   if (row.uuid) {
     processed.uuid = String(row.uuid);
@@ -85,7 +93,9 @@ function processProductRow(row: Record<string, unknown>): Product {
   }
   if (processed.images && processed.images.length > 0) {
     if (typeof processed.images[0] === 'string') {
-      processed.images = (processed.images as unknown as string[]).map((u) => ({ url: u }));
+      processed.images = (processed.images as unknown as string[]).map((u) => ({
+        url: u,
+      }));
     }
     processed.featuredImage = processed.images[0];
   }
@@ -166,7 +176,9 @@ export async function loadAndIndexProducts(): Promise<{ products: Product[] }> {
 export async function addProduct(product: ProductInput): Promise<void> {
   const db = getDb();
   const vendor = product.vendor?.brandName
-    ? await db.user.findFirst({ where: { brandName: product.vendor.brandName } })
+    ? await db.user.findFirst({
+        where: { brandName: product.vendor.brandName },
+      })
     : null;
   const category = product.category?.name
     ? await db.category.findFirst({ where: { name: product.category.name } })
@@ -201,7 +213,9 @@ export async function updateProduct(
 ): Promise<void> {
   const db = getDb();
   const vendor = product.vendor?.brandName
-    ? await db.user.findFirst({ where: { brandName: product.vendor.brandName } })
+    ? await db.user.findFirst({
+        where: { brandName: product.vendor.brandName },
+      })
     : null;
   const category = product.category?.name
     ? await db.category.findFirst({ where: { name: product.category.name } })
@@ -254,6 +268,43 @@ export async function getPendingProducts(): Promise<Product[]> {
   );
 }
 
+export async function getProductsByCategorySlug(
+  slug: string
+): Promise<Product[]> {
+  const db = getDb();
+  const rows: ProductWithRelations[] = await db.product.findMany({
+    where: { status: 'approved', category: { slug } },
+    include: { category: true, vendor: true },
+  });
+  return rows.map((row) =>
+    processProductRow({
+      id: row.id,
+      uuid: row.uuid,
+      slug: row.slug,
+      sku: row.sku,
+      title: row.title,
+      vendor: row.vendor ?? null,
+      description: row.description,
+      productType: row.productType,
+      tags: row.tags,
+      category: row.category ?? null,
+      images: parseImages(row.images),
+      totalInventory: row.quantity,
+      priceRange: {
+        minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
+        maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
+      },
+    })
+  );
+}
+
+export async function getCategoryBySlug(
+  slug: string
+): Promise<Category | null> {
+  const db = getDb();
+  return db.category.findFirst({ where: { slug } });
+}
+
 export async function approveProduct(uuid: string): Promise<void> {
   const db = getDb();
   await db.product.update({ where: { uuid }, data: { status: 'approved' } });
@@ -277,7 +328,9 @@ export async function createCategory(name: string): Promise<void> {
   const db = getDb();
   const existing = await db.category.findFirst({ where: { name } });
   if (existing) return;
-  await db.category.create({ data: { name, slug: name.toLowerCase().replace(/\s+/g, '-') } });
+  await db.category.create({
+    data: { name, slug: name.toLowerCase().replace(/\s+/g, '-') },
+  });
 }
 
 export async function renameCategory(

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getProductsByCategorySlug } from '../../../lib/products';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import type { Product } from '../../../types/product';
+import type { ApiMessage } from '../../../types';
+
+export interface ProductsQuery {
+  categorySlug?: string | string[];
+}
+
+export interface ProductsResponse {
+  products: Product[];
+}
+
+export default async function handler(
+  req: NextApiRequest & { query: ProductsQuery },
+  res: NextApiResponse<ProductsResponse | ApiMessage>
+): Promise<void> {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  const slug = getQueryParam(req.query.categorySlug);
+  try {
+    const products = slug ? await getProductsByCategorySlug(slug) : [];
+    return res.status(200).json({ products });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load products');
+  }
+}

--- a/pages/categories/[slug]/products.tsx
+++ b/pages/categories/[slug]/products.tsx
@@ -1,0 +1,166 @@
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import ProductCard from '../../../components/ProductCard';
+import type { Product, Category } from '../../../types';
+import {
+  getCategoryBySlug,
+  getProductsByCategorySlug,
+} from '../../../lib/products';
+
+interface CategoryProductsProps {
+  products: Product[];
+  category: Category;
+}
+
+export const getServerSideProps: GetServerSideProps<
+  CategoryProductsProps
+> = async (context: GetServerSidePropsContext) => {
+  const { params } = context;
+  const slug = params?.slug;
+  if (!slug || Array.isArray(slug)) {
+    return { notFound: true };
+  }
+  const [category, products] = await Promise.all([
+    getCategoryBySlug(String(slug)),
+    getProductsByCategorySlug(String(slug)),
+  ]);
+  if (!category) {
+    return { notFound: true };
+  }
+  return { props: { products, category } };
+};
+
+export default function CategoryProductsPage({
+  products,
+  category,
+}: CategoryProductsProps) {
+  const router = useRouter();
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
+  const [brand, setBrand] = useState('');
+  const [rating, setRating] = useState('');
+
+  useEffect(() => {
+    setMinPrice((router.query.min as string) || '');
+    setMaxPrice((router.query.max as string) || '');
+    setBrand((router.query.brand as string) || '');
+    setRating((router.query.rating as string) || '');
+  }, [
+    router.query.min,
+    router.query.max,
+    router.query.brand,
+    router.query.rating,
+  ]);
+
+  const updateQuery = (key: string, value: string) => {
+    const query = { ...router.query } as Record<string, string>;
+    if (value) query[key] = value;
+    else delete query[key];
+    router.push(
+      { pathname: router.pathname, query: { ...query, slug: category.slug } },
+      undefined,
+      { shallow: true }
+    );
+  };
+
+  const filtered = products.filter((p) => {
+    if (minPrice && p.minPrice < parseFloat(minPrice)) return false;
+    if (maxPrice && p.minPrice > parseFloat(maxPrice)) return false;
+    if (brand && p.vendor.brandName !== brand) return false;
+    if (rating && Math.round(p.averageRating) < parseInt(rating, 10))
+      return false;
+    return true;
+  });
+
+  return (
+    <div className="max-w-screen-2xl mx-auto min-h-screen px-4 sm:px-6 lg:px-8 py-6">
+      <Head>
+        <title>{category.name} Products</title>
+        <meta name="description" content={`Products for ${category.name}`} />
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">
+        {category.name} ({filtered.length})
+      </h1>
+      <div className="grid grid-cols-1 md:grid-cols-[220px_1fr] gap-6">
+        <aside className="border rounded bg-base-100 p-4 space-y-4">
+          <div>
+            <h3 className="font-semibold mb-2">Price</h3>
+            <div className="flex gap-2">
+              <input
+                type="number"
+                value={minPrice}
+                onChange={(e) => {
+                  setMinPrice(e.target.value);
+                  updateQuery('min', e.target.value);
+                }}
+                placeholder="Min"
+                className="input input-bordered w-full"
+              />
+              <input
+                type="number"
+                value={maxPrice}
+                onChange={(e) => {
+                  setMaxPrice(e.target.value);
+                  updateQuery('max', e.target.value);
+                }}
+                placeholder="Max"
+                className="input input-bordered w-full"
+              />
+            </div>
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">Brand</h3>
+            {['BrandA', 'BrandB', 'BrandC'].map((b) => (
+              <label key={b} className="flex items-center gap-2 mb-1">
+                <input
+                  type="checkbox"
+                  className="checkbox"
+                  checked={brand === b}
+                  onChange={() => {
+                    const v = brand === b ? '' : b;
+                    setBrand(v);
+                    updateQuery('brand', v);
+                  }}
+                />
+                <span>{b}</span>
+              </label>
+            ))}
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">Rating</h3>
+            {[5, 4, 3].map((r) => (
+              <label key={r} className="flex items-center gap-2 mb-1">
+                <input
+                  type="checkbox"
+                  className="checkbox"
+                  checked={rating === String(r)}
+                  onChange={() => {
+                    const v = rating === String(r) ? '' : String(r);
+                    setRating(v);
+                    updateQuery('rating', v);
+                  }}
+                />
+                <span>{r}★ & up</span>
+              </label>
+            ))}
+          </div>
+        </aside>
+        <section>
+          {filtered.length === 0 ? (
+            <div className="text-center py-10 text-gray-500">
+              No products found.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+              {filtered.map((p) => (
+                <ProductCard key={p.id} product={p} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `getProductsByCategorySlug` and `getCategoryBySlug` helpers
- add `/api/products` endpoint to fetch products by category slug
- implement new page `/categories/[slug]/products` with sidebar filters and product grid
- adjust category dropdown hover styles and z-index

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856aa2f8aec832fab422e4e84c41ac6