### PR TITLE
Create About & Contact pages with header updates

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -213,6 +213,10 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
           {!isAuthRoute && (
             <SearchBar placeholder="Search for products, brands..." />
           )}
+          <nav className="hidden lg:flex gap-4 ml-4">
+            <Link href="/about">About</Link>
+            <Link href="/contact">Contact</Link>
+          </nav>
         </div>
 
         <nav className="flex items-center gap-2">

--- a/components/HomeHeader.tsx
+++ b/components/HomeHeader.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useContext, useState } from 'react';
+import { useSession } from 'next-auth/react';
 import SearchIcon from './icons/SearchIcon';
 import UserIcon from './icons/UserIcon';
 import CartIcon from './icons/CartIcon';
@@ -9,6 +10,8 @@ import { AppContext } from '../contexts/AppContext';
 
 const HomeHeader: React.FC = () => {
   const router = useRouter();
+  const { data: session } = useSession();
+  const user = session?.user as any;
   const app = useContext(AppContext);
   const cart = app?.cart ?? [];
   const [term, setTerm] = useState('');
@@ -54,9 +57,25 @@ const HomeHeader: React.FC = () => {
           >
             <SearchIcon className="w-5 h-5" />
           </button>
-          <Link href="/profile" className="btn btn-ghost">
-            <UserIcon className="w-5 h-5" />
-          </Link>
+          {user ? (
+            <Link href="/profile" className="btn btn-ghost flex items-center gap-1">
+              <UserIcon className="w-5 h-5" />
+              <span className="hidden sm:block">
+                {user.firstName || user.lastName
+                  ? `${user.firstName || ''} ${user.lastName || ''}`.trim()
+                  : user.email}
+              </span>
+            </Link>
+          ) : (
+            <>
+              <Link href="/login" className="btn btn-ghost">
+                Login
+              </Link>
+              <Link href="/signup" className="btn btn-primary">
+                Signup
+              </Link>
+            </>
+          )}
           <Link href="/cart" className="btn btn-ghost relative">
             <CartIcon className="w-5 h-5" />
             {itemCount > 0 && (

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,24 @@
+import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
+
+const AboutPage: React.FC = () => {
+  return (
+    <div className="max-w-3xl mx-auto space-y-4">
+      <Head>
+        <title>{getPageTitle('About')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">About Us</h1>
+      <p>
+        ShopVerse is a modern ecommerce marketplace bringing the best products to
+        your fingertips. This page is a placeholder showcasing where you would
+        normally describe your company history and mission.
+      </p>
+      <p>
+        Use this space to highlight your values, share your story and let your
+        customers know what makes you unique.
+      </p>
+    </div>
+  );
+};
+
+export default AboutPage;

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,76 @@
+import Head from 'next/head';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { getPageTitle } from '../lib/pageTitle';
+
+interface ContactForm {
+  name: string;
+  email: string;
+  message: string;
+}
+
+const ContactPage: React.FC = () => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ContactForm>();
+
+  const submit: SubmitHandler<ContactForm> = (data) => {
+    // TODO: send data to backend
+    console.log(data);
+    reset();
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <Head>
+        <title>{getPageTitle('Contact')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Contact Us</h1>
+      <div className="space-y-1 text-sm">
+        <p>123 Market Street, London</p>
+        <p>
+          <a href="mailto:info@shopverse.com" className="link">
+            info@shopverse.com
+          </a>
+        </p>
+        <p>+44 1234 567890</p>
+      </div>
+      <form onSubmit={handleSubmit(submit)} className="space-y-2">
+        <input
+          type="text"
+          placeholder="Your name"
+          className="input input-bordered w-full"
+          {...register('name', { required: 'Name is required' })}
+        />
+        {errors.name && (
+          <p className="text-red-500 text-sm">{errors.name.message}</p>
+        )}
+        <input
+          type="email"
+          placeholder="Your email"
+          className="input input-bordered w-full"
+          {...register('email', { required: 'Email is required' })}
+        />
+        {errors.email && (
+          <p className="text-red-500 text-sm">{errors.email.message}</p>
+        )}
+        <textarea
+          placeholder="Your message"
+          className="textarea textarea-bordered w-full"
+          rows={4}
+          {...register('message', { required: 'Message is required' })}
+        ></textarea>
+        {errors.message && (
+          <p className="text-red-500 text-sm">{errors.message.message}</p>
+        )}
+        <button type="submit" className="btn btn-primary">
+          Send Message
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ContactPage;


### PR DESCRIPTION
## Summary
- add simple About page
- add Contact page with basic form
- show About and Contact links in main header
- update HomeHeader auth logic to show login/signup or user name

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857f465ba60832fb861f74a4025df56