### PR TITLE
UI layout and footer fixes

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -65,10 +65,10 @@ const Footer: FC = () => {
           </form>
         </div>
       </div>
-      <div className="mt-8 flex justify-center md:justify-start gap-4">
-        <VisaIcon size={32} />
-        <MastercardIcon size={32} />
-        <PaypalIcon size={32} />
+      <div className="mt-8 flex justify-end gap-4 pr-2">
+        <VisaIcon size={32} color="#1A1F71" />
+        <MastercardIcon size={32} color="#EB001B" />
+        <PaypalIcon size={32} color="#003087" />
       </div>
     </footer>
   );

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -10,13 +10,16 @@ interface LayoutProps {
 
 const Layout: FC<LayoutProps> = ({ children, heroSecond }) => {
   // If useTheme returns [Theme, Dispatch<SetStateAction<Theme>>]
-  const [theme, setTheme] = useTheme() as [string | Theme, Dispatch<SetStateAction<string | Theme>>];
+  const [theme, setTheme] = useTheme() as [
+    string | Theme,
+    Dispatch<SetStateAction<string | Theme>>,
+  ];
 
   return (
     <div className="flex flex-col min-h-screen overflow-x-hidden">
       <Header theme={theme} setTheme={setTheme} />
       {heroSecond && <div className="w-full">{heroSecond}</div>}
-      <main className="w-full mx-auto flex-1 px-4 sm:px-6 lg:px-8 py-6">
+      <main className="w-full max-w-[90%] mx-auto flex-1 px-4 sm:px-6 lg:px-8 py-6">
         {children}
       </main>
       <Footer />

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -229,7 +229,7 @@ export default function ProductDetail({
         />
       )}
       <div className="mt-4">
-        <Link href="/">&larr; Back to products</Link>
+        <Link href="/products">&larr; Back to products</Link>
       </div>
     </div>
   );

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -215,7 +215,7 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
         )}
       </div>
       <div className="mt-4">
-        <Link href="/">&larr; Back to products</Link>
+        <Link href="/products">&larr; Back to products</Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- constrain main content width to 90%
- move and colorize footer payment icons
- fix back navigation links on product pages

## Testing
- `npm run lint`
- `npm test` *(fails: 1 test suite failed)*

------
https://chatgpt.com/codex/tasks/task_e_6857d5c3b0e8832f95bf807ded599375