### PR TITLE
Fix brand signup layout and center form titles

### DIFF
--- a/pages/auth/forgot-password.tsx
+++ b/pages/auth/forgot-password.tsx
@@ -38,7 +38,7 @@ const ForgotPasswordPage: React.FC = () => {
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8 overflow-hidden">
       <div className="max-w-sm mx-auto border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
-        <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
+        <h1 className="text-2xl font-bold mb-4 text-center">Reset Password</h1>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
           <EmailInput
             name="email"

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -62,7 +62,7 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8 overflow-hidden">
       <div className="max-w-sm mx-auto border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full space-y-4">
-        <h1 className="text-2xl font-bold mb-4">Login</h1>
+        <h1 className="text-2xl font-bold mb-4 text-center">Login</h1>
         <button
           type="button"
           className="btn w-full mb-2 hover:bg-red-600 hover:text-white flex items-center justify-center gap-2"

--- a/pages/reset.tsx
+++ b/pages/reset.tsx
@@ -21,7 +21,7 @@ const RequestReset: React.FC = () => {
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8 overflow-hidden">
       <div className="max-w-sm mx-auto border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
-        <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
+        <h1 className="text-2xl font-bold mb-4 text-center">Reset Password</h1>
         <form onSubmit={submit} className="space-y-2">
           <TextInput
             name="email"

--- a/pages/reset/[token].tsx
+++ b/pages/reset/[token].tsx
@@ -26,7 +26,7 @@ const ResetToken: React.FC = () => {
 
   return (
     <div className="max-w-sm mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Set New Password</h1>
+      <h1 className="text-2xl font-bold mb-4 text-center">Set New Password</h1>
       <form onSubmit={handleSubmit(submit)} className="space-y-2">
         <PasswordInput
           className="w-full"

--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -191,9 +191,9 @@ export default function BrandSignup() {
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
-      <div className="max-w-3xl mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
+      <div className="max-w-3xl mx-auto border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
       <div className="text-center mb-6">
-        <h1 className="text-2xl font-bold">Brand Sign Up</h1>
+        <h1 className="text-2xl font-bold text-center">Brand Sign Up</h1>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
         <button

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -4,7 +4,7 @@ export default function Signup() {
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
       <div className="w-full max-w-md space-y-4 -mt-8">
-      <h1 className="text-2xl font-bold mb-4">Choose Signup Type</h1>
+      <h1 className="text-2xl font-bold mb-4 text-center">Choose Signup Type</h1>
       <Link href="/signup/user" className="btn btn-primary w-full">
         User Signup
       </Link>

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -147,7 +147,7 @@ export default function UserSignup() {
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
       <div className="max-w-lg mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
-        <h1 className="text-2xl font-bold mb-4">User Sign Up</h1>
+        <h1 className="text-2xl font-bold mb-4 text-center">User Sign Up</h1>
       <div className="flex flex-col gap-6 mb-4">
         <button
           type="button"


### PR DESCRIPTION
## Summary
- align login title and update text styles
- center header for signup selection
- center user and brand signup page titles
- wrap brand signup in correct container
- center titles on password reset forms

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b830defc832f90a2a12c710e299e