### PR TITLE
Implement pagination & in‑stock filter

### DIFF
--- a/lib/products.ts
+++ b/lib/products.ts
@@ -398,6 +398,74 @@ export async function getApprovedProductsPaginated(
   );
 }
 
+export interface PaginatedOptions {
+  limit: number;
+  offset: number;
+  categorySlug?: string;
+  search?: string;
+  inStock?: boolean;
+}
+
+export interface PaginatedResult {
+  products: Product[];
+  total: number;
+}
+
+export async function getProductsPaginated(
+  options: PaginatedOptions
+): Promise<PaginatedResult> {
+  const db = getDb();
+  const where: Prisma.ProductWhereInput = { status: 'approved' };
+  if (options.categorySlug) {
+    where.category = { slug: options.categorySlug };
+  }
+  if (options.inStock) {
+    where.quantity = { gt: 0 };
+  }
+  if (options.search) {
+    const term = options.search.trim();
+    if (term) {
+      where.OR = [
+        { title: { contains: term, mode: 'insensitive' } },
+        { description: { contains: term, mode: 'insensitive' } },
+      ];
+    }
+  }
+  const [total, rows] = await Promise.all([
+    db.product.count({ where }),
+    db.product.findMany({
+      where,
+      include: { category: true, vendor: true },
+      take: options.limit,
+      skip: options.offset,
+      orderBy: { id: 'asc' },
+    }),
+  ]);
+  return {
+    total,
+    products: rows.map((row) =>
+      processProductRow({
+        id: row.id,
+        uuid: row.uuid,
+        slug: row.slug,
+        sku: row.sku,
+        title: row.title,
+        vendor: row.vendor ?? null,
+        description: row.description,
+        productType: row.productType,
+        tags: row.tags,
+        category: row.category ?? null,
+        images: parseImages(row.images),
+        totalInventory: row.quantity,
+        priceRange: {
+          minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
+          maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
+        },
+      })
+    ),
+  };
+}
+
 export async function getCategoryBySlug(
   slug: string
 ): Promise<Category | null> {

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -1,21 +1,23 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import {
-  getProductsByCategorySlugPaginated,
-  getApprovedProductsPaginated,
-} from '../../../lib/products';
+import { getProductsPaginated } from '../../../lib/products';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { Product } from '../../../types/product';
 import type { ApiMessage } from '../../../types';
 
 export interface ProductsQuery {
+  category?: string | string[];
   categorySlug?: string | string[];
+  q?: string | string[];
+  inStock?: string | string[];
+  page?: string | string[];
   limit?: string | string[];
   offset?: string | string[];
 }
 
 export interface ProductsResponse {
   products: Product[];
+  total: number;
 }
 
 export default async function handler(
@@ -25,14 +27,22 @@ export default async function handler(
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
-  const slug = getQueryParam(req.query.categorySlug);
+  const slug =
+    getQueryParam(req.query.category) || getQueryParam(req.query.categorySlug);
   const limit = parseInt(getQueryParam(req.query.limit) ?? '20', 10);
-  const offset = parseInt(getQueryParam(req.query.offset) ?? '0', 10);
+  const page = parseInt(getQueryParam(req.query.page) ?? '1', 10);
+  const offset = parseInt(getQueryParam(req.query.offset) ?? String((page - 1) * limit), 10);
+  const q = getQueryParam(req.query.q);
+  const inStock = getQueryParam(req.query.inStock) === 'true';
   try {
-    const products = slug
-      ? await getProductsByCategorySlugPaginated(slug, limit, offset)
-      : await getApprovedProductsPaginated(limit, offset);
-    return res.status(200).json({ products });
+    const result = await getProductsPaginated({
+      limit,
+      offset,
+      categorySlug: slug || undefined,
+      search: q || undefined,
+      inStock,
+    });
+    return res.status(200).json({ products: result.products, total: result.total });
   } catch (error) {
     return handleApiError(res, error, 'Failed to load products');
   }

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -1,55 +1,63 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { GetServerSideProps } from 'next';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useCallback } from 'react';
+import Pagination from '../../components/Pagination';
 import ProductCard from '../../components/ProductCard';
 import { getPageTitle } from '../../lib/pageTitle';
+import { getProductsPaginated, PaginatedResult } from '../../lib/products';
 import type { Product } from '../../types/product';
 
-const LIMIT = 24;
+interface ProductsProps {
+  products: Product[];
+  total: number;
+}
 
-export default function ProductsList() {
-  const [products, setProducts] = useState<Product[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-  const loadMoreRef = useRef<HTMLDivElement | null>(null);
-  const offsetRef = useRef(0);
+export const getServerSideProps: GetServerSideProps<ProductsProps> = async (
+  context
+) => {
+  const page = parseInt((context.query.page as string) || '1', 10);
+  const inStock = context.query.inStock === 'true';
+  const category = context.query.category as string | undefined;
+  const q = context.query.q as string | undefined;
 
-  const fetchMore = useCallback(async () => {
-    if (loading || !hasMore) return;
-    setLoading(true);
-    try {
-      const res = await fetch(
-        `/api/products?limit=${LIMIT}&offset=${offsetRef.current}`
-      );
-      if (res.ok) {
-        const data = await res.json();
-        const newProducts = (data.products as Product[]) || [];
-        setProducts((prev) => [...prev, ...newProducts]);
-        offsetRef.current += newProducts.length;
-        if (newProducts.length < LIMIT) setHasMore(false);
-      } else {
-        setHasMore(false);
-      }
-    } catch {
-      setHasMore(false);
-    } finally {
-      setLoading(false);
-    }
-  }, [loading, hasMore]);
+  const limit = 20;
+  const offset = (page - 1) * limit;
+  const result: PaginatedResult = await getProductsPaginated({
+    limit,
+    offset,
+    categorySlug: category,
+    search: q,
+    inStock,
+  });
 
-  useEffect(() => {
-    fetchMore();
-  }, [fetchMore]);
+  return { props: { products: result.products, total: result.total } };
+};
 
-  useEffect(() => {
-    if (!loadMoreRef.current) return;
-    const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting) {
-        fetchMore();
-      }
-    });
-    observer.observe(loadMoreRef.current);
-    return () => observer.disconnect();
-  }, [fetchMore]);
+export default function ProductsPage({ products, total }: ProductsProps) {
+  const router = useRouter();
+  const pageParam = Array.isArray(router.query.page)
+    ? router.query.page[0]
+    : router.query.page;
+  const currentPage = pageParam ? parseInt(pageParam, 10) : 1;
+  const inStock = router.query.inStock === 'true';
+  const totalPages = Math.ceil(total / 20);
+
+  const handlePageChange = useCallback(
+    (p: number) => {
+      const query = { ...router.query, page: String(p) } as Record<string, string>;
+      router.push({ pathname: router.pathname, query });
+    },
+    [router]
+  );
+
+  const toggleInStock = useCallback(() => {
+    const query = { ...router.query } as Record<string, string>;
+    if (inStock) delete query.inStock;
+    else query.inStock = 'true';
+    query.page = '1';
+    router.push({ pathname: router.pathname, query });
+  }, [router, inStock]);
 
   return (
     <div className="min-h-screen bg-base-200 py-10">
@@ -58,17 +66,31 @@ export default function ProductsList() {
       </Head>
       <div className="max-w-screen-xl mx-auto px-4">
         <h1 className="text-3xl font-bold mb-4">Products</h1>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {products.map((p) => (
-            <ProductCard key={p.id} product={p} />
-          ))}
-        </div>
-        {loading && (
-          <div className="flex justify-center my-4">
-            <span className="loading loading-spinner"></span>
+        <label className="flex items-center gap-2 mb-4">
+          <input
+            type="checkbox"
+            className="checkbox"
+            checked={inStock}
+            onChange={toggleInStock}
+          />
+          <span>In Stock Only</span>
+        </label>
+        {products.length === 0 ? (
+          <p className="text-gray-500">No products found.</p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+            {products.map((p) => (
+              <ProductCard key={p.id} product={p} />
+            ))}
           </div>
         )}
-        {hasMore && <div ref={loadMoreRef} className="h-1" />}
+        {totalPages > 1 && (
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- paginate products with new `getProductsPaginated` helper
- update products API to support pagination and in-stock filter
- rework `/products` page with server-side pagination

## Testing
- `npm test` *(fails: 4 failed, 6 passed)*
- `npm run lint`
- `npm run type-check` *(fails: Prisma types missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856f60c8bf8832facfcb09382dfde3f