### PR TITLE
Fix Search API to filter by category

### DIFF
--- a/components/RecommendedProducts.tsx
+++ b/components/RecommendedProducts.tsx
@@ -18,7 +18,9 @@ const RecommendedProducts: React.FC<RecommendedProductsProps> = ({
 
   useEffect(() => {
     if (!category) return;
-    fetch(`/api/search?category=${encodeURIComponent(category)}&perPage=4`)
+    fetch(
+      `/api/search?filterByCategory=${encodeURIComponent(category)}&perPage=4`
+    )
       .then((res) => (res.ok ? (res.json() as Promise<SearchResults>) : null))
       .then((data) => {
         if (data && Array.isArray(data.results)) {

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -5,6 +5,7 @@ import { parseImages } from './utils/parseImages';
 import type { Category } from '../types/category';
 import type { Vendor } from '../types/vendor';
 import type { Prisma } from '@prisma/client';
+import client from './typesenseClient';
 
 type ProductWithRelations = Prisma.ProductGetPayload<{
   include: { category: true; vendor: true };
@@ -168,8 +169,39 @@ export function mapDbRowToProduct(row: ProductRow): Product {
   });
 }
 
+export async function indexProductsToTypesense(
+  products: Product[]
+): Promise<void> {
+  if (products.length === 0) return;
+  const documents = products.map((p) => ({
+    id: String(p.id),
+    title: p.title,
+    name: p.title,
+    slug: p.slug,
+    description: p.descriptionText || p.description || '',
+    price: p.minPrice,
+    category: p.category.name.trim().toLowerCase(),
+    brand: p.vendor.brandName.trim(),
+    sold_count: p.soldCount,
+  }));
+
+  try {
+    await client
+      .collections('products')
+      .documents()
+      .import(documents, { action: 'upsert' });
+    const cats = Array.from(new Set(documents.map((d) => d.category))).join(
+      ', '
+    );
+    console.log(`Indexed ${documents.length} products. Categories: ${cats}`);
+  } catch (err) {
+    console.error('Failed to index products to Typesense', err);
+  }
+}
+
 export async function loadAndIndexProducts(): Promise<{ products: Product[] }> {
   const products = await loadProductsData();
+  await indexProductsToTypesense(products);
   return { products };
 }
 

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -68,7 +68,10 @@ export default async function handler(
   }
 
   const q = getQueryParam(req.query.q) ?? '';
-  const category = getQueryParam(req.query.category);
+  const category =
+    getQueryParam(req.query.filterByCategory) ??
+    getQueryParam(req.query.category);
+  const normalizedCategory = category?.trim().toLowerCase();
   const brand = getQueryParam(req.query.brand);
   const minPrice = getQueryParam(req.query.minPrice);
   const maxPrice = getQueryParam(req.query.maxPrice);
@@ -89,7 +92,8 @@ export default async function handler(
   };
 
   const filters: string[] = [];
-  if (category && category !== 'All') filters.push(`category:=${category}`);
+  if (normalizedCategory && normalizedCategory !== 'all')
+    filters.push(`category:=${normalizedCategory}`);
   if (brand && brand !== 'All') filters.push(`brand:=${brand}`);
   if (minPrice) filters.push(`price:>=${minPrice}`);
   if (maxPrice) filters.push(`price:<=${maxPrice}`);
@@ -120,6 +124,19 @@ export default async function handler(
           categories.push(...facet.counts.map((c) => c.value));
         }
       }
+    }
+    if (
+      normalizedCategory &&
+      normalizedCategory !== 'all' &&
+      !categories.includes(normalizedCategory)
+    ) {
+      console.warn('Category filter not matched', normalizedCategory);
+    }
+    if (hits.length === 0) {
+      console.warn('No products found for search', {
+        q,
+        category: normalizedCategory,
+      });
     }
     const fallback = result.found === 0 ? await getBestSellingProducts(8) : [];
     try {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -80,14 +80,14 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
   }, [router.query.type]);
 
   useEffect(() => {
-    const catParam = router.query.category;
+    const catParam = router.query.filterByCategory;
     if (catParam) {
       const c = Array.isArray(catParam) ? catParam[0] : (catParam as string);
       setFilterByCategory(c);
     } else {
       setFilterByCategory('All');
     }
-  }, [router.query.category]);
+  }, [router.query.filterByCategory]);
 
   useEffect(() => {
     async function loadCats() {
@@ -147,7 +147,7 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       if (filterByVendor && filterByVendor !== 'All')
         params.append('brand', filterByVendor);
       if (filterByCategory && filterByCategory !== 'All')
-        params.append('category', filterByCategory);
+        params.append('filterByCategory', filterByCategory);
       if (filterByType && filterByType !== 'All')
         params.append('filterByType', filterByType);
       if (inStock) params.append('inStock', 'true');

--- a/scripts/seedProducts.ts
+++ b/scripts/seedProducts.ts
@@ -4,6 +4,7 @@ import csv from 'csv-parser';
 import bcrypt from 'bcryptjs';
 import { prisma } from '../lib/prisma';
 import { slugify } from '../lib/slugify';
+import { loadAndIndexProducts } from '../lib/products';
 
 interface CsvRow {
   TITLE?: string;
@@ -121,6 +122,14 @@ async function main() {
     stream.on('end', resolve);
     stream.on('error', reject);
   });
+
+  // Re-index products in Typesense after seeding
+  try {
+    const { products } = await loadAndIndexProducts();
+    console.log(`Re-indexed ${products.length} products`);
+  } catch (err) {
+    console.error('Failed to re-index products', err);
+  }
 
   await prisma.$disconnect();
 }


### PR DESCRIPTION
## Summary
- reindex products after seeding to Typesense
- index products with category information
- support `filterByCategory` in search API
- update home and recommended products to use `filterByCategory`
- add debug logging when searches return no results

## Testing
- `npx prettier --write lib/products.ts pages/api/search.ts pages/index.tsx components/RecommendedProducts.tsx scripts/seedProducts.ts`
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856e7f64af8832f935880e1a8bb179f