### PR TITLE
Update Product Quantity & Display Price

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -19,7 +19,11 @@ const ProductCard: React.FC<ProductCardProps> = ({
   const context = useContext(AppContext) as AppContextValue;
   const addToCart = context?.addToCart;
 
-  const isOut = product.totalInventory !== undefined && product.totalInventory <= 0;
+  const inventory =
+    product.totalInventory !== undefined
+      ? product.totalInventory
+      : (product as any).quantity;
+  const isOut = typeof inventory === 'number' && inventory <= 0;
   const onSale = product.maxPrice > product.minPrice;
   const isNew = product.tags?.toLowerCase().includes('new');
   const rating = Math.round(product.averageRating || 0);
@@ -32,8 +36,8 @@ const ProductCard: React.FC<ProductCardProps> = ({
             product.images && product.images.length > 0
               ? product.images
               : product.featuredImage
-              ? [product.featuredImage]
-              : []
+                ? [product.featuredImage]
+                : []
           }
           placeholderSeed={Number(product.id)}
           className="w-full bg-gray-200 flex items-center justify-center aspect-[4/5]"
@@ -48,7 +52,10 @@ const ProductCard: React.FC<ProductCardProps> = ({
         </div>
       )}
       <div className="p-3 flex flex-col gap-1">
-        <Link href={`/product/${product.slug}`} className="font-semibold text-base line-clamp-2 hover:underline">
+        <Link
+          href={`/product/${product.slug}`}
+          className="font-semibold text-base line-clamp-2 hover:underline"
+        >
           <span
             dangerouslySetInnerHTML={{
               __html: highlightTitle || product.title || 'Untitled Product',
@@ -67,12 +74,13 @@ const ProductCard: React.FC<ProductCardProps> = ({
           />
         </p>
         <div className="flex justify-between items-center mt-auto text-sm">
-          <span className="font-bold">
+          <span className="font-bold text-base">
             {formatCurrency(product.minPrice ?? 0, product.currency)}
           </span>
           {product.reviewCount > 0 && (
             <span className="text-xs">
-              {'★'.repeat(rating)}{'☆'.repeat(5 - rating)}
+              {'★'.repeat(rating)}
+              {'☆'.repeat(5 - rating)}
             </span>
           )}
         </div>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "postinstall": "npm run setup-env && node scripts/setupPrisma.js && PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 prisma generate",
     "init:typesense": "ts-node scripts/initTypesense.ts",
     "generate:erd": "ts-node scripts/generateErd.ts",
-    "seed:products": "ts-node scripts/seedProducts.ts"
+    "seed:products": "ts-node scripts/seedProducts.ts",
+    "update:quantities": "ts-node scripts/updateQuantities.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/scripts/seedProducts.ts
+++ b/scripts/seedProducts.ts
@@ -90,10 +90,10 @@ async function processRow(row: CsvRow) {
         productType: row.PRODUCT_TYPE || '',
         tags: row.TAGS || '',
         images: row.IMAGES || null,
-        quantity:
-          typeof row.TOTAL_INVENTORY !== 'undefined'
-            ? parseInt(row.TOTAL_INVENTORY as any, 10) || 0
-            : Math.floor(Math.random() * 20),
+        quantity: (() => {
+          const rand = Math.floor(Math.random() * 20);
+          return rand < 6 ? 0 : rand;
+        })(),
         minPrice: price.min,
         maxPrice: price.max,
         currency: price.currency,

--- a/scripts/updateQuantities.ts
+++ b/scripts/updateQuantities.ts
@@ -1,0 +1,25 @@
+import { prisma } from '../lib/prisma';
+import { loadAndIndexProducts } from '../lib/products';
+
+async function main() {
+  const products = await prisma.product.findMany({ select: { id: true } });
+  for (const product of products) {
+    const qty = Math.floor(Math.random() * 20);
+    await prisma.product.update({
+      where: { id: product.id },
+      data: { quantity: qty },
+    });
+  }
+  try {
+    const { products: all } = await loadAndIndexProducts();
+    console.log(`Updated and re-indexed ${all.length} products`);
+  } catch (err) {
+    console.error('Failed to re-index products', err);
+  }
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  prisma.$disconnect().finally(() => process.exit(1));
+});


### PR DESCRIPTION
## Summary
- randomize `quantity` in seeding script and expose an update script
- display product price more prominently on cards
- handle quantity in product cards to show out-of-stock status
- add `update:quantities` npm script for convenience

## Testing
- `npm run format`
- `npm test --silent` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_6856fe0ad068832fa758097e0bb88731