### PR TITLE
Fix product image placeholders and add pagination

### DIFF
--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,0 +1,50 @@
+import type { FC } from 'react';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+const Pagination: FC<PaginationProps> = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}) => {
+  if (totalPages <= 1) return null;
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+  return (
+    <div className="flex justify-center my-4">
+      <div className="join">
+        <button
+          type="button"
+          className="btn btn-sm join-item"
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage === 1}
+        >
+          Prev
+        </button>
+        {pages.map((p) => (
+          <button
+            key={p}
+            type="button"
+            className={`btn btn-sm join-item ${p === currentPage ? 'btn-active' : ''}`}
+            onClick={() => onPageChange(p)}
+          >
+            {p}
+          </button>
+        ))}
+        <button
+          type="button"
+          className="btn btn-sm join-item"
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage === totalPages}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/components/ProductImageSlider.tsx
+++ b/components/ProductImageSlider.tsx
@@ -16,14 +16,14 @@ export default function ProductImageSlider({
   placeholderSeed = 1,
 }: ProductImageSliderProps) {
   const [idx, setIdx] = useState(0);
-  const urls = images.map((img) =>
-    typeof img === 'string' ? img : img.url
-  );
+  const urls = images.map((img) => (typeof img === 'string' ? img : img.url));
+  const placeholderUrl = `https://picsum.photos/seed/${placeholderSeed}/400/400`;
+  const [errorMap, setErrorMap] = useState<Record<number, boolean>>({});
   if (!urls || urls.length === 0) {
     return (
       <div className={`relative aspect-[4/5] ${className}`}>
         <Image
-          src={`https://source.unsplash.com/400x400/?product&sig=${placeholderSeed}`}
+          src={placeholderUrl}
           alt="Placeholder product"
           fill
           className={`object-cover ${imgClass}`}
@@ -36,10 +36,11 @@ export default function ProductImageSlider({
   return (
     <div className={`relative aspect-[4/5] ${className}`}>
       <Image
-        src={images[idx].url}
+        src={errorMap[idx] ? placeholderUrl : images[idx].url}
         alt={images[idx].alt || `Image ${idx + 1}`}
         fill
         className={`object-cover ${imgClass}`}
+        onError={() => setErrorMap((m) => ({ ...m, [idx]: true }))}
       />
       {urls.length > 1 && (
         <>

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['cdn.shopify.com', 'images.unsplash.com', 'source.unsplash.com'],
+    domains: [
+      'cdn.shopify.com',
+      'images.unsplash.com',
+      'source.unsplash.com',
+      'picsum.photos',
+    ],
   },
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import Head from 'next/head';
 import { getPageTitle } from '../lib/pageTitle';
 import HeroSlider from '../components/HeroSlider';
 import ProductCard from '../components/ProductCard';
+import Pagination from '../components/Pagination';
 import DEFAULT_CATEGORIES from '../lib/defaultCategories';
 import { Product } from '../types/product';
 
@@ -298,20 +299,27 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       ) : products.length === 0 ? (
         <p className="text-gray-500">No products found</p>
       ) : (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 w-full">
-          {products.map((p) => (
-            <ProductCard
-              key={p.id}
-              product={p}
-              highlightTitle={
-                p.highlights?.find((h) => h.field === 'title')?.snippet
-              }
-              highlightDescription={
-                p.highlights?.find((h) => h.field === 'description')?.snippet
-              }
-            />
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 w-full">
+            {products.map((p) => (
+              <ProductCard
+                key={p.id}
+                product={p}
+                highlightTitle={
+                  p.highlights?.find((h) => h.field === 'title')?.snippet
+                }
+                highlightDescription={
+                  p.highlights?.find((h) => h.field === 'description')?.snippet
+                }
+              />
+            ))}
+          </div>
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </>
       )}
     </div>
   );

--- a/pages/products.tsx
+++ b/pages/products.tsx
@@ -4,6 +4,7 @@ import type { Product } from '../types/product';
 import ProductCard from '../components/ProductCard';
 import Head from 'next/head';
 import { getPageTitle } from '../lib/pageTitle';
+import Pagination from '../components/Pagination';
 
 const Products: React.FC = () => {
   const { addToCart } = useContext(AppContext)!;
@@ -15,6 +16,9 @@ const Products: React.FC = () => {
   const [maxPrice, setMaxPrice] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
   const [filtersOpen, setFiltersOpen] = useState<boolean>(false);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [totalPages, setTotalPages] = useState<number>(1);
+  const pageSize = 20;
 
   useEffect(() => {
     async function loadCats() {
@@ -39,10 +43,13 @@ const Products: React.FC = () => {
       if (category && category !== 'All') params.append('category', category);
       if (minPrice) params.append('minPrice', minPrice);
       if (maxPrice) params.append('maxPrice', maxPrice);
+      params.append('page', String(currentPage));
+      params.append('perPage', String(pageSize));
       const res = await fetch(`/api/search?${params.toString()}`);
       if (res.ok) {
         const data = await res.json();
         setProducts(data.results as Product[]);
+        setTotalPages(data.totalPages || 1);
       } else {
         setProducts([]);
       }
@@ -56,10 +63,17 @@ const Products: React.FC = () => {
   useEffect(() => {
     fetchProducts();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [currentPage]);
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage > 0 && newPage <= totalPages) {
+      setCurrentPage(newPage);
+    }
+  };
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setCurrentPage(1);
     fetchProducts();
   };
 
@@ -143,11 +157,18 @@ const Products: React.FC = () => {
         ) : products.length === 0 ? (
           <p>No products found.</p>
         ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 sm:gap-6">
-            {products.map((p) => (
-              <ProductCard key={p.id} product={p} />
-            ))}
-          </div>
+          <>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 sm:gap-6">
+              {products.map((p) => (
+                <ProductCard key={p.id} product={p} />
+              ))}
+            </div>
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace broken Unsplash placeholders with picsum
- allow picsum domain for next/image
- add Pagination component
- show pagination on homepage and products listing
- update product list API calls for page params

## Testing
- `npm test` *(fails: shows 4 failing tests)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6856ef92f154832f9715859adf2bb722