### PR TITLE
Add descriptive page titles

### DIFF
--- a/lib/pageTitle.ts
+++ b/lib/pageTitle.ts
@@ -1,0 +1,4 @@
+export const SITE_NAME = 'Product Search App';
+export function getPageTitle(page: string): string {
+  return page ? `${page} - ${SITE_NAME}` : SITE_NAME;
+}

--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -3,6 +3,8 @@ import { AppContext } from '../../contexts/AppContext';
 import Link from 'next/link';
 import { AnalyticsData } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function AdminAnalytics() {
   const { user } = useContext(AppContext)!;
@@ -23,6 +25,9 @@ export default function AdminAnalytics() {
 
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Admin Analytics')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Super Admin Dashboard</h1>
       <div className="mb-4 space-x-2">
         <Link href="/admin/users" className="btn btn-sm">

--- a/pages/admin/approvals.tsx
+++ b/pages/admin/approvals.tsx
@@ -2,6 +2,8 @@ import { useCallback, useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import { PendingProduct, ApiMessage } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function Approvals() {
   const { user } = useContext(AppContext)!;
@@ -35,6 +37,9 @@ export default function Approvals() {
 
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Vendor Approvals')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Vendor Product Approvals</h1>
       {message && <div className="mb-4 text-green-600">{message}</div>}
       <ul className="space-y-2">

--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -3,6 +3,8 @@ import { AppContext } from '../../contexts/AppContext';
 import { Category, CategoryInput, ApiMessage } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
 import { TextInput } from '../../components/form-fields';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function Categories() {
   const { user } = useContext(AppContext)!;
@@ -68,6 +70,9 @@ export default function Categories() {
 
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Manage Categories')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Categories</h1>
       {message && <div className="mb-4 text-green-600">{message}</div>}
       <div className="flex gap-2 mb-4">

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -10,6 +10,8 @@ import { AppContext } from '../../contexts/AppContext';
 import { Product, ProductInput, ApiMessage } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
 import { TextInput } from '../../components/form-fields';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function Admin() {
   const { user } = useContext(AppContext)!;
@@ -140,6 +142,9 @@ export default function Admin() {
 
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Admin Dashboard')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Admin Panel</h1>
       <div className="mb-4 space-x-2">
         <Link href="/admin/users" className="btn btn-sm">

--- a/pages/admin/search-analytics.tsx
+++ b/pages/admin/search-analytics.tsx
@@ -3,6 +3,8 @@ import { AppContext } from '../../contexts/AppContext';
 import Link from 'next/link';
 import { SearchAnalyticsResponse } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function SearchAnalytics() {
   const { user } = useContext(AppContext)!;
@@ -22,6 +24,9 @@ export default function SearchAnalytics() {
 
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Search Analytics')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Search Analytics</h1>
       <div className="mb-4 space-x-2">
         <Link href="/admin/analytics" className="btn btn-sm">

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -7,6 +7,8 @@ import {
   ApiMessage,
 } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function ManageUsers() {
   const { user } = useContext(AppContext)!;
@@ -60,6 +62,9 @@ export default function ManageUsers() {
 
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Manage Users')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Manage Users</h1>
       {message && <div className="mb-4 text-green-600">{message}</div>}
       <ul className="space-y-2">

--- a/pages/auth/forgot-password.tsx
+++ b/pages/auth/forgot-password.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { EmailInput } from '../../components/form-fields';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 interface ForgotPasswordForm {
   email: string;
@@ -32,6 +34,9 @@ const ForgotPasswordPage: React.FC = () => {
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Forgot Password')}</title>
+      </Head>
       <div className="max-w-sm mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
         <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">

--- a/pages/brand/analytics.tsx
+++ b/pages/brand/analytics.tsx
@@ -1,5 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/AppContext';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 type TopProduct = {
   id: string;
@@ -31,6 +33,9 @@ const BrandAnalytics: React.FC = () => {
 
   return (
     <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Brand Analytics')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Sales Summary</h1>
       <p>Total Orders: {data.totalOrders}</p>
       <p>Total Revenue: £{data.totalRevenue.toFixed(2)}</p>

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -10,6 +10,8 @@ import { AppContext } from '../../contexts/AppContext';
 import type { User } from '../../types/user';
 import type { Product, ProductInput } from '../../types/product';
 import { TextInput } from '../../components/form-fields';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 type ProductForm = Partial<ProductInput> & { id?: string };
 
@@ -167,6 +169,9 @@ const BrandDashboard: React.FC = () => {
 
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8 min-h-screen py-6">
+      <Head>
+        <title>{getPageTitle('Brand Dashboard')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Brand Dashboard</h1>
       {lowStock.length > 0 && (
         <div className="alert alert-warning mb-4">

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -1,6 +1,8 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import { Order } from '../../types';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 
 const BrandOrders: React.FC = () => {
@@ -33,6 +35,9 @@ const BrandOrders: React.FC = () => {
 
   return (
     <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Brand Orders')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Order History</h1>
       {error && <div className="alert alert-error mb-2">{error}</div>}
       {loading && (

--- a/pages/brand/profile.tsx
+++ b/pages/brand/profile.tsx
@@ -8,6 +8,8 @@ import React, {
 import { AppContext } from '../../contexts/AppContext';
 import type { User, Vendor } from '../../types';
 import { TextInput, Textarea } from '../../components/form-fields';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export const BrandProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
@@ -84,6 +86,9 @@ export const BrandProfile: React.FC = () => {
 
   return (
     <div className="max-w-sm mx-auto">
+      <Head>
+        <title>{getPageTitle('Brand Profile')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Brand Profile</h1>
       {message && <div className="mb-2 text-green-600">{message}</div>}
       <form onSubmit={submit} className="space-y-2">

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -1,5 +1,7 @@
 import { useContext } from 'react';
 import { useRouter } from 'next/router';
+import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
 import { AppContext, AppContextValue } from '../contexts/AppContext';
 
 // Define the type for a cart item
@@ -36,6 +38,9 @@ const Cart: React.FC = () => {
 
   return (
     <div className="max-w-3xl mx-auto min-h-screen p-4">
+      <Head>
+        <title>{getPageTitle('Cart')}</title>
+      </Head>
       <h1 className="text-3xl font-bold mb-4">Summary</h1>
       {cart.length === 0 && <p>Your cart is empty.</p>}
       <ul className="space-y-2 mb-4">

--- a/pages/categories/[slug]/index.tsx
+++ b/pages/categories/[slug]/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import ProductCard from '../../../components/ProductCard';
 import Head from 'next/head';
 import React from 'react';
+import { getPageTitle } from '../../../lib/pageTitle';
 import { Category, Product } from '../../../types';
 
 
@@ -34,7 +35,7 @@ const CategoryPage: React.FC = () => {
   return (
     <div className="max-w-screen-2xl mx-auto min-h-screen p-4">
       <Head>
-        <title>Category: {slug}</title>
+        <title>{getPageTitle(slug && !Array.isArray(slug) ? `Category: ${slug}` : 'Category')}</title>
         <meta name="description" content={`Products for ${slug}`} />
         <script
           type="application/ld+json"

--- a/pages/categories/[slug]/products.tsx
+++ b/pages/categories/[slug]/products.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
+import { getPageTitle } from '../../../lib/pageTitle';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import ProductCard from '../../../components/ProductCard';
@@ -77,7 +78,7 @@ export default function CategoryProductsPage({
   return (
     <div className="max-w-screen-2xl mx-auto min-h-screen px-4 sm:px-6 lg:px-8 py-6">
       <Head>
-        <title>{category.name} Products</title>
+        <title>{getPageTitle(`${category.name} Products`)}</title>
         <meta name="description" content={`Products for ${category.name}`} />
       </Head>
       <h1 className="text-2xl font-bold mb-4">

--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 import { Category } from '../../types';
 
 const Categories: React.FC = () => {
@@ -19,6 +21,9 @@ const Categories: React.FC = () => {
 
   return (
     <div className="max-w-2xl mx-auto min-h-screen p-4">
+      <Head>
+        <title>{getPageTitle('Categories')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Categories</h1>
       <ul className="list-disc pl-4 space-y-2">
         {categories.map((c) => renderCat(c))}

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,6 +1,8 @@
 import { useContext, useState, FormEvent, ChangeEvent } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
+import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
 import { AppContext, AppContextValue } from '../contexts/AppContext';
 import type { User } from '../types/user';
 import type { Coupon } from '../types';
@@ -81,6 +83,9 @@ const Checkout: React.FC = () => {
 
   return (
     <div className="max-w-3xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Checkout')}</title>
+      </Head>
       <h1 className="text-3xl font-bold mb-4">Checkout</h1>
       <div className="mb-4 max-h-64 overflow-y-auto">
         <ul className="space-y-2">

--- a/pages/checkout/cancel.tsx
+++ b/pages/checkout/cancel.tsx
@@ -1,3 +1,13 @@
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
+
 export default function Cancel() {
-  return <p className="p-4">Payment canceled.</p>;
+  return (
+    <div className="p-4">
+      <Head>
+        <title>{getPageTitle('Payment Canceled')}</title>
+      </Head>
+      Payment canceled.
+    </div>
+  );
 }

--- a/pages/checkout/success.tsx
+++ b/pages/checkout/success.tsx
@@ -1,5 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function Success() {
   const router = useRouter();
@@ -18,7 +20,30 @@ export default function Success() {
       .catch(() => setStatus('error'));
   }, [session_id]);
 
-  if (status === 'processing') return <p className="p-4">Processing payment...</p>;
-  if (status === 'error') return <p className="p-4">Payment failed.</p>;
-  return <p className="p-4">Payment successful! Check your email for confirmation.</p>;
+  if (status === 'processing')
+    return (
+      <p className="p-4">
+        <Head>
+          <title>{getPageTitle('Processing Payment')}</title>
+        </Head>
+        Processing payment...
+      </p>
+    );
+  if (status === 'error')
+    return (
+      <p className="p-4">
+        <Head>
+          <title>{getPageTitle('Payment Failed')}</title>
+        </Head>
+        Payment failed.
+      </p>
+    );
+  return (
+    <p className="p-4">
+      <Head>
+        <title>{getPageTitle('Payment Successful')}</title>
+      </Head>
+      Payment successful! Check your email for confirmation.
+    </p>
+  );
 }

--- a/pages/confirm/[token].tsx
+++ b/pages/confirm/[token].tsx
@@ -1,5 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function Confirm() {
   const router = useRouter();
@@ -17,5 +19,12 @@ export default function Confirm() {
     }
     verify();
   }, [token]);
-  return <div className="p-4">{message || 'Verifying...'}</div>;
+  return (
+    <div className="p-4">
+      <Head>
+        <title>{getPageTitle('Email Confirmation')}</title>
+      </Head>
+      {message || 'Verifying...'}
+    </div>
+  );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
 import HeroSlider from '../components/HeroSlider';
 import ProductCard from '../components/ProductCard';
 import DEFAULT_CATEGORIES from '../lib/defaultCategories';
@@ -286,7 +287,7 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
   return (
     <div className="min-h-screen bg-base-200 flex flex-col items-center py-10 font-sans">
       <Head>
-        <title>Product Search App</title>
+        <title>{getPageTitle('Home')}</title>
         <meta name="description" content="Search products from CSV data" />
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -5,6 +5,8 @@ import type { AppContextValue } from '../contexts/AppContext';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
+import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
 import {
   EmailInput,
   PasswordInput,
@@ -61,6 +63,9 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Login')}</title>
+      </Head>
       <div className="max-w-md mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full space-y-4">
         <h1 className="text-2xl font-bold mb-4">Login</h1>
         <button

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -1,6 +1,8 @@
 import { useContext, useEffect, useState } from 'react';
 import { AppContext } from '../contexts/AppContext';
 import type { Order } from '../types';
+import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
 
 type OrdersProps = {};
 
@@ -29,6 +31,9 @@ const Orders: React.FC<OrdersProps> = (_props) => {
 
   return (
     <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Orders')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Orders</h1>
       {error && <div className="alert alert-error mb-2">{error}</div>}
       {loading && (

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -1,6 +1,7 @@
 import { useContext, useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 import Link from 'next/link';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { AppContext } from '../../contexts/AppContext';
@@ -89,7 +90,7 @@ export default function ProductDetail({
   return (
     <div className="p-6 max-w-screen-2xl mx-auto bg-base-100 rounded-box shadow-md min-h-screen">
       <Head>
-        <title>{product.title} - Product</title>
+        <title>{getPageTitle(product.title || 'Product')}</title>
         <meta
           name="description"
           content={product.descriptionText?.slice(0, 150)}

--- a/pages/products.tsx
+++ b/pages/products.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useContext, FormEvent } from 'react';
 import { AppContext } from '../contexts/AppContext';
 import type { Product } from '../types/product';
 import ProductCard from '../components/ProductCard';
+import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
 
 const Products: React.FC = () => {
   const { addToCart } = useContext(AppContext)!;
@@ -63,6 +65,9 @@ const Products: React.FC = () => {
 
   return (
     <div className="w-full bg-gradient-to-br from-base-200 to-base-100 min-h-screen">
+      <Head>
+        <title>{getPageTitle('Products')}</title>
+      </Head>
       <div className="max-w-screen-xl mx-auto px-4">
         <h1 className="text-3xl font-bold mb-4">Products</h1>
         <button

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useContext, FormEvent, ChangeEvent } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import Link from 'next/link';
 import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 import ProductImageSlider from '../../components/ProductImageSlider';
 import type { Product } from '../../types';
 import type {
@@ -66,7 +67,7 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
   return (
     <div className="max-w-screen-2xl mx-auto bg-base-100 rounded-box shadow-md">
       <Head>
-        <title>{(product.title || 'Product') + ' - Product'}</title>
+        <title>{getPageTitle(product?.title || 'Product')}</title>
         <meta
           name="description"
           content={product.descriptionText?.slice(0, 150)}

--- a/pages/reset.tsx
+++ b/pages/reset.tsx
@@ -1,5 +1,7 @@
 import { useState, FormEvent, ChangeEvent } from 'react';
 import { TextInput } from '../components/form-fields';
+import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
 
 const RequestReset: React.FC = () => {
   const [email, setEmail] = useState<string>('');
@@ -19,6 +21,9 @@ const RequestReset: React.FC = () => {
 
   return (
     <div className="max-w-sm mx-auto">
+      <Head>
+        <title>{getPageTitle('Reset Password')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
       <form onSubmit={submit} className="space-y-2">
         <TextInput

--- a/pages/reset/[token].tsx
+++ b/pages/reset/[token].tsx
@@ -2,6 +2,8 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { PasswordInput } from '../../components/form-fields';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 const ResetToken: React.FC = () => {
   const router = useRouter();
@@ -25,6 +27,9 @@ const ResetToken: React.FC = () => {
 
   return (
     <div className="max-w-sm mx-auto">
+      <Head>
+        <title>{getPageTitle('Set New Password')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Set New Password</h1>
       <form onSubmit={handleSubmit(submit)} className="space-y-2">
         <PasswordInput

--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -17,6 +17,8 @@ import {
 } from '../../components/form-fields';
 import GoogleIcon from '../../components/icons/GoogleIcon';
 import GithubIcon from '../../components/icons/GithubIcon';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
@@ -191,6 +193,9 @@ export default function BrandSignup() {
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Brand Signup')}</title>
+      </Head>
       <div className="max-w-3xl mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
       <div className="text-center mb-6">
         <h1 className="text-2xl font-bold">Brand Sign Up</h1>

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,8 +1,13 @@
 import Link from 'next/link';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function Signup() {
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Signup')}</title>
+      </Head>
       <div className="w-full max-w-md space-y-4 -mt-8">
       <h1 className="text-2xl font-bold mb-4">Choose Signup Type</h1>
       <Link href="/signup/user" className="btn btn-primary w-full">

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -7,6 +7,8 @@ import { signIn } from 'next-auth/react';
 import { components, OptionProps, SingleValueProps } from 'react-select';
 import countryList from 'react-select-country-list';
 import Flag from 'react-world-flags';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 import GoogleIcon from '../../components/icons/GoogleIcon';
 import GithubIcon from '../../components/icons/GithubIcon';
 import {
@@ -146,6 +148,9 @@ export default function UserSignup() {
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('User Signup')}</title>
+      </Head>
       <div className="max-w-lg mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
         <h1 className="text-2xl font-bold mb-4">User Sign Up</h1>
       <div className="flex flex-col gap-6 mb-4">

--- a/pages/user/orders.tsx
+++ b/pages/user/orders.tsx
@@ -1,6 +1,8 @@
 import { useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import type { Order } from '../../types';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 const UserOrders: React.FC = () => {
   const { user } = useContext(AppContext)!;
   const [orders, setOrders] = useState<Order[]>([]);
@@ -26,6 +28,9 @@ const UserOrders: React.FC = () => {
 
   return (
     <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('My Orders')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">My Orders</h1>
       {error && <div className="alert alert-error mb-2">{error}</div>}
       {loading && (

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -2,6 +2,8 @@ import React, { useContext, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { AppContext } from '../../contexts/AppContext';
 import type { User } from '../../types/user';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export const UserProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
@@ -54,6 +56,9 @@ export const UserProfile: React.FC = () => {
 
   return (
     <div className="max-w-sm mx-auto">
+      <Head>
+        <title>{getPageTitle('My Profile')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">My Profile</h1>
       {message && <div className="mb-2 text-green-600">{message}</div>}
       <form onSubmit={handleSubmit(submit)} className="space-y-2">

--- a/pages/user/wishlist.tsx
+++ b/pages/user/wishlist.tsx
@@ -1,6 +1,8 @@
 import React, { useContext } from 'react';
 import Link from 'next/link';
 import { AppContext, AppContextValue } from '../../contexts/AppContext';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 const UserWishlist: React.FC = () => {
   const context = useContext<AppContextValue | undefined>(AppContext);
@@ -13,6 +15,9 @@ const UserWishlist: React.FC = () => {
 
   return (
     <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('My Wishlist')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">My Wishlist</h1>
       <ul className="space-y-2">
         {wishlist.map((item) => (

--- a/pages/vendor/index.tsx
+++ b/pages/vendor/index.tsx
@@ -9,6 +9,8 @@ import {
 import { AppContext } from '../../contexts/AppContext';
 import type { Product } from '../../types';
 import { TextInput } from '../../components/form-fields';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function VendorDashboard() {
   const { user } = useContext(AppContext)!;
@@ -135,6 +137,9 @@ export default function VendorDashboard() {
 
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Vendor Dashboard')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Vendor Dashboard</h1>
       {message && <div className="mb-4 text-green-600">{message}</div>}
       <form onSubmit={submit} className="space-y-2 mb-6">

--- a/pages/vendor/orders.tsx
+++ b/pages/vendor/orders.tsx
@@ -7,6 +7,8 @@ import {
 import { AppContext } from '../../contexts/AppContext';
 import { NotificationContext } from '../../contexts/NotificationContext';
 import type { Order } from '../../types';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
 
 export default function VendorOrders() {
   const { user } = useContext(AppContext)!;
@@ -57,6 +59,9 @@ export default function VendorOrders() {
 
   return (
     <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Vendor Orders')}</title>
+      </Head>
       <h1 className="text-2xl font-bold mb-4">Order History</h1>
       {error && <div className="alert alert-error mb-2">{error}</div>}
       {loading && (


### PR DESCRIPTION
## Summary
- create a helper `getPageTitle` with site name
- use `<Head>` and dynamic titles across all pages
- include fallbacks for dynamic pages

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b5ce8184832faa265f32c91d18aa