### PR TITLE
Update product quantity seeding and price display

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import ProductImageSlider from './ProductImageSlider';
 import { AppContext, AppContextValue } from '../contexts/AppContext';
 import type { Product } from '../types/product';
+import { formatCurrency } from '../lib/utils/formatCurrency';
 
 interface ProductCardProps {
   product: Product;
@@ -67,7 +68,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
         </p>
         <div className="flex justify-between items-center mt-auto text-sm">
           <span className="font-bold">
-            {product.currency} {product.minPrice?.toFixed(2)}
+            {formatCurrency(product.minPrice ?? 0, product.currency)}
           </span>
           {product.reviewCount > 0 && (
             <span className="text-xs">

--- a/lib/utils/formatCurrency.ts
+++ b/lib/utils/formatCurrency.ts
@@ -1,0 +1,12 @@
+export function formatCurrency(amount: number, currency: string = 'USD'): string {
+  if (isNaN(amount)) amount = 0;
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${currency} ${amount.toFixed(2)}`;
+  }
+}

--- a/scripts/seedProducts.ts
+++ b/scripts/seedProducts.ts
@@ -16,6 +16,7 @@ interface CsvRow {
   TAGS?: string;
   IMAGES?: string;
   PRICE_RANGE_V2?: string;
+  TOTAL_INVENTORY?: string;
 }
 
 async function ensureVendor(name: string) {
@@ -89,7 +90,10 @@ async function processRow(row: CsvRow) {
         productType: row.PRODUCT_TYPE || '',
         tags: row.TAGS || '',
         images: row.IMAGES || null,
-        quantity: 0,
+        quantity:
+          typeof row.TOTAL_INVENTORY !== 'undefined'
+            ? parseInt(row.TOTAL_INVENTORY as any, 10) || 0
+            : Math.floor(Math.random() * 20),
         minPrice: price.min,
         maxPrice: price.max,
         currency: price.currency,


### PR DESCRIPTION
## Summary
- seed product quantity using existing CSV field or random values
- add currency formatting helper
- show formatted price on product cards

## Testing
- `npm run type-check` *(fails: ProductWhereInput missing)*
- `npm test` *(fails: 1 failing suite)*

------
https://chatgpt.com/codex/tasks/task_e_6856fbc43b44832f91864bf75fac5fd3