### PR TITLE
Enhance product detail UI

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -33,10 +33,10 @@ const ProductCard: React.FC<ProductCardProps> = ({
       <Link href={`/product/${product.slug}`} className="block overflow-hidden">
         <ProductImageSlider
           images={
-            product.images && product.images.length > 0
-              ? product.images
-              : product.featuredImage
-                ? [product.featuredImage]
+            product.featuredImage
+              ? [product.featuredImage]
+              : product.images && product.images.length > 0
+                ? [product.images[0]]
                 : []
           }
           placeholderSeed={Number(product.id)}

--- a/components/ProductImageSlider.tsx
+++ b/components/ProductImageSlider.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
 import type { Image as ProductImage } from '../types/image';
+import ChevronLeftIcon from './icons/ChevronLeftIcon';
+import ChevronRightIcon from './icons/ChevronRightIcon';
 
 export interface ProductImageSliderProps {
   images?: ProductImage[];
@@ -16,6 +18,7 @@ export default function ProductImageSlider({
   placeholderSeed = 1,
 }: ProductImageSliderProps) {
   const [idx, setIdx] = useState(0);
+  const [zoom, setZoom] = useState(false);
   const urls = images.map((img) => (typeof img === 'string' ? img : img.url));
   const placeholderUrl = `https://picsum.photos/seed/${placeholderSeed}/400/400`;
   const [errorMap, setErrorMap] = useState<Record<number, boolean>>({});
@@ -39,7 +42,8 @@ export default function ProductImageSlider({
         src={errorMap[idx] ? placeholderUrl : images[idx].url}
         alt={images[idx].alt || `Image ${idx + 1}`}
         fill
-        className={`object-cover ${imgClass}`}
+        className={`object-cover cursor-zoom-in ${imgClass}`}
+        onClick={() => setZoom(true)}
         onError={() => setErrorMap((m) => ({ ...m, [idx]: true }))}
       />
       {urls.length > 1 && (
@@ -49,16 +53,32 @@ export default function ProductImageSlider({
             className="btn btn-xs absolute left-1 top-1/2 -translate-y-1/2"
             onClick={prev}
           >
-            Prev
+            <ChevronLeftIcon size={16} />
           </button>
           <button
             type="button"
             className="btn btn-xs absolute right-1 top-1/2 -translate-y-1/2"
             onClick={next}
           >
-            Next
+            <ChevronRightIcon size={16} />
           </button>
         </>
+      )}
+      {zoom && (
+        <dialog open className="modal">
+          <div className="modal-box p-0 max-w-none">
+            <Image
+              src={errorMap[idx] ? placeholderUrl : images[idx].url}
+              alt={images[idx].alt || `Image ${idx + 1}`}
+              width={800}
+              height={800}
+              className="w-full h-auto object-contain"
+            />
+            <form method="dialog" className="modal-backdrop">
+              <button onClick={() => setZoom(false)}>close</button>
+            </form>
+          </div>
+        </dialog>
       )}
     </div>
   );

--- a/components/RecommendedProducts.tsx
+++ b/components/RecommendedProducts.tsx
@@ -19,7 +19,7 @@ const RecommendedProducts: React.FC<RecommendedProductsProps> = ({
   useEffect(() => {
     if (!category) return;
     fetch(
-      `/api/search?filterByCategory=${encodeURIComponent(category)}&perPage=4`
+      `/api/search?filterByCategory=${encodeURIComponent(category)}&perPage=10`
     )
       .then((res) => (res.ok ? (res.json() as Promise<SearchResults>) : null))
       .then((data) => {
@@ -36,10 +36,12 @@ const RecommendedProducts: React.FC<RecommendedProductsProps> = ({
   return (
     <div className="mt-8">
       <h3 className="font-semibold mb-4">{title}</h3>
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 sm:gap-6">
-        {products.map((p) => (
-          <ProductCard key={p.id} product={p} />
-        ))}
+      <div className="overflow-x-auto">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6 min-w-max">
+          {products.map((p) => (
+            <ProductCard key={p.id} product={p} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/components/icons/ChevronLeftIcon.tsx
+++ b/components/icons/ChevronLeftIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const ChevronLeftIcon: React.FC<IconProps> = ({
+  size = 24,
+  color = 'currentColor',
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M15 19l-7-7 7-7"
+    />
+  </svg>
+);
+
+export default ChevronLeftIcon;

--- a/components/icons/ChevronRightIcon.tsx
+++ b/components/icons/ChevronRightIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const ChevronRightIcon: React.FC<IconProps> = ({
+  size = 24,
+  color = 'currentColor',
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M9 5l7 7-7 7"
+    />
+  </svg>
+);
+
+export default ChevronRightIcon;

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -206,7 +206,7 @@ export function AppProvider({ children }: AppProviderProps) {
 
   const removeFromWishlist = (id: string) => {
     setWishlist((prev) => prev.filter((item) => item.id !== id));
-    addNotification('Removed from wishlist', 'info');
+    addNotification('Removed from wishlist', 'warning');
   };
 
   return (


### PR DESCRIPTION
## Summary
- show only the first product image on listing cards
- allow zooming product images with arrow controls
- show 10 related products below the detail view
- warn when removing from wishlist
- add ChevronLeftIcon and ChevronRightIcon components

## Testing
- `npm run lint`
- `npm test` *(fails: Test Suites: 1 failed, 3 passed)*
- `npm run type-check` *(fails: ProductWhereInput not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570fc275f0832f814da9c6a8829607