### PR TITLE
Fix search log schema

### DIFF
--- a/pages/api/admin/search-analytics.ts
+++ b/pages/api/admin/search-analytics.ts
@@ -6,7 +6,7 @@ import { handleApiError } from '../../../lib/utils/handleApiError';
 
 interface SearchLog {
   query: string;
-  noResults?: boolean | null;
+  noResults: boolean;
 }
 
 async function handler(

--- a/prisma/migrations/20250621170000_add-noResults-field/migration.sql
+++ b/prisma/migrations/20250621170000_add-noResults-field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "SearchLog" ADD COLUMN     "noResults" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -118,6 +118,7 @@ model SearchLog {
   uuid      String    @unique @default(uuid())
   userId    Int?
   query     String
+  noResults Boolean   @default(false)
   createdAt DateTime  @default(now())
 
   user      User?     @relation(fields: [userId], references: [id], onDelete: SetNull)


### PR DESCRIPTION
## Summary
- add `noResults` to `SearchLog` model
- create SQL migration for `noResults`
- update search analytics API typings

## Testing
- `npm test` *(fails: 2 failed, 2 passed)*
- `npx prisma generate` *(fails: binaries download blocked)*
- `npx prisma migrate dev --name add-noResults-field` *(fails: binaries download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856e6bf866c832fafc3645dc9f56999