### PR TITLE
Add Fly.io Typesense guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ Vercel will auto-deploy.
 
 ---
 
+## ☁️ Typesense on Fly.io
+
+You can run a development Typesense server for free on Fly.io without any
+browser dependencies. Follow the steps in
+[docs/typesense-flyio.md](docs/typesense-flyio.md) to initialize a Fly app,
+create a persistent volume and deploy the container.
+
+---
+
 ## 🌐 API Usage
 
 **GET** `/api/search?q=vitamin`

--- a/docs/typesense-flyio.md
+++ b/docs/typesense-flyio.md
@@ -1,0 +1,54 @@
+# Deploying Typesense on Fly.io
+
+This guide shows how to run a self-hosted Typesense instance for development on Fly.io without relying on Puppeteer, Chrome or other browser binaries.
+
+## Setup Steps
+
+1. **Initialize** a Fly project (answers can be defaults):
+   ```bash
+   flyctl launch --no-deploy
+   ```
+2. **Create a volume** for persistent data:
+   ```bash
+   flyctl volumes create typesense_data --size 1 --region <your-region>
+   ```
+3. **Create a Dockerfile** in the project root:
+   ```Dockerfile
+   FROM typesense/typesense:0.25.1
+   CMD ["--data-dir", "/data", "--api-key", "xyz123", "--enable-cors"]
+   ```
+4. **Update `fly.toml`** with the mount and port configuration:
+   ```toml
+   [[mounts]]
+     source = "typesense_data"
+     destination = "/data"
+
+   [[services]]
+     internal_port = 8108
+     protocol = "tcp"
+     [[services.ports]]
+       port = 80
+   ```
+5. **Store the API key** as a Fly secret:
+   ```bash
+   flyctl secrets set TYPESENSE_API_KEY=xyz123
+   ```
+6. **Deploy** the app:
+   ```bash
+   flyctl deploy
+   ```
+
+## Validation
+
+Check the health endpoint:
+```bash
+curl https://<your-app>.fly.dev/health
+```
+
+Test the API:
+```bash
+curl https://<your-app>.fly.dev/collections \
+  -H "X-TYPESENSE-API-KEY: xyz123"
+```
+
+The instance now runs without any browser dependencies and exposes a CORS-enabled API suitable for development.


### PR DESCRIPTION
## Summary
- document how to host a dev Typesense instance on Fly.io
- link to the new guide from the README

## Testing
- `npm test` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6856b05a8858832f9c53117b4bd727f9