### PR TITLE
Enhance Pagination and Layout

### DIFF
--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -12,7 +12,12 @@ const Pagination: FC<PaginationProps> = ({
   onPageChange,
 }) => {
   if (totalPages <= 1) return null;
-  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+  let start = Math.max(1, currentPage - 2);
+  let end = Math.min(totalPages, start + 3);
+  if (end - start < 3) {
+    start = Math.max(1, end - 3);
+  }
+  const pages = Array.from({ length: end - start + 1 }, (_, i) => start + i);
   return (
     <div className="flex justify-center my-4">
       <div className="join">
@@ -22,7 +27,7 @@ const Pagination: FC<PaginationProps> = ({
           onClick={() => onPageChange(currentPage - 1)}
           disabled={currentPage === 1}
         >
-          Prev
+          Previous
         </button>
         {pages.map((p) => (
           <button

--- a/pages/categories/[slug]/products.tsx
+++ b/pages/categories/[slug]/products.tsx
@@ -154,7 +154,7 @@ export default function CategoryProductsPage({
               No products found.
             </div>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
               {filtered.map((p) => (
                 <ProductCard key={p.id} product={p} />
               ))}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -61,6 +61,16 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
   const abortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
+    const pageParam = router.query.page;
+    if (pageParam) {
+      const p = Array.isArray(pageParam) ? parseInt(pageParam[0], 10) : parseInt(pageParam as string, 10);
+      setCurrentPage(isNaN(p) ? 1 : p);
+    } else {
+      setCurrentPage(1);
+    }
+  }, [router.query.page]);
+
+  useEffect(() => {
     const qParam = router.query.q;
     if (qParam) {
       const q = Array.isArray(qParam) ? qParam[0] : (qParam as string);
@@ -217,13 +227,18 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
   const handlePageChange = (newPage: number) => {
     if (newPage > 0 && newPage <= totalPages) {
       setCurrentPage(newPage);
+      const query = { ...router.query, page: String(newPage) } as Record<string, string>;
+      router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+      if (typeof window !== 'undefined') {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
     }
   };
 
   const handleTypeClick = (type: string) => {
     setFilterByType(type);
     setCurrentPage(1);
-    const query = { ...router.query };
+    const query = { ...router.query, page: '1' } as Record<string, string>;
     if (type && type !== 'All') {
       query.type = type;
     } else {
@@ -235,6 +250,8 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
   const handleSearch = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setCurrentPage(1);
+    const query = { ...router.query, page: '1' } as Record<string, string>;
+    router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
     fetchProducts();
   };
 
@@ -245,6 +262,7 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       clear: () => {
         setFilterByVendor('All');
         setCurrentPage(1);
+        router.push({ pathname: router.pathname, query: { ...router.query, page: '1' } }, undefined, { shallow: true });
       },
     });
   if (filterByType !== 'All')
@@ -258,6 +276,7 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       clear: () => {
         setFilterByCategory('All');
         setCurrentPage(1);
+        router.push({ pathname: router.pathname, query: { ...router.query, page: '1' } }, undefined, { shallow: true });
       },
     });
   if (inStock)
@@ -266,6 +285,7 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       clear: () => {
         setInStock(false);
         setCurrentPage(1);
+        router.push({ pathname: router.pathname, query: { ...router.query, page: '1' } }, undefined, { shallow: true });
       },
     });
   if (minPrice)
@@ -274,6 +294,7 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       clear: () => {
         setMinPrice('');
         setCurrentPage(1);
+        router.push({ pathname: router.pathname, query: { ...router.query, page: '1' } }, undefined, { shallow: true });
       },
     });
   if (maxPrice)
@@ -282,6 +303,7 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       clear: () => {
         setMaxPrice('');
         setCurrentPage(1);
+        router.push({ pathname: router.pathname, query: { ...router.query, page: '1' } }, undefined, { shallow: true });
       },
     });
 
@@ -300,7 +322,7 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
         <p className="text-gray-500">No products found</p>
       ) : (
         <>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 w-full">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 w-full">
             {products.map((p) => (
               <ProductCard
                 key={p.id}


### PR DESCRIPTION
## Summary
- paginate only four numbers at a time with Prev/Next buttons
- sync home page pagination with `page` query parameter and scroll to top
- adjust product grids to five columns for better spacing

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f2a22f88832fb1f64ba29fdc1c53