### PR TITLE
Adjust Product Image Sizes and Fix Zoom Modal

### DIFF
--- a/components/ProductImageSlider.tsx
+++ b/components/ProductImageSlider.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import type { Image as ProductImage } from '../types/image';
 import ChevronLeftIcon from './icons/ChevronLeftIcon';
@@ -21,6 +21,16 @@ export default function ProductImageSlider({
 }: ProductImageSliderProps) {
   const [idx, setIdx] = useState(0);
   const [zoom, setZoom] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setZoom(false);
+    };
+    if (zoom) {
+      document.addEventListener('keydown', handler);
+    }
+    return () => document.removeEventListener('keydown', handler);
+  }, [zoom]);
   const urls = images.map((img) => (typeof img === 'string' ? img : img.url));
   const placeholderUrl = `https://picsum.photos/seed/${placeholderSeed}/400/400`;
   const [errorMap, setErrorMap] = useState<Record<number, boolean>>({});
@@ -61,8 +71,22 @@ export default function ProductImageSlider({
         </div>
       )}
       {zoom && (
-        <dialog open className="modal">
-          <div className="modal-box p-0 max-w-none">
+        <dialog
+          ref={dialogRef}
+          open
+          className="modal"
+          onClick={(e) => {
+            if (e.target === dialogRef.current) setZoom(false);
+          }}
+        >
+          <div className="modal-box p-0 max-w-none relative">
+            <button
+              type="button"
+              className="btn btn-sm btn-circle absolute right-2 top-2"
+              onClick={() => setZoom(false)}
+            >
+              ✖
+            </button>
             <Image
               src={errorMap[idx] ? placeholderUrl : images[idx].url}
               alt={images[idx].alt || `Image ${idx + 1}`}
@@ -70,8 +94,12 @@ export default function ProductImageSlider({
               height={800}
               className="w-full h-auto object-contain"
             />
-            <form method="dialog" className="modal-backdrop">
-              <button onClick={() => setZoom(false)}>close</button>
+            <form
+              method="dialog"
+              className="modal-backdrop"
+              onClick={() => setZoom(false)}
+            >
+              <button>close</button>
             </form>
           </div>
         </dialog>

--- a/components/RecommendedProducts.tsx
+++ b/components/RecommendedProducts.tsx
@@ -42,7 +42,7 @@ const RecommendedProducts: React.FC<RecommendedProductsProps> = ({
             <ProductCard
               key={p.id}
               product={p}
-              className="w-40 sm:w-48 flex-shrink-0"
+              className="w-36 sm:w-44 flex-shrink-0"
             />
           ))}
         </div>

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -100,7 +100,7 @@ export default function ProductDetail({
       <div className="flex flex-col md:flex-row gap-8">
         <div className="md:w-1/2 flex justify-center">
           <ProductImageSlider
-            className="w-full max-w-sm md:max-w-md"
+            className="w-full max-w-sm"
             images={
               product.images && product.images.length > 0
                 ? product.images


### PR DESCRIPTION
## Summary
- shrink recommended product card sizes
- reduce main product image width
- add close button and ESC/outside click handling for zoom dialog

## Testing
- `npm run lint`
- `npx jest --runTestsByPath __tests__/Header.test.tsx` *(fails: 4 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6857965d4024832fb028a2819d8e7bc6