### PR TITLE
Implement Temu-style header categories dropdown

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,6 +13,14 @@ import ChevronDownIcon from './icons/ChevronDownIcon';
 import ElectronicsIcon from './icons/ElectronicsIcon';
 import FashionIcon from './icons/FashionIcon';
 import DEFAULT_CATEGORIES from '../lib/defaultCategories';
+
+const DEFAULT_CATEGORY_TREE: Record<string, string[]> = {
+  Electronics: ['Phones', 'Computers', 'Cameras'],
+  Fashion: ['Men', 'Women', 'Accessories'],
+  Home: ['Furniture', 'Decor', 'Kitchen'],
+  Toys: ['Puzzles', 'Action Figures', 'Dolls'],
+  Sports: ['Outdoor', 'Indoor', 'Fitness'],
+};
 import type { Category } from '../types/category';
 import type { Product } from '../types/product';
 import type { User } from '../types/user';
@@ -29,8 +37,15 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
   const cart = appContext?.cart ?? [];
   const user = session?.user as User | undefined;
   const pathname = router.pathname;
-  const isAuthRoute = ['/login', '/signup', '/user/signup', '/brand/signup'].includes(pathname);
+  const isAuthRoute = [
+    '/login',
+    '/signup',
+    '/user/signup',
+    '/brand/signup',
+  ].includes(pathname);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [activeParent, setActiveParent] = useState<string>('');
   const [categories, setCategories] = useState<Category[]>([]);
   const [search, setSearch] = useState('');
   const searchRef = useRef<HTMLFormElement>(null);
@@ -38,9 +53,20 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
   useEffect(() => {
     fetch('/api/categories')
       .then((res) => res.json())
-      .then((data) => setCategories(data.categories || DEFAULT_CATEGORIES))
-      .catch(() => setCategories(DEFAULT_CATEGORIES));
-  }, []);
+      .then((data) => {
+        const list = data.categories || DEFAULT_CATEGORIES;
+        setCategories(list);
+        if (list.length > 0 && !activeParent) {
+          setActiveParent(list[0].name);
+        }
+      })
+      .catch(() => {
+        setCategories(DEFAULT_CATEGORIES);
+        if (!activeParent && DEFAULT_CATEGORIES.length > 0) {
+          setActiveParent(DEFAULT_CATEGORIES[0].name);
+        }
+      });
+  }, [activeParent]);
 
   const itemCount = cart.reduce((sum, item) => sum + (item.qty || 0), 0);
   const logout = () => signOut({ redirect: false });
@@ -59,33 +85,95 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
   return (
     <header className="relative bg-base-300 mb-6">
       <div className="w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-4 gap-y-2">
-        <Link href="/" className="btn btn-ghost text-xl">Home</Link>
+        <Link href="/" className="btn btn-ghost text-xl">
+          Home
+        </Link>
 
-        <div className="flex-1 flex items-center gap-x-4" onMouseLeave={() => setMenuOpen(false)}>
-          <ul className="menu menu-horizontal hidden md:flex">
-            <li>
+        <div className="flex-1 flex items-center gap-x-4">
+          <button
+            type="button"
+            className="md:hidden btn btn-ghost"
+            onClick={() => setMobileMenuOpen((p) => !p)}
+          >
+            <MenuIcon className="w-5 h-5" />
+          </button>
+
+          <ul
+            className="menu menu-horizontal hidden md:flex"
+            onMouseEnter={() => setMenuOpen(true)}
+            onMouseLeave={() => setMenuOpen(false)}
+          >
+            <li className="relative">
               <button
                 type="button"
                 className="flex items-center gap-1"
-                onMouseEnter={() => setMenuOpen(true)}
                 onClick={() => setMenuOpen((prev) => !prev)}
               >
-                Categories <ChevronDownIcon className="w-4 h-4" />
+                Categories
+                <ChevronDownIcon
+                  className={`w-4 h-4 transition-transform ${menuOpen ? 'rotate-180' : ''}`}
+                />
               </button>
-              {menuOpen && (
-                <div id="mega-menu" className="absolute left-0 top-full mt-1 z-50 p-4 bg-base-100 shadow-lg rounded w-screen max-w-3xl">
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              <div
+                id="mega-menu"
+                className={`absolute left-0 top-full mt-1 z-50 bg-base-100 shadow-xl rounded w-screen max-w-3xl transition-opacity duration-200 ease-in-out ${menuOpen ? 'opacity-100 visible' : 'opacity-0 invisible'}`}
+                onMouseEnter={() => setMenuOpen(true)}
+                onMouseLeave={() => setMenuOpen(false)}
+              >
+                <div className="flex gap-4 px-4 py-4">
+                  <ul className="w-1/3 space-y-1">
                     {categories.map((cat) => (
-                      <Link key={cat.name} href={`/categories/${encodeURIComponent(cat.name)}`} className="flex items-center gap-1 hover:text-primary">
-                        {iconMap[cat.name] || null}
-                        {cat.name}
-                      </Link>
+                      <li key={cat.name}>
+                        <button
+                          type="button"
+                          className={`flex items-center gap-1 w-full text-left px-2 py-1 hover:bg-base-200 ${activeParent === cat.name ? 'bg-base-200 font-medium' : ''}`}
+                          onMouseEnter={() => setActiveParent(cat.name)}
+                        >
+                          {iconMap[cat.name] || null}
+                          {cat.name}
+                        </button>
+                      </li>
                     ))}
-                  </div>
+                  </ul>
+                  <ul className="flex-1 grid grid-cols-2 gap-2">
+                    {(DEFAULT_CATEGORY_TREE[activeParent] || []).map((sub) => (
+                      <li key={sub}>
+                        <Link href="#" className="hover:text-primary">
+                          {sub}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
                 </div>
-              )}
+              </div>
             </li>
           </ul>
+
+          {mobileMenuOpen && (
+            <div className="absolute left-0 top-full mt-1 z-50 w-full bg-base-100 shadow-xl md:hidden">
+              <ul className="menu menu-vertical p-4 gap-1">
+                {categories.map((cat) => (
+                  <li key={cat.name}>
+                    <details>
+                      <summary className="flex items-center gap-1">
+                        {iconMap[cat.name] || null}
+                        {cat.name}
+                      </summary>
+                      <ul className="pl-4">
+                        {(DEFAULT_CATEGORY_TREE[cat.name] || []).map((sub) => (
+                          <li key={sub}>
+                            <Link href="#" className="hover:text-primary">
+                              {sub}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </details>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           {!isAuthRoute && (
             <form
@@ -127,13 +215,19 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
           {user ? (
             <>
               <span>Hello, {user.firstName || user.email}</span>
-              <button onClick={logout} className="btn btn-outline">Logout</button>
+              <button onClick={logout} className="btn btn-outline">
+                Logout
+              </button>
             </>
           ) : (
             !isAuthRoute && (
               <>
-                <Link href="/login" className="btn btn-ghost">Login</Link>
-                <Link href="/signup" className="btn btn-primary">Signup</Link>
+                <Link href="/login" className="btn btn-ghost">
+                  Login
+                </Link>
+                <Link href="/signup" className="btn btn-primary">
+                  Signup
+                </Link>
               </>
             )
           )}


### PR DESCRIPTION
## Summary
- add default category tree constants
- manage category hover state with icon rotation
- show subcategories on hover
- add mobile hamburger dropdown

## Testing
- `npx prettier --write components/Header.tsx`
- `npm test` *(fails: TestingLibraryElementError and act warnings)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6856e9e531f4832fb369edf4ff9f22fb