### PR TITLE
Fix user signup message and logout redirect

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -67,7 +67,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
   }, [menuOpen, categories]);
 
   const itemCount = cart.reduce((sum, item) => sum + (item.qty || 0), 0);
-  const logout = () => signOut({ redirect: false });
+  const logout = () => signOut({ callbackUrl: '/' });
 
   const iconMap: Record<string, JSX.Element> = {
     Electronics: <ElectronicsIcon className="h-5 w-5 mr-1" />, 

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -136,12 +136,15 @@ export function AppProvider({ children }: AppProviderProps) {
       throw new Error('Signup failed');
     }
     const data: T = await res.json();
-    addNotification('Signup successful', 'success');
+    addNotification(
+      'Signup successful! Please check your email to verify your account before logging in.',
+      'success'
+    );
     return data;
   };
 
   const logout = (): void => {
-    nextSignOut({ redirect: false });
+    nextSignOut({ callbackUrl: '/' });
     addNotification('Logged out', 'info');
   };
 


### PR DESCRIPTION
## Summary
- notify user to verify email after signup
- redirect to home on logout

## Testing
- `npm run type-check` *(fails: ProductWhereInput missing)*
- `npm test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_685794f076ec832f9767043f105a9339