### PR TITLE
Fix alignment on auth forms

### DIFF
--- a/pages/auth/forgot-password.tsx
+++ b/pages/auth/forgot-password.tsx
@@ -31,8 +31,8 @@ const ForgotPasswordPage: React.FC = () => {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
-      <div className="max-w-sm mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
+    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8 overflow-hidden">
+      <div className="max-w-sm mx-auto border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
         <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
           <EmailInput

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -60,8 +60,8 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
-      <div className="max-w-md mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full space-y-4">
+    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8 overflow-hidden">
+      <div className="max-w-sm mx-auto border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full space-y-4">
         <h1 className="text-2xl font-bold mb-4">Login</h1>
         <button
           type="button"

--- a/pages/reset.tsx
+++ b/pages/reset.tsx
@@ -18,23 +18,25 @@ const RequestReset: React.FC = () => {
   };
 
   return (
-    <div className="max-w-sm mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
-      <form onSubmit={submit} className="space-y-2">
-        <TextInput
-          name="email"
-          className="w-full"
-          value={email}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            setEmail(e.target.value)
-          }
-          placeholder="Email"
-        />
-        <button className="btn btn-primary w-full" type="submit">
-          Request Reset
-        </button>
-      </form>
-      {message && <p className="mt-2">{message}</p>}
+    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8 overflow-hidden">
+      <div className="max-w-sm mx-auto border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
+        <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
+        <form onSubmit={submit} className="space-y-2">
+          <TextInput
+            name="email"
+            className="w-full"
+            value={email}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setEmail(e.target.value)
+            }
+            placeholder="Email"
+          />
+          <button className="btn btn-primary w-full" type="submit">
+            Request Reset
+          </button>
+        </form>
+        {message && <p className="mt-2">{message}</p>}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- center login form vertically
- center forgot password form vertically
- add wrapper layout for password reset page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b616e7a8832f953a586cba5afd88