### PR TITLE
Adjust product card size on home

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -9,6 +9,8 @@ interface ProductCardProps {
   product: Product;
   highlightTitle?: string;
   highlightDescription?: string;
+  /** Render a smaller card variant */
+  compact?: boolean;
   className?: string;
 }
 
@@ -16,6 +18,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
   product,
   highlightTitle,
   highlightDescription,
+  compact = false,
   className = '',
 }) => {
   const context = useContext(AppContext) as AppContextValue;
@@ -56,10 +59,10 @@ const ProductCard: React.FC<ProductCardProps> = ({
           {isOut && <span className="badge">Out of stock</span>}
         </div>
       )}
-      <div className="p-2 flex flex-col gap-1">
+      <div className={`${compact ? 'p-1 gap-0.5' : 'p-2 gap-1'} flex flex-col`}>
         <Link
           href={`/product/${product.slug}`}
-          className="font-semibold text-base line-clamp-2 hover:underline"
+          className={`font-semibold line-clamp-2 hover:underline ${compact ? 'text-sm' : 'text-base'}`}
         >
           <span
             dangerouslySetInnerHTML={{
@@ -67,7 +70,9 @@ const ProductCard: React.FC<ProductCardProps> = ({
             }}
           />
         </Link>
-        <p className="text-sm text-base-content line-clamp-2">
+        <p
+          className={`text-base-content line-clamp-2 ${compact ? 'text-xs' : 'text-sm'}`}
+        >
           <span
             dangerouslySetInnerHTML={{
               __html:
@@ -78,8 +83,10 @@ const ProductCard: React.FC<ProductCardProps> = ({
             }}
           />
         </p>
-        <div className="flex justify-between items-center mt-auto text-sm">
-          <span className="font-bold text-base">
+        <div
+          className={`flex justify-between items-center mt-auto ${compact ? 'text-xs' : 'text-sm'}`}
+        >
+          <span className={`font-bold ${compact ? 'text-sm' : 'text-base'}`}>
             {formatCurrency(product.minPrice ?? 0, product.currency)}
           </span>
           {product.reviewCount > 0 && (
@@ -90,7 +97,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
           )}
         </div>
         <button
-          className="btn btn-sm btn-primary absolute bottom-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity"
+          className={`btn btn-primary absolute bottom-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity ${compact ? 'btn-xs' : 'btn-sm'}`}
           onClick={() => addToCart && addToCart(product)}
           disabled={!addToCart}
         >

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -63,7 +63,9 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
   useEffect(() => {
     const pageParam = router.query.page;
     if (pageParam) {
-      const p = Array.isArray(pageParam) ? parseInt(pageParam[0], 10) : parseInt(pageParam as string, 10);
+      const p = Array.isArray(pageParam)
+        ? parseInt(pageParam[0], 10)
+        : parseInt(pageParam as string, 10);
       setCurrentPage(isNaN(p) ? 1 : p);
     } else {
       setCurrentPage(1);
@@ -227,8 +229,13 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
   const handlePageChange = (newPage: number) => {
     if (newPage > 0 && newPage <= totalPages) {
       setCurrentPage(newPage);
-      const query = { ...router.query, page: String(newPage) } as Record<string, string>;
-      router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+      const query = { ...router.query, page: String(newPage) } as Record<
+        string,
+        string
+      >;
+      router.push({ pathname: router.pathname, query }, undefined, {
+        shallow: true,
+      });
       if (typeof window !== 'undefined') {
         window.scrollTo({ top: 0, behavior: 'smooth' });
       }
@@ -251,7 +258,9 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
     e.preventDefault();
     setCurrentPage(1);
     const query = { ...router.query, page: '1' } as Record<string, string>;
-    router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+    router.push({ pathname: router.pathname, query }, undefined, {
+      shallow: true,
+    });
     fetchProducts();
   };
 
@@ -262,7 +271,11 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       clear: () => {
         setFilterByVendor('All');
         setCurrentPage(1);
-        router.push({ pathname: router.pathname, query: { ...router.query, page: '1' } }, undefined, { shallow: true });
+        router.push(
+          { pathname: router.pathname, query: { ...router.query, page: '1' } },
+          undefined,
+          { shallow: true }
+        );
       },
     });
   if (filterByType !== 'All')
@@ -276,7 +289,11 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       clear: () => {
         setFilterByCategory('All');
         setCurrentPage(1);
-        router.push({ pathname: router.pathname, query: { ...router.query, page: '1' } }, undefined, { shallow: true });
+        router.push(
+          { pathname: router.pathname, query: { ...router.query, page: '1' } },
+          undefined,
+          { shallow: true }
+        );
       },
     });
   if (inStock)
@@ -285,7 +302,11 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       clear: () => {
         setInStock(false);
         setCurrentPage(1);
-        router.push({ pathname: router.pathname, query: { ...router.query, page: '1' } }, undefined, { shallow: true });
+        router.push(
+          { pathname: router.pathname, query: { ...router.query, page: '1' } },
+          undefined,
+          { shallow: true }
+        );
       },
     });
   if (minPrice)
@@ -294,7 +315,11 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       clear: () => {
         setMinPrice('');
         setCurrentPage(1);
-        router.push({ pathname: router.pathname, query: { ...router.query, page: '1' } }, undefined, { shallow: true });
+        router.push(
+          { pathname: router.pathname, query: { ...router.query, page: '1' } },
+          undefined,
+          { shallow: true }
+        );
       },
     });
   if (maxPrice)
@@ -303,7 +328,11 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
       clear: () => {
         setMaxPrice('');
         setCurrentPage(1);
-        router.push({ pathname: router.pathname, query: { ...router.query, page: '1' } }, undefined, { shallow: true });
+        router.push(
+          { pathname: router.pathname, query: { ...router.query, page: '1' } },
+          undefined,
+          { shallow: true }
+        );
       },
     });
 
@@ -322,7 +351,7 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
         <p className="text-gray-500">No products found</p>
       ) : (
         <>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 w-full">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 lg:grid-cols-6 gap-4 w-full">
             {products.map((p) => (
               <ProductCard
                 key={p.id}
@@ -333,6 +362,7 @@ const Home: React.FC & { heroSecond?: typeof HeroSlider } = () => {
                 highlightDescription={
                   p.highlights?.find((h) => h.field === 'description')?.snippet
                 }
+                compact
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- add `compact` variant to `ProductCard`
- shrink product card layout on home page with more columns

## Testing
- `npm test` *(fails: 4 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6857b4a99744832f91e0bddce12d831c