### PR TITLE
Fix favicon and logo layout

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import type { FC } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import VisaIcon from './icons/VisaIcon';
@@ -21,7 +22,9 @@ const Footer: FC = () => {
     <footer className="bg-base-300 mt-12 py-8 text-base-content px-4 sm:px-6 lg:px-8">
       <div className="w-full grid grid-cols-1 md:grid-cols-3 gap-8">
         <div>
-          <h3 className="font-bold mb-2">ShopVerse</h3>
+          <Link href="/" className="inline-block mb-2">
+            <Image src="/images/logo.png" alt="Logo" width={120} height={40} />
+          </Link>
           <p className="text-sm text-gray-600">
             Everything you need, all in one place.
           </p>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -85,8 +85,8 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
 
   return (
     <header className="relative bg-base-300 mb-6">
-      <div className="w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-4 gap-y-2">
-        <Link href="/" className="btn btn-ghost">
+      <div className="w-full px-4 sm:px-6 lg:px-8 flex items-center gap-x-4 gap-y-2 h-16">
+        <Link href="/" className="flex items-center">
           <Image src="/images/logo.png" alt="Logo" width={120} height={40} />
         </Link>
 
@@ -238,11 +238,17 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
 
           {user ? (
             <div className="dropdown dropdown-end">
-              <label tabIndex={0} className="flex items-center gap-1 cursor-pointer">
+              <label
+                tabIndex={0}
+                className="flex items-center gap-1 cursor-pointer"
+              >
                 <UserIcon className="w-5 h-5" />
                 <span>{user.firstName || user.email}</span>
               </label>
-              <ul tabIndex={0} className="dropdown-content z-50 menu p-2 shadow bg-base-100 rounded w-40">
+              <ul
+                tabIndex={0}
+                className="dropdown-content z-50 menu p-2 shadow bg-base-100 rounded w-40"
+              >
                 <li>
                   <Link href="/orders">My Orders</Link>
                 </li>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,13 +1,20 @@
-import { Html, Head, Main, NextScript } from 'next/document'
+import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
     <Html lang="en">
       <Head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-        <link rel="icon" href="/favicon.webp" type="image/webp" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin=""
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
+        <link rel="icon" href="/favicon.webp" type="image/webp" sizes="32x32" />
       </Head>
       <body className="font-sans">
         <script
@@ -31,5 +38,5 @@ export default function Document() {
         <NextScript />
       </body>
     </Html>
-  )
+  );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -344,7 +344,7 @@ const Home: React.FC & {
       <Head>
         <title>{getPageTitle('Home')}</title>
         <meta name="description" content="Search products from CSV data" />
-        <link rel="icon" href="/favicon.webp" type="image/webp" />
+        <link rel="icon" href="/favicon.webp" type="image/webp" sizes="32x32" />
       </Head>
       {loading ? (
         <div className="flex justify-center my-4 w-full">


### PR DESCRIPTION
## Summary
- adjust header layout to keep logo in header bar
- show the logo in the footer
- tweak favicon links with sizes
- revert favicon binary to repo version

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857e76f1180832f83b0a53c27fe9ac6