### PR TITLE
Fix Typesense suggest endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,23 @@ TYPESENSE_API_KEY=xyz
 
 Visit [http://localhost:8108/health](http://localhost:8108/health) to verify the server is running.
 
-6. **Place your product data**
+6. **Initialize the Typesense collection**
+
+```bash
+npm run init:typesense
+```
+
+7. **Place your product data**
 
 Either put your `products.csv` inside the `/data/` directory **or** specify a
-remote file via the `PRODUCTS_URL` environment variable.
+remote file via the `PRODUCTS_URL` environment variable. Then seed the database
+and index the products:
 
-7. **Run the project**
+```bash
+npm run seed:products
+```
+
+8. **Run the project**
 
 ```bash
 npm run dev

--- a/pages/api/suggest.ts
+++ b/pages/api/suggest.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { host, port, protocol, apiKey } from '../../lib/typesenseClient';
+import client from '../../lib/typesenseClient';
 import { handleApiError } from '../../lib/utils/handleApiError';
+import { ObjectNotFound } from 'typesense/lib/Typesense/Errors';
 import type { SuggestionsResponse, ApiMessage } from '../../types';
 
 export default async function handler(
@@ -18,18 +19,27 @@ export default async function handler(
     return res.status(200).json({ suggestions: [] });
   }
 
-  const url = `${protocol}://${host}:${port}/collections/products/documents/suggest?q=${encodeURIComponent(query)}&query_by=title,description&num_suggestions=5`;
-
   try {
-    const resp = await fetch(url, {
-      headers: { 'X-TYPESENSE-API-KEY': apiKey },
-    });
-    if (!resp.ok) {
-      throw new Error(`HTTP ${resp.status}`);
-    }
-    const data = await resp.json();
-    return res.status(200).json(data);
+    const result = await client
+      .collections('products')
+      .documents()
+      .search({
+        q: query,
+        query_by: 'title,description',
+        prefix: 'true',
+        page: 1,
+        per_page: 5,
+      });
+
+    const suggestions = Array.isArray(result.hits)
+      ? result.hits.map((h: any) => h.document.title).filter(Boolean)
+      : [];
+    return res.status(200).json({ suggestions });
   } catch (err) {
+    if (err instanceof ObjectNotFound) {
+      console.error('Typesense collection "products" not found');
+      return res.status(500).json({ message: 'Search index missing' });
+    }
     console.error('Typesense suggest error', err);
     return handleApiError(res, err, 'Suggest failed');
   }


### PR DESCRIPTION
## Summary
- fix `/api/suggest` to use search API
- add Typesense init and seed docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d25f2354832fa593e686fb298805