### PR TITLE
Update settings page with country select and email tab

### DIFF
--- a/components/form-fields/CountrySelect.tsx
+++ b/components/form-fields/CountrySelect.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  Control,
+  Controller,
+  FieldValues,
+  Path,
+  RegisterOptions,
+} from 'react-hook-form';
+import Select from 'react-select';
+import Flag from 'react-world-flags';
+import countries, { CountryInfo } from '../../data/countries';
+
+interface CountrySelectProps<T extends FieldValues> {
+  name: Path<T>;
+  label?: string;
+  control: Control<T>;
+  rules?: RegisterOptions<T, Path<T>>;
+  error?: string;
+  className?: string;
+}
+
+const formatOptionLabel = (option: CountryInfo) => (
+  <div className="flex items-center gap-2">
+    <Flag code={option.value} style={{ height: '1rem' }} />
+    <span>
+      {option.label} ({option.callingCode})
+    </span>
+  </div>
+);
+
+const CountrySelect = <T extends FieldValues>({
+  name,
+  label,
+  control,
+  rules,
+  error,
+  className = '',
+}: CountrySelectProps<T>) => {
+  const inputId = String(name);
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {label}
+        </label>
+      )}
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        render={({ field }) => (
+          <Select
+            inputId={inputId}
+            {...field}
+            options={countries}
+            placeholder="Select country"
+            isSearchable
+            className={`w-full ${className}`}
+            classNamePrefix="react-select"
+            formatOptionLabel={formatOptionLabel}
+          />
+        )}
+      />
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default CountrySelect;

--- a/components/form-fields/index.ts
+++ b/components/form-fields/index.ts
@@ -7,3 +7,4 @@ export { default as Checkbox } from './Checkbox';
 export { default as RadioGroup } from './RadioGroup';
 export { default as DatePicker } from './DatePicker';
 export { default as FileUpload } from './FileUpload';
+export { default as CountrySelect } from './CountrySelect';

--- a/data/countries.ts
+++ b/data/countries.ts
@@ -1,0 +1,25 @@
+export interface CountryInfo {
+  label: string;
+  value: string;
+  callingCode: string;
+}
+
+const countries: CountryInfo[] = [
+  { value: 'US', label: 'United States', callingCode: '+1' },
+  { value: 'GB', label: 'United Kingdom', callingCode: '+44' },
+  { value: 'CA', label: 'Canada', callingCode: '+1' },
+  { value: 'AU', label: 'Australia', callingCode: '+61' },
+  { value: 'DE', label: 'Germany', callingCode: '+49' },
+  { value: 'FR', label: 'France', callingCode: '+33' },
+  { value: 'IN', label: 'India', callingCode: '+91' },
+  { value: 'PK', label: 'Pakistan', callingCode: '+92' },
+  { value: 'CN', label: 'China', callingCode: '+86' },
+  { value: 'JP', label: 'Japan', callingCode: '+81' },
+  { value: 'BR', label: 'Brazil', callingCode: '+55' },
+  { value: 'ZA', label: 'South Africa', callingCode: '+27' },
+  { value: 'NG', label: 'Nigeria', callingCode: '+234' },
+  { value: 'RU', label: 'Russia', callingCode: '+7' },
+  { value: 'SA', label: 'Saudi Arabia', callingCode: '+966' },
+];
+
+export default countries;

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -102,6 +102,27 @@ export function resetPassword(token: string, password: string) {
   });
 }
 
+export async function changeEmail(
+  currentEmail: string,
+  token: string,
+  newEmail: string
+) {
+  const user = await prisma.user.findFirst({
+    where: {
+      email: currentEmail,
+      resetToken: token,
+      resetExpires: { gt: new Date() },
+    },
+  });
+  if (!user) throw new Error('Invalid token');
+  const exists = await prisma.user.findUnique({ where: { email: newEmail } });
+  if (exists) throw new Error('Email exists');
+  await prisma.user.update({
+    where: { email: currentEmail },
+    data: { email: newEmail, resetToken: null, resetExpires: null },
+  });
+}
+
 export function updateUserProfile(email: string, data: Prisma.UserUpdateInput) {
   return prisma.user.update({ where: { email }, data });
 }

--- a/pages/api/change-email.ts
+++ b/pages/api/change-email.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { changeEmail } from '../../lib/users';
+import { handleApiError } from '../../lib/utils/handleApiError';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
+import type { ApiMessage } from '../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
+  if (req.method !== 'POST')
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
+  const { email, token } = req.body as { email?: string; token?: string };
+  if (!email || !token)
+    return res.status(400).json({ message: 'email and token required' });
+  try {
+    await changeEmail(session.user.email, token, email);
+    return res.status(200).json({ message: 'Email updated' });
+  } catch (e) {
+    return handleApiError(res, e, 'Error updating email');
+  }
+}

--- a/pages/api/request-email-change.ts
+++ b/pages/api/request-email-change.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { setResetToken, findUser } from '../../lib/users';
+import crypto from 'crypto';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
+import { handleApiError } from '../../lib/utils/handleApiError';
+import type { ResetTokenResponse, ApiMessage } from '../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResetTokenResponse | ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'POST')
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user)
+      return res.status(401).json({ message: 'Unauthorized' });
+    const { email } = req.body as { email?: string };
+    if (!email) return res.status(400).json({ message: 'email required' });
+    if (await findUser(email))
+      return res.status(409).json({ message: 'Email exists' });
+    const token = crypto.randomBytes(6).toString('hex');
+    const expires = Date.now() + 3600 * 1000;
+    await setResetToken(session.user.email, token, expires);
+    return res.status(200).json({ message: 'Code sent', token });
+  } catch (e) {
+    return handleApiError(res, e, 'Failed to request email change');
+  }
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect, useMemo, useContext } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import Head from 'next/head';
-import countryList from 'react-select-country-list';
 import { getPageTitle } from '../lib/pageTitle';
 import useRequireAuth from '../hooks/useRequireAuth';
 import { NotificationContext } from '../contexts/NotificationContext';
@@ -9,8 +8,9 @@ import {
   TextInput,
   EmailInput,
   PasswordInput,
-  SelectDropdown,
+  CountrySelect,
 } from '../components/form-fields';
+import countries from '../data/countries';
 
 interface ProfileFormValues {
   firstName: string;
@@ -27,7 +27,16 @@ interface PasswordFormValues {
 interface AddressFormValues {
   address: string;
   city: string;
-  country: { label: string; value: string } | null;
+  country: {
+    label: string;
+    value: string;
+    callingCode: string;
+  } | null;
+}
+
+interface EmailFormValues {
+  email: string;
+  token: string;
 }
 
 const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
@@ -35,12 +44,15 @@ const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
 const SettingsPage: React.FC = () => {
   const user = useRequireAuth();
   const { addNotification } = useContext(NotificationContext);
-  const [active, setActive] = useState<'profile' | 'password' | 'address'>('profile');
-  const countryOptions = useMemo(() => countryList().getData(), []);
+  const [active, setActive] = useState<
+    'profile' | 'password' | 'address' | 'email'
+  >('profile');
+  const [codeSent, setCodeSent] = useState(false);
 
   const profileForm = useForm<ProfileFormValues>();
   const passwordForm = useForm<PasswordFormValues>();
   const addressForm = useForm<AddressFormValues>();
+  const emailForm = useForm<EmailFormValues>();
 
   useEffect(() => {
     if (!user) return;
@@ -57,7 +69,7 @@ const SettingsPage: React.FC = () => {
         addressForm.reset({
           address: data.address || '',
           city: data.city || '',
-          country: data.country ? { label: data.country, value: data.country } : null,
+          country: countries.find((c) => c.value === data.country) || null,
         });
       })
       .catch(() => {});
@@ -73,7 +85,9 @@ const SettingsPage: React.FC = () => {
     else addNotification('Update failed', 'error');
   };
 
-  const submitPassword: SubmitHandler<PasswordFormValues> = async ({ password }) => {
+  const submitPassword: SubmitHandler<PasswordFormValues> = async ({
+    password,
+  }) => {
     const res = await fetch('/api/user/profile', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -97,6 +111,37 @@ const SettingsPage: React.FC = () => {
     });
     if (res.ok) addNotification('Address updated', 'success');
     else addNotification('Update failed', 'error');
+  };
+
+  const sendCode = async () => {
+    const email = emailForm.getValues('email');
+    if (!email) return;
+    const res = await fetch('/api/request-email-change', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    if (res.ok) {
+      setCodeSent(true);
+      addNotification('Verification code sent', 'success');
+    } else {
+      addNotification('Send failed', 'error');
+    }
+  };
+
+  const submitEmailChange: SubmitHandler<EmailFormValues> = async (values) => {
+    const res = await fetch('/api/change-email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    });
+    if (res.ok) {
+      addNotification('Email updated', 'success');
+      setCodeSent(false);
+      emailForm.reset();
+    } else {
+      addNotification('Update failed', 'error');
+    }
   };
 
   if (!user) return null;
@@ -132,11 +177,22 @@ const SettingsPage: React.FC = () => {
               Manage Address
             </button>
           </li>
+          <li>
+            <button
+              className={active === 'email' ? 'active' : ''}
+              onClick={() => setActive('email')}
+            >
+              Change Email
+            </button>
+          </li>
         </ul>
       </aside>
       <div className="flex-1">
         {active === 'profile' && (
-          <form onSubmit={profileForm.handleSubmit(submitProfile)} className="space-y-2 max-w-md">
+          <form
+            onSubmit={profileForm.handleSubmit(submitProfile)}
+            className="space-y-2 max-w-md mx-auto"
+          >
             <h2 className="text-xl font-bold mb-2">Update Profile</h2>
             <TextInput
               label="First Name"
@@ -171,13 +227,19 @@ const SettingsPage: React.FC = () => {
           </form>
         )}
         {active === 'password' && (
-          <form onSubmit={passwordForm.handleSubmit(submitPassword)} className="space-y-2 max-w-md">
+          <form
+            onSubmit={passwordForm.handleSubmit(submitPassword)}
+            className="space-y-2 max-w-md mx-auto"
+          >
             <h2 className="text-xl font-bold mb-2">Change Password</h2>
             <PasswordInput
               label="New Password"
               register={passwordForm.register}
               name="password"
-              rules={{ required: 'Required', pattern: { value: passwordRegex, message: 'Weak password' } }}
+              rules={{
+                required: 'Required',
+                pattern: { value: passwordRegex, message: 'Weak password' },
+              }}
               error={passwordForm.formState.errors.password?.message}
             />
             <PasswordInput
@@ -186,7 +248,9 @@ const SettingsPage: React.FC = () => {
               name="confirm"
               rules={{
                 required: 'Required',
-                validate: (v) => v === passwordForm.getValues('password') || 'Passwords do not match',
+                validate: (v) =>
+                  v === passwordForm.getValues('password') ||
+                  'Passwords do not match',
               }}
               error={passwordForm.formState.errors.confirm?.message}
             />
@@ -196,7 +260,10 @@ const SettingsPage: React.FC = () => {
           </form>
         )}
         {active === 'address' && (
-          <form onSubmit={addressForm.handleSubmit(submitAddress)} className="space-y-2 max-w-md">
+          <form
+            onSubmit={addressForm.handleSubmit(submitAddress)}
+            className="space-y-2 max-w-md mx-auto"
+          >
             <h2 className="text-xl font-bold mb-2">Manage Address</h2>
             <TextInput
               label="Address"
@@ -212,17 +279,48 @@ const SettingsPage: React.FC = () => {
               rules={{ required: 'Required' }}
               error={addressForm.formState.errors.city?.message}
             />
-            <SelectDropdown
+            <CountrySelect
               label="Country"
               name="country"
               control={addressForm.control}
-              options={countryOptions}
-              placeholder="Select country"
               rules={{ required: 'Required' }}
               error={addressForm.formState.errors.country?.message as string}
             />
             <button type="submit" className="btn btn-primary w-full">
               Save Address
+            </button>
+          </form>
+        )}
+        {active === 'email' && (
+          <form
+            onSubmit={emailForm.handleSubmit(submitEmailChange)}
+            className="space-y-2 max-w-md mx-auto"
+          >
+            <h2 className="text-xl font-bold mb-2">Change Email</h2>
+            <EmailInput
+              label="New Email"
+              register={emailForm.register}
+              name="email"
+              rules={{ required: 'Required' }}
+              error={emailForm.formState.errors.email?.message}
+            />
+            <div className="flex items-end gap-2">
+              <TextInput
+                label="Verification Code"
+                register={emailForm.register}
+                name="token"
+                error={emailForm.formState.errors.token?.message}
+              />
+              <button type="button" className="btn" onClick={sendCode}>
+                Send Code
+              </button>
+            </div>
+            <button
+              type="submit"
+              className="btn btn-primary w-full"
+              disabled={!codeSent}
+            >
+              Confirm
             </button>
           </form>
         )}


### PR DESCRIPTION
## Summary
- add CountrySelect form component with flags and codes
- list common countries and calling codes
- update settings page layout and add Change Email tab
- implement backend API for requesting and confirming email change

## Testing
- `npx prettier -w components/form-fields/CountrySelect.tsx pages/settings.tsx lib/users.ts pages/api/request-email-change.ts pages/api/change-email.ts data/countries.ts`
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6857ee6c4e2c832f8f4ed66e030e9719