### PR TITLE
Add infinite scroll for products page

### DIFF
--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -1,8 +1,7 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useCallback } from 'react';
-import Pagination from '../../components/Pagination';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import ProductCard from '../../components/ProductCard';
 import { getPageTitle } from '../../lib/pageTitle';
 import { getProductsPaginated, PaginatedResult } from '../../lib/products';
@@ -45,13 +44,67 @@ export default function ProductsPage({ products, total }: ProductsProps) {
   const inStock = router.query.inStock === 'true';
   const totalPages = Math.ceil(total / 20);
 
-  const handlePageChange = useCallback(
-    (p: number) => {
-      const query = { ...router.query, page: String(p) } as Record<string, string>;
-      router.push({ pathname: router.pathname, query });
-    },
-    [router]
-  );
+  const [items, setItems] = useState<Product[]>(products);
+  const [page, setPage] = useState<number>(currentPage);
+  const [loadingMore, setLoadingMore] = useState<boolean>(false);
+  const [hasMore, setHasMore] = useState<boolean>(currentPage < totalPages);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !hasMore) return;
+    const nextPage = page + 1;
+    setLoadingMore(true);
+    try {
+      const params = new URLSearchParams({
+        ...Object.fromEntries(
+          Object.entries(router.query).map(([k, v]) => [
+            k,
+            Array.isArray(v) ? v[0] : v,
+          ])
+        ),
+        page: String(nextPage),
+        limit: '20',
+      });
+      const res = await fetch(`/api/products?${params.toString()}`);
+      if (res.ok) {
+        const data = (await res.json()) as PaginatedResult;
+        setItems((prev) => [...prev, ...data.products]);
+        setPage(nextPage);
+        router.replace(
+          {
+            pathname: router.pathname,
+            query: { ...router.query, page: String(nextPage) },
+          },
+          undefined,
+          { shallow: true }
+        );
+        if (nextPage >= Math.ceil(data.total / 20)) {
+          setHasMore(false);
+        }
+      } else {
+        console.error('Failed to load products', await res.text());
+        setHasMore(false);
+      }
+    } catch (err) {
+      console.error('Failed to load products', err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [loadingMore, hasMore, page, router]);
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (entry.isIntersecting) {
+        loadMore();
+      }
+    });
+    observer.observe(sentinelRef.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [loadMore]);
 
   const toggleInStock = useCallback(() => {
     const query = { ...router.query } as Record<string, string>;
@@ -77,22 +130,24 @@ export default function ProductsPage({ products, total }: ProductsProps) {
           />
           <span>In Stock Only</span>
         </label>
-        {products.length === 0 ? (
+        {items.length === 0 ? (
           <p className="text-gray-500">No products found.</p>
         ) : (
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-            {products.map((p) => (
+            {items.map((p) => (
               <ProductCard key={p.id} product={p} />
             ))}
           </div>
         )}
-        {totalPages > 1 && (
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            onPageChange={handlePageChange}
-          />
-        )}
+        <div
+          ref={sentinelRef}
+          className="h-10 mt-4 flex justify-center items-center"
+        >
+          {loadingMore && <span className="loading loading-spinner" />}
+          {!hasMore && page >= totalPages && items.length > 0 && (
+            <span className="text-sm text-gray-500">No more products</span>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add infinite scrolling to `/products`
- load more products as sentinel enters viewport
- keep the current page in the URL for back navigation
- show a spinner while loading and a final "No more products" message

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: some header tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6856fad75650832fb20e37c3f5ae5e9d