### PR TITLE
Fix Excessive API Requests on Products Scroll

### DIFF
--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -79,6 +79,7 @@ export default function ProductsPage({ products, total, categories }: ProductsPr
   const [hasMore, setHasMore] = useState(products.length < total);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const observerRef = useRef<IntersectionObserver>();
+  const isFetchingRef = useRef(false);
   const priceTimer = useRef<NodeJS.Timeout>();
   const firstPriceRef = useRef(true);
 
@@ -99,7 +100,8 @@ export default function ProductsPage({ products, total, categories }: ProductsPr
   );
 
   const loadMore = useCallback(async () => {
-    if (loadingMore || !hasMore) return;
+    if (isFetchingRef.current || loadingMore || !hasMore) return;
+    isFetchingRef.current = true;
     setLoadingMore(true);
     const next = page + 1;
     const data = await fetchPage(next);
@@ -117,6 +119,7 @@ export default function ProductsPage({ products, total, categories }: ProductsPr
       );
     }
     setLoadingMore(false);
+    isFetchingRef.current = false;
   }, [fetchPage, hasMore, loadingMore, page, router]);
 
   const loadMoreFn = useRef(loadMore);


### PR DESCRIPTION
## Summary
- avoid overlapping requests when scrolling products list

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: prisma binaries blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685707aaa924832f8e849dba1e76ebfb