### PR TITLE
Improve account pages UI

### DIFF
--- a/__tests__/Header.test.tsx
+++ b/__tests__/Header.test.tsx
@@ -48,11 +48,16 @@ test('shows login and signup when unauthenticated', () => {
 });
 
 test('shows name and cart count when authenticated', () => {
-  const user = { role: 'super-admin', firstName: 'Alice', email: 'a@a.com' };
+  const user = {
+    role: 'super-admin',
+    firstName: 'Alice',
+    lastName: 'Smith',
+    email: 'a@a.com',
+  };
   const cart = [{ ID: 1, qty: 2 }];
   mockUseSession.mockReturnValue({ data: { user } });
   renderWithContext(<Header theme="light" setTheme={() => {}} />, { cart });
-  expect(screen.getAllByText('Alice').length).toBeGreaterThan(0);
+  expect(screen.getAllByText('Alice Smith').length).toBeGreaterThan(0);
   expect(screen.getAllByText('2').length).toBeGreaterThan(0);
 });
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -237,11 +237,29 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
 
           {user ? (
             <div className="dropdown dropdown-end">
-              <label tabIndex={0} className="flex items-center gap-1 cursor-pointer">
-                <UserIcon className="w-5 h-5" />
-                <span>{user.firstName || user.email}</span>
+              <label
+                tabIndex={0}
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                {user.logo ? (
+                  <img
+                    src={user.logo}
+                    alt="avatar"
+                    className="w-6 h-6 rounded-full object-cover"
+                  />
+                ) : (
+                  <UserIcon className="w-5 h-5" />
+                )}
+                <span>
+                  {user.firstName || user.lastName
+                    ? `${user.firstName || ''} ${user.lastName || ''}`.trim()
+                    : user.email}
+                </span>
               </label>
-              <ul tabIndex={0} className="dropdown-content z-50 menu p-2 shadow bg-base-100 rounded w-40">
+              <ul
+                tabIndex={0}
+                className="dropdown-content z-50 menu p-2 shadow bg-base-100 rounded w-40"
+              >
                 <li>
                   <Link href="/orders">My Orders</Link>
                 </li>

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -15,7 +15,7 @@ const Orders: React.FC<OrdersProps> = (_props) => {
   useEffect(() => {
     if (!user) return;
     setLoading(true);
-    fetch(`/api/orders?email=${encodeURIComponent(user.email)}`)
+    fetch('/api/user/orders')
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data: Order[]) => {
         setOrders(data);
@@ -30,7 +30,7 @@ const Orders: React.FC<OrdersProps> = (_props) => {
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="max-w-4xl mx-auto">
       <Head>
         <title>{getPageTitle('Orders')}</title>
       </Head>
@@ -41,22 +41,58 @@ const Orders: React.FC<OrdersProps> = (_props) => {
           <span className="loading loading-spinner"></span>
         </div>
       )}
-      <ul className="space-y-2">
-        {orders.map((o) => (
-          <li key={o.id} className="border p-2">
-            <p>
-              Order #{o.id} - {o.status}
-            </p>
-            <ul className="list-disc pl-4 text-sm mb-1">
-              <li>
-                {o.product.title} x {o.quantity}
-              </li>
-            </ul>
-            <p>Total: £{o.total}</p>
-          </li>
-        ))}
-        {!loading && orders.length === 0 && <li>No orders found.</li>}
-      </ul>
+      {orders.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="table w-full">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Product</th>
+                <th>Status</th>
+                <th>Total</th>
+                <th>Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.map((o) => (
+                <tr key={o.id} className="hover">
+                  <td>{o.id}</td>
+                  <td>
+                    <div className="flex items-center gap-2">
+                      <img
+                        src={
+                          o.product.featuredImage?.url ||
+                          `https://picsum.photos/seed/${o.product.id}/40/40`
+                        }
+                        alt={o.product.title}
+                        className="w-10 h-10 object-cover rounded"
+                      />
+                      <span>{o.product.title}</span>
+                    </div>
+                  </td>
+                  <td>
+                    <span
+                      className={`badge ${
+                        o.status === 'pending'
+                          ? 'badge-warning'
+                          : o.status === 'shipped'
+                            ? 'badge-info'
+                            : 'badge-success'
+                      }`}
+                    >
+                      {o.status}
+                    </span>
+                  </td>
+                  <td>£{o.total}</td>
+                  <td>{new Date(o.createdAt).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        !loading && <p>No orders found.</p>
+      )}
     </div>
   );
 };

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,10 +1,20 @@
 import Link from 'next/link';
 import Head from 'next/head';
+import { useEffect, useState } from 'react';
 import useRequireAuth from '../hooks/useRequireAuth';
 import { getPageTitle } from '../lib/pageTitle';
+import type { User } from '../types/user';
 
 const Profile: React.FC = () => {
   const user = useRequireAuth();
+  const [profile, setProfile] = useState<User | null>(null);
+  useEffect(() => {
+    if (!user) return;
+    fetch('/api/user/profile')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setProfile(data))
+      .catch(() => {});
+  }, [user]);
   if (!user) return null;
 
   return (
@@ -14,11 +24,23 @@ const Profile: React.FC = () => {
       </Head>
       <h1 className="text-2xl font-bold mb-4">My Profile</h1>
       <p>
-        <strong>Name:</strong> {user.firstName} {user.lastName}
+        <strong>Name:</strong> {profile?.firstName || user.firstName}{' '}
+        {profile?.lastName || user.lastName}
       </p>
       <p>
-        <strong>Email:</strong> {user.email}
+        <strong>Email:</strong> {profile?.email || user.email}
       </p>
+      {profile?.phoneNumber && (
+        <p>
+          <strong>Phone:</strong> {profile.phoneNumber}
+        </p>
+      )}
+      {profile?.address && (
+        <p>
+          <strong>Address:</strong> {profile.address}, {profile.city},{' '}
+          {profile.country}
+        </p>
+      )}
       <Link href="/profile/edit" className="btn btn-primary mt-4">
         Update Profile
       </Link>
@@ -27,4 +49,3 @@ const Profile: React.FC = () => {
 };
 
 export default Profile;
-

--- a/pages/profile/edit.tsx
+++ b/pages/profile/edit.tsx
@@ -1,18 +1,30 @@
 import { useForm, SubmitHandler } from 'react-hook-form';
 import Head from 'next/head';
+import { useEffect, useState } from 'react';
 import useRequireAuth from '../../hooks/useRequireAuth';
 import { getPageTitle } from '../../lib/pageTitle';
-import { EmailInput, PasswordInput, TextInput } from '../../components/form-fields';
+import {
+  EmailInput,
+  PasswordInput,
+  TextInput,
+} from '../../components/form-fields';
+import type { User } from '../../types/user';
 
 interface FormValues {
   firstName: string;
   lastName: string;
   email: string;
+  phoneNumber: string;
+  address: string;
+  city: string;
+  country: string;
   password: string;
 }
 
 const EditProfile: React.FC = () => {
   const user = useRequireAuth();
+  const [editingEmail, setEditingEmail] = useState(false);
+  const [loading, setLoading] = useState(true);
   const {
     register,
     handleSubmit,
@@ -23,9 +35,35 @@ const EditProfile: React.FC = () => {
       firstName: user?.firstName || '',
       lastName: user?.lastName || '',
       email: user?.email || '',
+      phoneNumber: '',
+      address: '',
+      city: '',
+      country: '',
       password: '',
     },
   });
+
+  useEffect(() => {
+    if (!user) return;
+    fetch('/api/user/profile')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: User | null) => {
+        if (data) {
+          reset({
+            firstName: data.firstName || '',
+            lastName: data.lastName || '',
+            email: data.email,
+            phoneNumber: data.phoneNumber || '',
+            address: data.address || '',
+            city: data.city || '',
+            country: data.country || '',
+            password: '',
+          });
+        }
+      })
+      .finally(() => setLoading(false))
+      .catch(() => setLoading(false));
+  }, [user, reset]);
 
   const submit: SubmitHandler<FormValues> = async (data) => {
     await fetch('/api/user/profile', {
@@ -37,9 +75,10 @@ const EditProfile: React.FC = () => {
   };
 
   if (!user) return null;
+  if (loading) return <div className="p-4">Loading...</div>;
 
   return (
-    <div className="max-w-sm mx-auto">
+    <div className="max-w-md mx-auto">
       <Head>
         <title>{getPageTitle('Update Profile')}</title>
       </Head>
@@ -59,13 +98,56 @@ const EditProfile: React.FC = () => {
           rules={{ required: 'Required' }}
           error={errors.lastName?.message}
         />
-        <EmailInput<FormValues>
-          label="Email"
-          name="email"
+        <div className="flex items-end gap-2">
+          <div className="flex-1">
+            <EmailInput<FormValues>
+              label="Email"
+              name="email"
+              readOnly={!editingEmail}
+              register={register}
+              rules={{ required: 'Required' }}
+              error={errors.email?.message}
+            />
+          </div>
+          {!editingEmail && (
+            <button
+              type="button"
+              className="btn btn-sm"
+              onClick={() => {
+                const pwd = window.prompt('Enter password to edit email');
+                if (pwd) setEditingEmail(true);
+              }}
+            >
+              Change Email
+            </button>
+          )}
+        </div>
+        <TextInput<FormValues>
+          label="Phone"
+          name="phoneNumber"
           register={register}
-          rules={{ required: 'Required' }}
-          error={errors.email?.message}
+          error={errors.phoneNumber?.message}
         />
+        <TextInput<FormValues>
+          label="Address"
+          name="address"
+          register={register}
+          error={errors.address?.message}
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <TextInput<FormValues>
+            label="City"
+            name="city"
+            register={register}
+            error={errors.city?.message}
+          />
+          <TextInput<FormValues>
+            label="Country"
+            name="country"
+            register={register}
+            error={errors.country?.message}
+          />
+        </div>
         <PasswordInput<FormValues>
           label="Password"
           name="password"
@@ -82,4 +164,3 @@ const EditProfile: React.FC = () => {
 };
 
 export default EditProfile;
-


### PR DESCRIPTION
## Summary
- enhance header with avatar and full name
- redesign My Orders page with table layout and status badges
- load profile details and show extra fields
- expand profile edit form with more fields and change email option
- update unit tests

## Testing
- `npx -y jest`

------
https://chatgpt.com/codex/tasks/task_e_6857e6812cc0832fa4eed22eb0c84e4f