### PR TITLE
Fix password input toggle and layout

### DIFF
--- a/components/form-fields/PasswordInput.tsx
+++ b/components/form-fields/PasswordInput.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import EyeIcon from '../icons/EyeIcon';
+import EyeOffIcon from '../icons/EyeOffIcon';
 import {
   UseFormRegister,
   RegisterOptions,
@@ -82,9 +84,14 @@ const PasswordInput = <T extends FieldValues>(
         <button
           type="button"
           onClick={toggle}
-          className="inline-flex items-center px-3 border border-l-0 rounded-r-md bg-gray-100 hover:bg-gray-200"
+          className="inline-flex items-center px-3 border border-l-0 rounded-r-md bg-gray-100 hover:bg-gray-200 focus:outline-none"
+          aria-label={show ? 'Hide password' : 'Show password'}
         >
-          {show ? 'Hide' : 'Show'}
+          {show ? (
+            <EyeOffIcon className="h-5 w-5" />
+          ) : (
+            <EyeIcon className="h-5 w-5" />
+          )}
         </button>
       </div>
       {error && <p className="text-sm text-red-600 mt-1">{error}</p>}

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -196,7 +196,7 @@ export default function UserSignup() {
           }}
           error={errors.email?.message as string}
         />
-        <div className="grid grid-cols-2 gap-2">
+        <div className="space-y-2">
           <PasswordInput
             name="password"
             placeholder="Password"


### PR DESCRIPTION
## Summary
- use eye icons for password visibility toggle
- stack password fields on user signup form

## Testing
- `npx jest` *(fails: Unable to find accessible element / toggle dark mode / etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6856b708cc54832f8216458aff3c3a6e