### PR TITLE
Implement local payment methods

### DIFF
--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -21,6 +21,9 @@ interface AddOrderParams {
   items: OrderItemInput[];
   total: number;
   status?: Order['status'];
+  paymentMethod?: string;
+  paymentReference?: string;
+  paymentProof?: string;
 }
 
 function mapOrderRow(row: OrderWithRelations): Order {
@@ -32,6 +35,9 @@ function mapOrderRow(row: OrderWithRelations): Order {
     quantity: row.quantity,
     total: row.total,
     status: row.status as Order['status'],
+    paymentMethod: row.paymentMethod || undefined,
+    paymentReference: row.paymentReference || undefined,
+    paymentProof: row.paymentProof || undefined,
     user: row.user,
     product: mapDbRowToProduct(row.product),
     createdAt: row.createdAt,
@@ -44,6 +50,9 @@ export async function addOrder({
   items,
   total,
   status = 'pending',
+  paymentMethod,
+  paymentReference,
+  paymentProof,
 }: AddOrderParams): Promise<Order[]> {
   const db = getDb();
   const user = await db.user.findUnique({ where: { email: userEmail } });
@@ -58,6 +67,9 @@ export async function addOrder({
           quantity: item.qty ?? 1,
           total,
           status,
+          paymentMethod,
+          paymentReference,
+          paymentProof,
         },
         include: {
           user: true,

--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -17,6 +17,32 @@ import { handleApiError } from '../../lib/utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import type { Order, OrderPlacedResponse, ApiMessage } from '../../types';
+import formidable, { type Fields, type Files, type File } from 'formidable';
+import fs from 'fs';
+import path from 'path';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function parseBody(req: NextApiRequest): Promise<{ fields: Fields; files: Files }> {
+  const type = req.headers['content-type'] || '';
+  if (type.includes('application/json')) {
+    const buffers: Uint8Array[] = [];
+    for await (const chunk of req) buffers.push(chunk);
+    const body = Buffer.concat(buffers).toString();
+    return { fields: JSON.parse(body || '{}') as Fields, files: {} as Files };
+  }
+  return new Promise<{ fields: Fields; files: Files }>((resolve, reject) => {
+    const form = formidable({ multiples: true });
+    form.parse(req, (err, fields, files) => {
+      if (err) reject(err);
+      else resolve({ fields, files });
+    });
+  });
+}
 
 async function handler(
   req: NextApiRequest,
@@ -24,10 +50,26 @@ async function handler(
 ): Promise<void> {
   try {
     if (req.method === 'POST') {
-      const { email, items, total } = req.body;
-    if (!email || !items) {
-      return res.status(400).json({ message: 'email and items required' });
-    }
+      const { fields, files } = await parseBody(req);
+      const email = fields.email as string;
+      const items = fields.items ? JSON.parse(String(fields.items)) : [];
+      const total = fields.total ? parseFloat(String(fields.total)) : 0;
+      const paymentMethod = fields.paymentMethod as string | undefined;
+      const paymentReference = fields.paymentReference as string | undefined;
+      let paymentProofPath: string | undefined = undefined;
+      const proof = files.paymentProof as File | File[] | undefined;
+      if (proof) {
+        const file = Array.isArray(proof) ? proof[0] : proof;
+        const dir = path.join(process.cwd(), 'public', 'payment-proofs');
+        fs.mkdirSync(dir, { recursive: true });
+        const name = Date.now() + '-' + file.originalFilename;
+        const dest = path.join(dir, name);
+        fs.renameSync(file.filepath, dest);
+        paymentProofPath = `/payment-proofs/${name}`;
+      }
+      if (!email || !items) {
+        return res.status(400).json({ message: 'email and items required' });
+      }
 
     for (const item of items) {
       const product = await getProductByUuid(String(item.uuid || item.id));
@@ -49,6 +91,9 @@ async function handler(
         userEmail: email,
         items,
         total: total || 0,
+        paymentMethod,
+        paymentReference,
+        paymentProof: paymentProofPath,
       });
       const orderId = Array.isArray(orders) && orders.length > 0 ? orders[0].id : '';
       await clearCart(email);

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -7,6 +7,7 @@ import { AppContext, AppContextValue } from '../contexts/AppContext';
 import type { User } from '../types/user';
 import type { Coupon } from '../types';
 import { TextInput, Textarea } from '../components/form-fields';
+import FileUpload from '../components/form-fields/FileUpload';
 
 // Types for cart item and user
 type CartItem = {
@@ -33,6 +34,9 @@ const Checkout: React.FC = () => {
   const [error, setError] = useState('');
   const [coupon, setCoupon] = useState('');
   const [discount, setDiscount] = useState(0);
+  const [paymentMethod, setPaymentMethod] = useState('card');
+  const [paymentReference, setPaymentReference] = useState('');
+  const [paymentProof, setPaymentProof] = useState<File | null>(null);
 
   const itemCount = cart.reduce((s, i) => s + i.qty, 0);
   const totalPrice = cart.reduce(
@@ -63,19 +67,33 @@ const Checkout: React.FC = () => {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch('/api/checkout/create-session', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          items: cart,
-          email: user.email,
-          shipping: { name, address },
-          discount,
-        }),
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.message || 'Checkout failed');
-      window.location.href = data.url;
+      if (paymentMethod === 'card') {
+        const res = await fetch('/api/checkout/create-session', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            items: cart,
+            email: user.email,
+            shipping: { name, address },
+            discount,
+          }),
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.message || 'Checkout failed');
+        window.location.href = data.url;
+      } else {
+        const fd = new FormData();
+        fd.append('email', user.email);
+        fd.append('items', JSON.stringify(cart));
+        fd.append('total', discountedTotal.toString());
+        fd.append('paymentMethod', paymentMethod);
+        if (paymentReference) fd.append('paymentReference', paymentReference);
+        if (paymentProof) fd.append('paymentProof', paymentProof);
+        const res = await fetch('/api/orders', { method: 'POST', body: fd });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.message || 'Checkout failed');
+        router.push('/orders');
+      }
     } catch (e: any) {
       setError(e.message || 'Order failed');
     }
@@ -182,14 +200,67 @@ const Checkout: React.FC = () => {
             <Textarea
               name="address"
               id="address"
-            className="w-full"
-            value={address}
-            onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
-              setAddress(e.target.value)
-            }
-            required
-          />
+              className="w-full"
+              value={address}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                setAddress(e.target.value)
+              }
+              required
+            />
         </div>
+        <div>
+          <label className="label" htmlFor="paymentMethod">
+            Payment Method
+          </label>
+          <select
+            id="paymentMethod"
+            className="select select-bordered w-full"
+            value={paymentMethod}
+            onChange={(e) => setPaymentMethod(e.target.value)}
+          >
+            <option value="card">Credit/Debit Card</option>
+            <option value="easypaisa">EasyPaisa</option>
+            <option value="jazzcash">JazzCash</option>
+            <option value="bank">Bank Transfer</option>
+          </select>
+        </div>
+        {paymentMethod !== 'card' && (
+          <div className="border p-3 rounded space-y-2">
+            {paymentMethod === 'easypaisa' && (
+              <p>
+                Send payment to EasyPaisa account <b>0300-1234567</b> and enter
+                the transaction ID below.
+              </p>
+            )}
+            {paymentMethod === 'jazzcash' && (
+              <p>
+                Send payment to JazzCash account <b>0300-7654321</b> and enter
+                the transaction ID below.
+              </p>
+            )}
+            {paymentMethod === 'bank' && (
+              <p>
+                Transfer to Bank Account <b>PK00 TEST 1234 5678 9012 3456</b> and
+                provide reference.
+              </p>
+            )}
+            <TextInput
+              name="reference"
+              id="reference"
+              placeholder="Transaction / Reference ID"
+              className="w-full"
+              value={paymentReference}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setPaymentReference(e.target.value)
+              }
+            />
+            <FileUpload
+              name="proof"
+              label="Upload Payment Proof (optional)"
+              onChange={(e) => setPaymentProof(e.target.files?.[0] || null)}
+            />
+          </div>
+        )}
         {error && <p className="text-red-500">{error}</p>}
         <button className="btn btn-primary" type="submit">
           Place Order

--- a/prisma/migrations/20250622081216_add-payment-fields/migration.sql
+++ b/prisma/migrations/20250622081216_add-payment-fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Order" ADD COLUMN "paymentMethod" TEXT;
+ALTER TABLE "Order" ADD COLUMN "paymentReference" TEXT;
+ALTER TABLE "Order" ADD COLUMN "paymentProof" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,6 +92,9 @@ model Order {
   quantity  Int
   total     Float
   status    String    @default("pending")
+  paymentMethod   String?
+  paymentReference String?
+  paymentProof     String?
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
 

--- a/types/order.ts
+++ b/types/order.ts
@@ -5,6 +5,9 @@ import type { Product } from './product';
 export interface Order extends PrismaOrder {
   user: User;
   product: Product;
+  paymentMethod?: string | null;
+  paymentReference?: string | null;
+  paymentProof?: string | null;
 }
 
 type OrderResponse = Order;


### PR DESCRIPTION
## Summary
- add `paymentMethod`, `paymentReference` and `paymentProof` columns for orders
- record payment fields when creating orders
- support multipart uploads for the orders API
- extend checkout page with EasyPaisa, JazzCash and Bank Transfer options

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing `jest` and `node` types)*

------
https://chatgpt.com/codex/tasks/task_e_6857ba2f4370832f8acf024db8a26314