### PR TITLE
Fix User Signup Flow, Role Assignment, and Auth Redirects

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -67,7 +67,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
   }, [menuOpen, categories]);
 
   const itemCount = cart.reduce((sum, item) => sum + (item.qty || 0), 0);
-  const logout = () => signOut({ callbackUrl: '/' });
+  const logout = () => signOut({ callbackUrl: '/', redirect: true });
 
   const iconMap: Record<string, JSX.Element> = {
     Electronics: <ElectronicsIcon className="h-5 w-5 mr-1" />, 

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -81,7 +81,7 @@ export function AppProvider({ children }: AppProviderProps) {
         lastName,
         brandName,
         gender,
-        role,
+        role: (role || '').toLowerCase(),
         phoneNumber: '',
         address: '',
         city: '',
@@ -144,7 +144,7 @@ export function AppProvider({ children }: AppProviderProps) {
   };
 
   const logout = (): void => {
-    nextSignOut({ callbackUrl: '/' });
+    nextSignOut({ callbackUrl: '/', redirect: true });
     addNotification('Logged out', 'info');
   };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,5 +2,5 @@ import { Prisma } from '@prisma/client';
 
 export type UserInfo = Pick<
   Prisma.User,
-  'email' | 'firstName' | 'lastName' | 'brandName' | 'gender' | 'role' | 'phoneNumber' | 'address' | 'city' | 'country'
->;
+  'email' | 'firstName' | 'lastName' | 'brandName' | 'gender' | 'phoneNumber' | 'address' | 'city' | 'country'
+> & { role: string };


### PR DESCRIPTION
## Summary
- store user roles in lowercase in AppContext
- declare role as string in `UserInfo`
- always redirect to home after logout

## Testing
- `npm test` *(fails: Cannot find elements in Header test)*

------
https://chatgpt.com/codex/tasks/task_e_685798784e80832f9aab3ebb00d11527