### PR TITLE
Add login link on password reset screens

### DIFF
--- a/pages/auth/forgot-password.tsx
+++ b/pages/auth/forgot-password.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Link from 'next/link';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { EmailInput } from '../../components/form-fields';
 
@@ -7,7 +8,11 @@ interface ForgotPasswordForm {
 }
 
 const ForgotPasswordPage: React.FC = () => {
-  const { register, handleSubmit, formState: { errors } } = useForm<ForgotPasswordForm>();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ForgotPasswordForm>();
   const [message, setMessage] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -18,7 +23,7 @@ const ForgotPasswordPage: React.FC = () => {
       const res = await fetch('/api/request-reset', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email })
+        body: JSON.stringify({ email }),
       });
       const data = await res.json();
       if (res.ok) setMessage('Check your email for reset link');
@@ -42,16 +47,29 @@ const ForgotPasswordPage: React.FC = () => {
             required
             rules={{
               required: 'Email is required',
-              pattern: { value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/, message: 'Invalid email format' }
+              pattern: {
+                value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                message: 'Invalid email format',
+              },
             }}
             error={errors.email?.message as string}
             className="w-full"
           />
-          <button className="btn btn-primary w-full" type="submit" disabled={loading}>
+          <button
+            className="btn btn-primary w-full"
+            type="submit"
+            disabled={loading}
+          >
             {loading && <span className="loading loading-spinner mr-2" />}
             Request Reset
           </button>
         </form>
+        <p className="text-center mt-4">
+          Already have an account?{' '}
+          <Link href="/login" className="link">
+            Login
+          </Link>
+        </p>
         {message && <p className="mt-2">{message}</p>}
       </div>
     </div>

--- a/pages/reset.tsx
+++ b/pages/reset.tsx
@@ -1,4 +1,5 @@
 import { useState, FormEvent, ChangeEvent } from 'react';
+import Link from 'next/link';
 import { TextInput } from '../components/form-fields';
 
 const RequestReset: React.FC = () => {
@@ -34,6 +35,12 @@ const RequestReset: React.FC = () => {
           Request Reset
         </button>
       </form>
+      <p className="text-center mt-4">
+        Already have an account?{' '}
+        <Link href="/login" className="link">
+          Login
+        </Link>
+      </p>
       {message && <p className="mt-2">{message}</p>}
     </div>
   );

--- a/pages/reset/[token].tsx
+++ b/pages/reset/[token].tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import Link from 'next/link';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { PasswordInput } from '../../components/form-fields';
 
@@ -38,6 +39,12 @@ const ResetToken: React.FC = () => {
           Reset Password
         </button>
       </form>
+      <p className="text-center mt-4">
+        Already have an account?{' '}
+        <Link href="/login" className="link">
+          Login
+        </Link>
+      </p>
       {message && <p className="mt-2">{message}</p>}
     </div>
   );


### PR DESCRIPTION
## Summary
- add login link on `pages/reset.tsx`
- show login link on forgot password page
- add login option on password reset token page

## Testing
- `npx prettier --write pages/reset.tsx pages/auth/forgot-password.tsx pages/reset/[token].tsx`
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6856b5b45524832f9d32d76be6af8989