### PR TITLE
Simplify signup flow

### DIFF
--- a/pages/api/signup/brand.ts
+++ b/pages/api/signup/brand.ts
@@ -14,45 +14,13 @@ export default async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
 
-    const {
-      email,
-      password,
-      firstName,
-      lastName,
-      brandName,
-      phoneNumber,
-      businessAddress,
-      city,
-      country,
-      website,
-      businessDescription,
-      taxId,
-    } = req.body as {
+    const { email, password, firstName } = req.body as {
       email?: string;
       password?: string;
       firstName?: string;
-      lastName?: string;
-      brandName?: string;
-      phoneNumber?: string;
-      businessAddress?: string;
-      city?: string;
-      country?: string;
-      website?: string;
-      businessDescription?: string;
-      taxId?: string;
     };
 
-    if (
-      !email ||
-      !password ||
-      !firstName ||
-      !lastName ||
-      !brandName ||
-      !phoneNumber ||
-      !businessAddress ||
-      !city ||
-      !country
-    ) {
+    if (!email || !password || !firstName) {
       return res.status(400).json({ message: 'missing required fields' });
     }
     if (await findUser(email)) {
@@ -64,15 +32,8 @@ export default async function handler(
         email,
         password: hashed,
         firstName,
-        lastName,
-        brandName,
-        phoneNumber,
-        businessAddress,
-        city,
-        country,
-        website: website ?? undefined,
-        businessDescription: businessDescription ?? undefined,
-        taxId: taxId ?? undefined,
+        lastName: '',
+        brandName: '',
         role: 'BRAND',
         verificationToken: token,
       });

--- a/pages/api/signup/user.ts
+++ b/pages/api/signup/user.ts
@@ -13,28 +13,12 @@ export default async function handler(
     if (req.method !== 'POST') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const {
-      email,
-      password,
-      firstName,
-      lastName,
-      gender,
-      phoneNumber,
-      address,
-      city,
-      country,
-    } = req.body as {
+    const { email, password, firstName } = req.body as {
       email?: string;
       password?: string;
       firstName?: string;
-      lastName?: string;
-      gender?: string;
-      phoneNumber?: string;
-      address?: string;
-      city?: string;
-      country?: string;
     };
-    if (!email || !password || !firstName || !lastName) {
+    if (!email || !password || !firstName) {
       return res.status(400).json({ message: 'missing required fields' });
     }
     if (await findUser(email)) {
@@ -46,12 +30,8 @@ export default async function handler(
         email,
         password: hashed,
         firstName,
-        lastName,
-        gender: gender || '',
-        phoneNumber: phoneNumber ?? undefined,
-        address: address ?? undefined,
-        city: city ?? undefined,
-        country: country ?? undefined,
+        lastName: '',
+        gender: 'other',
         role: 'USER',
         verificationToken: token,
       });

--- a/pages/api/user/profile.ts
+++ b/pages/api/user/profile.ts
@@ -19,8 +19,10 @@ export default async function handler(
       return res.status(200).json(userData);
     }
     if (req.method === 'PUT') {
-      const { phoneNumber, address, city, country } = req.body;
+      const { lastName, gender, phoneNumber, address, city, country } = req.body;
       await updateUserProfile(session.user.email, {
+        lastName,
+        gender,
         phoneNumber,
         address,
         city,

--- a/pages/brand/profile.tsx
+++ b/pages/brand/profile.tsx
@@ -5,6 +5,7 @@ import React, {
   ChangeEvent,
   FormEvent,
 } from 'react';
+import { useRouter } from 'next/router';
 import { AppContext } from '../../contexts/AppContext';
 import type { User, Vendor } from '../../types';
 import { TextInput, Textarea } from '../../components/form-fields';
@@ -13,6 +14,8 @@ import { getPageTitle } from '../../lib/pageTitle';
 
 export const BrandProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
+  const router = useRouter();
+  const showComplete = router.query.complete === '1';
   const [brandName, setBrandName] = useState<string>(user?.brandName || '');
   const [phoneNumber, setPhoneNumber] = useState<string>(
     user?.phoneNumber || ''
@@ -90,6 +93,9 @@ export const BrandProfile: React.FC = () => {
         <title>{getPageTitle('Brand Profile')}</title>
       </Head>
       <h1 className="text-2xl font-bold mb-4">Brand Profile</h1>
+      {showComplete && (
+        <div className="alert alert-info mb-2">Please complete your profile.</div>
+      )}
       {message && <div className="mb-2 text-green-600">{message}</div>}
       <form onSubmit={submit} className="space-y-2">
         <TextInput

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -43,9 +43,15 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
   useEffect(() => {
     if (user) {
       if (onLoginSuccess) onLoginSuccess(user);
-      if (user.role === 'brand') router.push('/brand/dashboard');
-      else if (user.role === 'super-admin') router.push('/admin');
-      else router.push('/user/dashboard');
+      if (user.role === 'brand') {
+        if (!user.brandName) router.push('/brand/profile?complete=1');
+        else router.push('/brand/dashboard');
+      } else if (user.role === 'super-admin') {
+        router.push('/admin');
+      } else {
+        if (!user.lastName) router.push('/user/profile?complete=1');
+        else router.push('/');
+      }
     }
   }, [user, router, onLoginSuccess]);
 

--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -1,47 +1,21 @@
-import { useState, useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import Image from 'next/image';
-import { components, OptionProps, SingleValueProps } from 'react-select';
-import countryList from 'react-select-country-list';
-import Flag from 'react-world-flags';
-import { useForm, Controller } from 'react-hook-form';
 import { AppContext } from '../../contexts/AppContext';
 import { signIn } from 'next-auth/react';
-import {
-  TextInput,
-  EmailInput,
-  PasswordInput,
-  Textarea,
-  SelectDropdown,
-} from '../../components/form-fields';
-import GoogleIcon from '../../components/icons/GoogleIcon';
-import GithubIcon from '../../components/icons/GithubIcon';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
+import GoogleIcon from '../../components/icons/GoogleIcon';
+import GithubIcon from '../../components/icons/GithubIcon';
+import {
+  EmailInput,
+  PasswordInput,
+  TextInput,
+} from '../../components/form-fields';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
-
-type CountryOptionType = { label: string; value: string };
-
-const CountryOption = (props: OptionProps<CountryOptionType, false>) => (
-  <components.Option {...props}>
-    <div className="flex items-center gap-2">
-      <Flag code={props.data.value} style={{ width: 20, height: 15 }} />
-      <span aria-label={props.data.label}>{props.data.label}</span>
-    </div>
-  </components.Option>
-);
-
-const CountrySingleValue = (props: SingleValueProps<CountryOptionType, false>) => (
-  <components.SingleValue {...props}>
-    <div className="flex items-center gap-2">
-      <Flag code={props.data.value} style={{ width: 20, height: 15 }} />
-      <span aria-label={props.data.label}>{props.data.label}</span>
-    </div>
-  </components.SingleValue>
-);
 
 export default function BrandSignup() {
   const router = useRouter();
@@ -49,65 +23,47 @@ export default function BrandSignup() {
   const {
     register,
     handleSubmit,
-    control,
     watch,
     getValues,
     setError,
     clearErrors,
     formState: { errors },
   } = useForm<{
-    brandName: string;
     firstName: string;
-    lastName: string;
     email: string;
     password: string;
     confirm: string;
-    phoneNumber: string;
-    businessAddress: string;
-    city: string;
-    country: string;
-    website: string;
-    businessDescription: string;
-    taxId: string;
-    logo: FileList;
   }>();
-  const [logoFile, setLogoFile] = useState<File | null>(null);
-  const [logoPreview, setLogoPreview] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
   const [passwordFocused, setPasswordFocused] = useState(false);
   const [formError, setFormError] = useState('');
-  const countryOptions = useMemo(
-    () =>
-      countryList()
-        .getData()
-        .map((c: { label: string; value: string }) => ({ label: `${c.label} (${c.value})`, value: c.value })),
-    []
-  );
 
   useEffect(() => {
     if (user) {
-      if (user.role === 'brand') router.push('/brand/dashboard');
+      if (user.role === 'brand') router.push('/brand/profile?complete=1');
       else if (user.role === 'super-admin') router.push('/admin');
-      else router.push('/user/dashboard');
+      else router.push('/user/profile?complete=1');
     }
   }, [user, router]);
 
   const handleEmailBlur = async () => {
     const value = getValues('email');
-    if (value && emailRegex.test(value)) {
+    if (value && !emailRegex.test(value)) {
+      setError('email', { type: 'pattern', message: 'Invalid email format' });
+      return;
+    }
+    if (value) {
       try {
-        const res = await fetch(
-          `/api/check-email?email=${encodeURIComponent(value)}`
-        );
+        const res = await fetch(`/api/check-email?email=${encodeURIComponent(value)}`);
         if (res.ok) {
           const data = await res.json();
           if (data.exists) {
-            return 'Email already registered';
+            setError('email', { type: 'manual', message: 'Email already registered' });
+          } else {
+            clearErrors('email');
           }
         }
       } catch (_) {}
     }
-    return true;
   };
 
   const handlePasswordFocus = () => {
@@ -122,292 +78,124 @@ export default function BrandSignup() {
     const password = getValues('password');
     const confirm = getValues('confirm');
     if (password && confirm && password !== confirm) {
+      setError('confirm', { type: 'manual', message: 'Passwords do not match' });
       return 'Passwords do not match';
     }
+    clearErrors('confirm');
     return true;
   };
 
-  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) {
-      setLogoFile(null);
-      setLogoPreview(null);
-      return;
-    }
-    if (
-      !['image/png', 'image/jpeg'].includes(file.type) ||
-      file.size > 2 * 1024 * 1024
-    ) {
-      setError('logo', { type: 'manual', message: 'Logo must be PNG/JPG and under 2MB' });
-      return;
-    }
-    clearErrors('logo');
-    setLogoFile(file);
-    setLogoPreview(URL.createObjectURL(file));
-  };
-
   const submit = async (values: any) => {
-    setLoading(true);
     try {
-      const {
-        brandName,
-        firstName,
-        lastName,
-        email,
-        password,
-        phoneNumber,
-        businessAddress,
-        city,
-        country,
-        website,
-        businessDescription,
-        taxId,
-      } = values;
       const data = await signup<{ token: string }>('/api/signup/brand', {
-        brandName,
-        firstName,
-        lastName,
-        email,
-        password,
-        phoneNumber,
-        businessAddress,
-        city,
-        country,
-        website,
-        businessDescription,
-        taxId,
-        logo: logoFile,
+        firstName: values.firstName,
+        email: values.email,
+        password: values.password,
       });
       router.push(`/confirm/${data.token}`);
     } catch (e) {
       setFormError('Signup failed');
-    } finally {
-      setLoading(false);
     }
   };
 
   const passwordValue = watch('password');
-  const showPasswordHint =
-    passwordFocused ||
-    (passwordValue !== '' && !passwordRegex.test(passwordValue || ''));
+  const showPasswordHint = passwordFocused || (passwordValue !== '' && !passwordRegex.test(passwordValue));
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
       <Head>
         <title>{getPageTitle('Brand Signup')}</title>
       </Head>
-      <div className="max-w-3xl mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
-      <div className="text-center mb-6">
-        <h1 className="text-2xl font-bold text-center">Brand Sign Up</h1>
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-        <button
-          type="button"
-          className="btn btn-lg w-full flex items-center justify-center gap-2 hover:bg-red-600 hover:text-white rounded-lg"
-          onClick={() => signIn('google')}
-        >
-          <GoogleIcon className="h-5 w-5" />
-          Continue with Google
-        </button>
-        <button
-          type="button"
-          className="btn btn-lg w-full flex items-center justify-center gap-2 hover:bg-gray-800 hover:text-white rounded-lg"
-          onClick={() => signIn('github')}
-        >
-          <GithubIcon className="h-5 w-5" />
-          Continue with GitHub
-        </button>
-      </div>
-      {formError && <div className="text-red-500 mb-2">{formError}</div>}
-      <form id="brand-signup-form" onSubmit={handleSubmit(submit)} className="space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="space-y-5">
-            <h2 className="text-xl font-semibold">Account Info</h2>
-            <TextInput
-              name="firstName"
-              placeholder="First Name"
-              required
-              register={register}
-              rules={{ required: 'firstName is required' }}
-              error={errors.firstName?.message as string}
-            />
-            <TextInput
-              name="lastName"
-              placeholder="Last Name"
-              required
-              register={register}
-              rules={{ required: 'lastName is required' }}
-              error={errors.lastName?.message as string}
-            />
-            <EmailInput
-              name="email"
-              placeholder="Email"
-              required
+      <div className="max-w-lg mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
+        <h1 className="text-2xl font-bold mb-4 text-center">Brand Sign Up</h1>
+        <div className="flex flex-col gap-6 mb-4">
+          <button
+            type="button"
+            className="btn btn-lg px-6 w-full sm:w-auto flex items-center justify-center gap-2 hover:bg-red-600 hover:text-white"
+            onClick={() => signIn('google')}
+          >
+            <GoogleIcon className="h-5 w-5" />
+            Continue with Google
+          </button>
+          <button
+            type="button"
+            className="btn btn-lg px-6 w-full sm:w-auto flex items-center justify-center gap-2 hover:bg-gray-800 hover:text-white"
+            onClick={() => signIn('github')}
+          >
+            <GithubIcon className="h-5 w-5" />
+            Continue with GitHub
+          </button>
+        </div>
+        {formError && <div className="text-red-500 mb-2">{formError}</div>}
+        <form onSubmit={handleSubmit(submit)} className="space-y-2">
+          <TextInput
+            name="firstName"
+            placeholder="First Name"
+            register={register}
+            rules={{ required: 'First name is required' }}
+            error={errors.firstName?.message as string}
+          />
+          <EmailInput
+            name="email"
+            placeholder="Email"
+            register={register}
+            rules={{
+              required: 'Email is required',
+              pattern: { value: emailRegex, message: 'Invalid email format' },
+              validate: async () => {
+                await handleEmailBlur();
+                return true;
+              },
+            }}
+            error={errors.email?.message as string}
+          />
+          <div className="space-y-2">
+            <PasswordInput
+              name="password"
+              placeholder="Password"
               register={register}
               rules={{
-                required: 'Email is required',
-                pattern: { value: emailRegex, message: 'Invalid email format' },
-                validate: handleEmailBlur,
+                required: 'Password is required',
+                pattern: {
+                  value: passwordRegex,
+                  message:
+                    'Password must be at least 8 characters and include uppercase, lowercase, number and special character',
+                },
+                onBlur: handlePasswordBlur,
               }}
-              error={errors.email?.message as string}
+              onFocus={handlePasswordFocus}
+              error={errors.password?.message as string}
             />
-            <div className="space-y-5">
-              <PasswordInput
-                name="password"
-                aria-describedby="password-help"
-                placeholder="Password"
-                required
-                register={register}
-                rules={{
-                  required: 'Password is required',
-                  pattern: {
-                    value: passwordRegex,
-                    message:
-                      'Password must be at least 8 characters and include uppercase, lowercase, number and special character',
-                  },
-                  onBlur: handlePasswordBlur,
-                }}
-                onFocus={handlePasswordFocus}
-                error={errors.password?.message as string}
-              />
-              <PasswordInput
-                name="confirm"
-                placeholder="Confirm Password"
-                required
-                register={register}
-                rules={{ validate: handleConfirmBlur }}
-                error={errors.confirm?.message as string}
-              />
-              {showPasswordHint && (
-                <p id="password-help" className="text-sm text-gray-500">
-                  Password must be at least 8 characters and include uppercase,
-                  lowercase, number and special character
-                </p>
-              )}
-            </div>
-          </div>
-          <div className="space-y-5">
-            <h2 className="text-xl font-semibold">Business Info</h2>
-            <TextInput
-              name="brandName"
-              placeholder="Brand Name"
-              required
+            <PasswordInput
+              name="confirm"
+              placeholder="Confirm Password"
               register={register}
-              rules={{ required: 'brandName is required' }}
-              error={errors.brandName?.message as string}
-            />
-            <TextInput
-              name="phoneNumber"
-              placeholder="Phone Number"
-              required
-              register={register}
-              rules={{ required: 'phoneNumber is required' }}
-              error={errors.phoneNumber?.message as string}
-            />
-            <TextInput
-              name="businessAddress"
-              placeholder="Business Address"
-              required
-              register={register}
-              rules={{ required: 'businessAddress is required' }}
-              error={errors.businessAddress?.message as string}
-            />
-            <div className="space-y-5">
-              <div>
-                <TextInput
-                  name="city"
-                  placeholder="City"
-                  required
-                  register={register}
-                  rules={{ required: 'city is required' }}
-                  error={errors.city?.message as string}
-                />
-              </div>
-              <div>
-                <SelectDropdown
-                  name="country"
-                  control={control}
-                  options={countryOptions}
-                  placeholder="Country"
-                  components={{ Option: CountryOption, SingleValue: CountrySingleValue }}
-                  rules={{ required: 'country is required' }}
-                  error={errors.country?.message as string}
-                />
-              </div>
-            </div>
-
-          </div>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="space-y-5">
-            <TextInput
-              name="website"
-              placeholder="Website"
-              register={register}
-              error={errors.website?.message as string}
-            />
-            <TextInput
-              name="taxId"
-              placeholder="Tax ID"
-              register={register}
-              error={errors.taxId?.message as string}
+              rules={{ validate: handleConfirmBlur }}
+              error={errors.confirm?.message as string}
             />
           </div>
-          <div className="space-y-5">
-            <Textarea
-              name="businessDescription"
-              placeholder="Business Description"
-              register={register}
-              error={errors.businessDescription?.message as string}
-            />
-            <div>
-              <label className="block text-sm mb-1">Logo</label>
-              {logoPreview ? (
-                <Image
-                  src={logoPreview}
-                  alt="Preview"
-                  width={96}
-                  height={96}
-                  className="h-24 w-24 object-cover mb-2 rounded"
-                />
-              ) : (
-                <div className="h-24 w-24 border border-dashed flex items-center justify-center text-gray-400 mb-2 rounded">
-                  No logo
-                </div>
-              )}
-              <input
-                name="logo"
-                type="file"
-                accept="image/png,image/jpeg"
-                onChange={handleLogoChange}
-                className="file-input file-input-bordered w-full rounded-lg mt-2"
-              />
-              {errors.logo && (
-                <p className="text-red-500 text-sm">{errors.logo.message as string}</p>
-              )}
-            </div>
-          </div>
-        </div>
-        <button
-          className="btn btn-primary w-full mt-8"
-          type="submit"
-          disabled={loading}
-        >
-          {loading ? 'Creating...' : 'Create Brand Account'}
-        </button>
-      </form>
-      <p className="text-center mt-4">
-        Already have an account?{' '}
-        <Link href="/login" className="link">
-          Login
-        </Link>
-      </p>
-      <p className="text-sm text-center mt-4 text-gray-600">
-        Not a brand?{' '}
-        <Link href="/signup/user" className="text-blue-600 hover:underline">
-          Sign up as a user instead
-        </Link>
-      </p>
+          {showPasswordHint && (
+            <p id="password-help" className="text-sm text-gray-500">
+              Password must be at least 8 characters and include uppercase,
+              lowercase, number and special character
+            </p>
+          )}
+          <button className="btn btn-primary w-full" type="submit">
+            Sign Up
+          </button>
+        </form>
+        <p className="text-center mt-4">
+          Already have an account?{' '}
+          <Link href="/login" className="link">
+            Login
+          </Link>
+        </p>
+        <p className="text-sm text-center mt-4 text-gray-600">
+          Not a brand?{' '}
+          <Link href="/signup/user" className="text-blue-600 hover:underline">
+            Sign up as a user instead
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -1,45 +1,21 @@
-import { useContext, useEffect, useMemo, useState } from 'react';
-import { useForm, Controller } from 'react-hook-form';
+import { useContext, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
 import { signIn } from 'next-auth/react';
-import { components, OptionProps, SingleValueProps } from 'react-select';
-import countryList from 'react-select-country-list';
-import Flag from 'react-world-flags';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
 import GoogleIcon from '../../components/icons/GoogleIcon';
 import GithubIcon from '../../components/icons/GithubIcon';
 import {
-  TextInput,
   EmailInput,
   PasswordInput,
-  SelectDropdown,
+  TextInput,
 } from '../../components/form-fields';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
-
-type CountryOptionType = { label: string; value: string };
-
-const CountryOption = (props: OptionProps<CountryOptionType, false>) => (
-  <components.Option {...props}>
-    <div className="flex items-center gap-2">
-      <Flag code={props.data.value} style={{ width: 20, height: 15 }} />
-      <span aria-label={props.data.label}>{props.data.label}</span>
-    </div>
-  </components.Option>
-);
-
-const CountrySingleValue = (props: SingleValueProps<CountryOptionType, false>) => (
-  <components.SingleValue {...props}>
-    <div className="flex items-center gap-2">
-      <Flag code={props.data.value} style={{ width: 20, height: 15 }} />
-      <span aria-label={props.data.label}>{props.data.label}</span>
-    </div>
-  </components.SingleValue>
-);
 
 export default function UserSignup() {
   const router = useRouter();
@@ -55,31 +31,18 @@ export default function UserSignup() {
     formState: { errors },
   } = useForm<{
     firstName: string;
-    lastName: string;
     email: string;
     password: string;
     confirm: string;
-    gender: string;
-    phone: string;
-    address: string;
-    city: string;
-    country: string;
   }>();
   const [passwordFocused, setPasswordFocused] = useState(false);
   const [formError, setFormError] = useState('');
-  const countryOptions = useMemo(
-    () =>
-      countryList()
-        .getData()
-        .map((c: { label: string; value: string }) => ({ label: `${c.label} (${c.value})`, value: c.value })),
-    []
-  );
 
   useEffect(() => {
     if (user) {
-      if (user.role === 'brand') router.push('/brand/dashboard');
+      if (user.role === 'brand') router.push('/brand/profile?complete=1');
       else if (user.role === 'super-admin') router.push('/admin');
-      else router.push('/user/dashboard');
+      else router.push('/user/profile?complete=1');
     }
   }, [user, router]);
 
@@ -127,14 +90,8 @@ export default function UserSignup() {
     try {
       const data = await signup<{ token: string }>('/api/signup/user', {
         firstName: values.firstName,
-        lastName: values.lastName,
         email: values.email,
         password: values.password,
-        gender: values.gender,
-        phoneNumber: values.phone,
-        address: values.address,
-        city: values.city,
-        country: values.country,
       });
       router.push(`/confirm/${data.token}`);
     } catch (e) {
@@ -179,13 +136,6 @@ export default function UserSignup() {
           register={register}
           rules={{ required: 'First name is required' }}
           error={errors.firstName?.message as string}
-        />
-        <TextInput
-          name="lastName"
-          placeholder="Last Name"
-          register={register}
-          rules={{ required: 'Last name is required' }}
-          error={errors.lastName?.message as string}
         />
         <EmailInput
           name="email"
@@ -232,38 +182,6 @@ export default function UserSignup() {
             lowercase, number and special character
           </p>
         )}
-        <SelectDropdown
-          name="gender"
-          control={control}
-          options={[
-            { label: 'Male', value: 'male' },
-            { label: 'Female', value: 'female' },
-            { label: 'Other', value: 'other' },
-          ]}
-          placeholder="Select Gender"
-        />
-        <TextInput
-          name="phone"
-          placeholder="Phone Number"
-          register={register}
-        />
-        <TextInput
-          name="address"
-          placeholder="Address"
-          register={register}
-        />
-        <TextInput
-          name="city"
-          placeholder="City"
-          register={register}
-        />
-        <SelectDropdown
-          name="country"
-          control={control}
-          options={countryOptions}
-          placeholder="Country"
-          components={{ Option: CountryOption, SingleValue: CountrySingleValue }}
-        />
         <button className="btn btn-primary w-full" type="submit">
           Sign Up
         </button>

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
+import { useRouter } from 'next/router';
 import { AppContext } from '../../contexts/AppContext';
 import type { User } from '../../types/user';
 import Head from 'next/head';
@@ -7,7 +8,11 @@ import { getPageTitle } from '../../lib/pageTitle';
 
 export const UserProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
+  const router = useRouter();
+  const showComplete = router.query.complete === '1';
   type ProfileForm = {
+    lastName: string;
+    gender: string;
     phoneNumber: string;
     address: string;
     city: string;
@@ -20,6 +25,8 @@ export const UserProfile: React.FC = () => {
     formState: { errors },
   } = useForm<ProfileForm>({
     defaultValues: {
+      lastName: '',
+      gender: 'other',
       phoneNumber: '',
       address: '',
       city: '',
@@ -31,6 +38,8 @@ export const UserProfile: React.FC = () => {
   useEffect(() => {
     if (user) {
       reset({
+        lastName: user.lastName || '',
+        gender: user.gender || 'other',
         phoneNumber: user.phoneNumber || '',
         address: user.address || '',
         city: user.city || '',
@@ -60,8 +69,24 @@ export const UserProfile: React.FC = () => {
         <title>{getPageTitle('My Profile')}</title>
       </Head>
       <h1 className="text-2xl font-bold mb-4">My Profile</h1>
+      {showComplete && (
+        <div className="alert alert-info mb-2">Please complete your profile.</div>
+      )}
       {message && <div className="mb-2 text-green-600">{message}</div>}
       <form onSubmit={handleSubmit(submit)} className="space-y-2">
+        <input
+          className="input input-bordered w-full"
+          placeholder="Last Name"
+          {...register('lastName')}
+        />
+        <select
+          className="select select-bordered w-full"
+          {...register('gender')}
+        >
+          <option value="male">Male</option>
+          <option value="female">Female</option>
+          <option value="other">Other</option>
+        </select>
         <input
           className="input input-bordered w-full"
           placeholder="Phone Number"


### PR DESCRIPTION
## Summary
- reduce signup fields for users and brands
- update signup APIs accordingly
- redirect new logins to profile completion pages
- let users edit last name and gender in profile
- add completion banners to profile pages

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856babc7510832fb244d98a69ff1d32