### PR TITLE
Refine Image and Card Layout on Home & Detail pages

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -32,7 +32,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
 
   return (
     <div
-      className={`group relative flex flex-col h-full bg-base-100 border border-base-300 rounded-xl overflow-hidden shadow hover:shadow-lg transition-shadow duration-200 ${className}`}
+      className={`group relative flex flex-col h-full bg-base-100 border border-base-300 rounded-xl overflow-hidden shadow hover:shadow-lg transition-shadow duration-200 w-4/5 mx-auto ${className}`}
     >
       <Link href={`/product/${product.slug}`} className="block overflow-hidden">
         <ProductImageSlider
@@ -44,7 +44,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
                 : []
           }
           placeholderSeed={Number(product.id)}
-          className="w-4/5 mx-auto bg-gray-200 flex items-center justify-center"
+          className="w-full bg-gray-200 flex items-center justify-center"
           imgClass="transition-transform duration-200 group-hover:scale-105"
           aspectRatioClass="aspect-square"
         />
@@ -56,7 +56,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
           {isOut && <span className="badge">Out of stock</span>}
         </div>
       )}
-      <div className="p-3 flex flex-col gap-1">
+      <div className="p-2 flex flex-col gap-1">
         <Link
           href={`/product/${product.slug}`}
           className="font-semibold text-base line-clamp-2 hover:underline"

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -100,7 +100,7 @@ export default function ProductDetail({
       <div className="flex flex-col md:flex-row gap-8">
         <div className="md:w-1/2 flex justify-center">
           <ProductImageSlider
-            className="w-full"
+            className="w-11/12 md:w-10/12 mx-auto"
             images={
               product.images && product.images.length > 0
                 ? product.images


### PR DESCRIPTION
## Summary
- keep product card images flush by matching card width
- make text padding smaller to reduce card height
- shrink product detail image width for a tighter layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68579ac36ec4832faf4f14e2e02960c0