### PR TITLE
Fix Product Detail Page Serialization Error (vendor undefined)

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -14,7 +14,10 @@ export async function getProductByUuid(uuid: string) {
 }
 
 export async function getProductBySlug(slug: string) {
-  return prisma.product.findUnique({ where: { slug } });
+  return prisma.product.findUnique({
+    where: { slug },
+    include: { category: true, vendor: true },
+  });
 }
 
 export async function decreaseProductQuantity(

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -148,7 +148,7 @@ export function mapDbRowToProduct(row: ProductRow): Product {
     slug: row.slug,
     sku: row.sku,
     title: row.title,
-    vendor: row.vendor,
+    vendor: row.vendor ?? null,
     description: row.description,
     productType: row.productType,
     tags: row.tags,


### PR DESCRIPTION
## Summary
- load vendor and category relations when fetching by slug
- default vendor to `null` in `mapDbRowToProduct` to avoid serialization error

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: missing @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68570078d374832f806444b770c890d3