### PR TITLE
Display categories as cards

### DIFF
--- a/components/CategoryCard.tsx
+++ b/components/CategoryCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Link from 'next/link';
+import type { Category } from '../types';
+import ElectronicsIcon from './icons/ElectronicsIcon';
+import FashionIcon from './icons/FashionIcon';
+import HomeIcon from './icons/HomeIcon';
+import ToysIcon from './icons/ToysIcon';
+import SportsIcon from './icons/SportsIcon';
+
+interface CategoryCardProps {
+  category: Category;
+}
+
+const iconMap: Record<string, JSX.Element> = {
+  Electronics: <ElectronicsIcon className="w-8 h-8 mb-2" />,
+  Fashion: <FashionIcon className="w-8 h-8 mb-2" />,
+  Home: <HomeIcon className="w-8 h-8 mb-2" />,
+  Toys: <ToysIcon className="w-8 h-8 mb-2" />,
+  Sports: <SportsIcon className="w-8 h-8 mb-2" />,
+};
+
+const CategoryCard: React.FC<CategoryCardProps> = ({ category }) => {
+  return (
+    <Link
+      href={`/categories/${encodeURIComponent(category.name)}`}
+      className="group border border-base-300 rounded-xl p-4 flex flex-col items-center text-center transition-transform duration-200 hover:shadow-lg hover:-translate-y-1 hover:border-primary"
+    >
+      {iconMap[category.name] ?? <div className="w-8 h-8 mb-2" />}
+      <span className="capitalize font-medium">{category.name}</span>
+    </Link>
+  );
+};
+
+export default CategoryCard;

--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
 import Head from 'next/head';
+import CategoryCard from '../../components/CategoryCard';
 import { getPageTitle } from '../../lib/pageTitle';
 import { Category } from '../../types';
 
@@ -10,25 +10,28 @@ const Categories: React.FC = () => {
   useEffect(() => {
     fetch('/api/categories')
       .then((res) => (res.ok ? res.json() : { categories: [] }))
-      .then((data: { categories: Category[] }) => setCategories(data.categories));
+      .then((data: { categories: Category[] }) =>
+        setCategories(data.categories)
+      );
   }, []);
 
   const renderCat = (cat: Category): React.ReactNode => (
-    <li key={cat.id}>
-      <Link href={`/categories/${encodeURIComponent(cat.name)}`}>{cat.name}</Link>
-    </li>
+    <CategoryCard key={cat.id ?? cat.name} category={cat} />
   );
 
   return (
-    <div className="max-w-2xl mx-auto min-h-screen p-4">
+    <div className="max-w-screen-lg mx-auto min-h-screen p-4">
       <Head>
         <title>{getPageTitle('Categories')}</title>
       </Head>
       <h1 className="text-2xl font-bold mb-4">Categories</h1>
-      <ul className="list-disc pl-4 space-y-2">
-        {categories.map((c) => renderCat(c))}
-        {categories.length === 0 && <li>No categories found.</li>}
-      </ul>
+      {categories.length === 0 ? (
+        <p>No categories found.</p>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+          {categories.map((c) => renderCat(c))}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `CategoryCard` component with optional icons and hover effects
- show categories page in a card grid layout

## Testing
- `npx prettier -w components/CategoryCard.tsx pages/categories/index.tsx`
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing prisma client)*
- `npm test` *(fails: no test output due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6857c2c82d54832fbc6613d929bf4a6a