### PR TITLE
Implement infinite scroll for products

### DIFF
--- a/lib/products.ts
+++ b/lib/products.ts
@@ -329,6 +329,75 @@ export async function getProductsByCategorySlug(
   );
 }
 
+export async function getProductsByCategorySlugPaginated(
+  slug: string,
+  limit: number,
+  offset = 0
+): Promise<Product[]> {
+  const db = getDb();
+  const rows: ProductWithRelations[] = await db.product.findMany({
+    where: { status: 'approved', category: { slug } },
+    include: { category: true, vendor: true },
+    take: limit,
+    skip: offset,
+    orderBy: { id: 'asc' },
+  });
+  return rows.map((row) =>
+    processProductRow({
+      id: row.id,
+      uuid: row.uuid,
+      slug: row.slug,
+      sku: row.sku,
+      title: row.title,
+      vendor: row.vendor ?? null,
+      description: row.description,
+      productType: row.productType,
+      tags: row.tags,
+      category: row.category ?? null,
+      images: parseImages(row.images),
+      totalInventory: row.quantity,
+      priceRange: {
+        minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
+        maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
+      },
+    })
+  );
+}
+
+export async function getApprovedProductsPaginated(
+  limit: number,
+  offset = 0
+): Promise<Product[]> {
+  const db = getDb();
+  const rows: ProductWithRelations[] = await db.product.findMany({
+    where: { status: 'approved' },
+    include: { category: true, vendor: true },
+    take: limit,
+    skip: offset,
+    orderBy: { id: 'asc' },
+  });
+  return rows.map((row) =>
+    processProductRow({
+      id: row.id,
+      uuid: row.uuid,
+      slug: row.slug,
+      sku: row.sku,
+      title: row.title,
+      vendor: row.vendor ?? null,
+      description: row.description,
+      productType: row.productType,
+      tags: row.tags,
+      category: row.category ?? null,
+      images: parseImages(row.images),
+      totalInventory: row.quantity,
+      priceRange: {
+        minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
+        maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
+      },
+    })
+  );
+}
+
 export async function getCategoryBySlug(
   slug: string
 ): Promise<Category | null> {

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -1,5 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getProductsByCategorySlug } from '../../../lib/products';
+import {
+  getProductsByCategorySlugPaginated,
+  getApprovedProductsPaginated,
+} from '../../../lib/products';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { Product } from '../../../types/product';
@@ -7,6 +10,8 @@ import type { ApiMessage } from '../../../types';
 
 export interface ProductsQuery {
   categorySlug?: string | string[];
+  limit?: string | string[];
+  offset?: string | string[];
 }
 
 export interface ProductsResponse {
@@ -21,8 +26,12 @@ export default async function handler(
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
   const slug = getQueryParam(req.query.categorySlug);
+  const limit = parseInt(getQueryParam(req.query.limit) ?? '20', 10);
+  const offset = parseInt(getQueryParam(req.query.offset) ?? '0', 10);
   try {
-    const products = slug ? await getProductsByCategorySlug(slug) : [];
+    const products = slug
+      ? await getProductsByCategorySlugPaginated(slug, limit, offset)
+      : await getApprovedProductsPaginated(limit, offset);
     return res.status(200).json({ products });
   } catch (error) {
     return handleApiError(res, error, 'Failed to load products');

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -1,0 +1,75 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import Head from 'next/head';
+import ProductCard from '../../components/ProductCard';
+import { getPageTitle } from '../../lib/pageTitle';
+import type { Product } from '../../types/product';
+
+const LIMIT = 24;
+
+export default function ProductsList() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const offsetRef = useRef(0);
+
+  const fetchMore = useCallback(async () => {
+    if (loading || !hasMore) return;
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/products?limit=${LIMIT}&offset=${offsetRef.current}`
+      );
+      if (res.ok) {
+        const data = await res.json();
+        const newProducts = (data.products as Product[]) || [];
+        setProducts((prev) => [...prev, ...newProducts]);
+        offsetRef.current += newProducts.length;
+        if (newProducts.length < LIMIT) setHasMore(false);
+      } else {
+        setHasMore(false);
+      }
+    } catch {
+      setHasMore(false);
+    } finally {
+      setLoading(false);
+    }
+  }, [loading, hasMore]);
+
+  useEffect(() => {
+    fetchMore();
+  }, [fetchMore]);
+
+  useEffect(() => {
+    if (!loadMoreRef.current) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        fetchMore();
+      }
+    });
+    observer.observe(loadMoreRef.current);
+    return () => observer.disconnect();
+  }, [fetchMore]);
+
+  return (
+    <div className="min-h-screen bg-base-200 py-10">
+      <Head>
+        <title>{getPageTitle('Products')}</title>
+      </Head>
+      <div className="max-w-screen-xl mx-auto px-4">
+        <h1 className="text-3xl font-bold mb-4">Products</h1>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {products.map((p) => (
+            <ProductCard key={p.id} product={p} />
+          ))}
+        </div>
+        {loading && (
+          <div className="flex justify-center my-4">
+            <span className="loading loading-spinner"></span>
+          </div>
+        )}
+        {hasMore && <div ref={loadMoreRef} className="h-1" />}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow `/api/products` to paginate results
- expose helper to fetch approved products by page
- build a new `pages/products/index.tsx` with infinite scroll

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f17c7684832f99d9cd46fe892c6a