### PR TITLE
Fix getServerSideProps Serialization Error (Date to String)

### DIFF
--- a/lib/utils/serializeDates.ts
+++ b/lib/utils/serializeDates.ts
@@ -1,0 +1,16 @@
+export function serializeDates<T>(data: T): T {
+  if (data instanceof Date) {
+    return data.toISOString() as unknown as T;
+  }
+  if (Array.isArray(data)) {
+    return data.map((item) => serializeDates(item)) as unknown as T;
+  }
+  if (data && typeof data === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+      result[key] = serializeDates(value as unknown as T);
+    }
+    return result as T;
+  }
+  return data;
+}

--- a/pages/categories/[slug]/products.tsx
+++ b/pages/categories/[slug]/products.tsx
@@ -9,6 +9,7 @@ import {
   getCategoryBySlug,
   getProductsByCategorySlug,
 } from '../../../lib/products';
+import { serializeDates } from '../../../lib/utils/serializeDates';
 
 interface CategoryProductsProps {
   products: Product[];
@@ -30,7 +31,12 @@ export const getServerSideProps: GetServerSideProps<
   if (!category) {
     return { notFound: true };
   }
-  return { props: { products, category } };
+  return {
+    props: {
+      products: serializeDates(products),
+      category: serializeDates(category),
+    },
+  };
 };
 
 export default function CategoryProductsPage({

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -15,6 +15,7 @@ import {
 import { mapDbRowToProduct } from '../../lib/products';
 import { Product, Review } from '../../types';
 import { SelectDropdown, Textarea } from '../../components/form-fields';
+import { serializeDates } from '../../lib/utils/serializeDates';
 
 type ProductDetailProps = {
   product: Product;
@@ -40,7 +41,7 @@ export const getServerSideProps: GetServerSideProps<
   const stats = await getAverageRating(String(row.id));
   return {
     props: {
-      product,
+      product: serializeDates(product),
       initialReviews: reviews,
       initialAverage: stats.average,
       initialCount: stats.count,

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -7,6 +7,7 @@ import ProductCard from '../../components/ProductCard';
 import { getPageTitle } from '../../lib/pageTitle';
 import { getProductsPaginated, PaginatedResult } from '../../lib/products';
 import type { Product } from '../../types/product';
+import { serializeDates } from '../../lib/utils/serializeDates';
 
 interface ProductsProps {
   products: Product[];
@@ -31,7 +32,8 @@ export const getServerSideProps: GetServerSideProps<ProductsProps> = async (
     inStock,
   });
 
-  return { props: { products: result.products, total: result.total } };
+  const products = serializeDates(result.products);
+  return { props: { products, total: result.total } };
 };
 
 export default function ProductsPage({ products, total }: ProductsProps) {


### PR DESCRIPTION
## Summary
- add utility to recursively serialize `Date` objects
- ensure `/products`, category products, and single product pages return JSON-safe data

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6856f7e20684832fbc4349d5ea5a56cc