### PR TITLE
Implement product cards on home page and tweak UI

### DIFF
--- a/components/FeaturedProducts.tsx
+++ b/components/FeaturedProducts.tsx
@@ -1,69 +1,33 @@
-import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import ProductCard from './ProductCard';
+import type { Product } from '../types/product';
 
-interface FeaturedProduct {
-  id: number;
-  name: string;
-  price: string;
-  image: string;
-}
+const FeaturedProducts: React.FC = () => {
+  const [products, setProducts] = useState<Product[]>([]);
 
-const products: FeaturedProduct[] = [
-  {
-    id: 1,
-    name: 'Casual Shoes',
-    price: '$59.99',
-    image:
-      'https://images.unsplash.com/photo-1528701800489-20cb7128fd4c?auto=format&fit=crop&w=400&q=80',
-  },
-  {
-    id: 2,
-    name: 'Leather Tote Bag',
-    price: '$79.99',
-    image:
-      'https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=400&q=80',
-  },
-  {
-    id: 3,
-    name: 'Wireless Headphones',
-    price: '$149.99',
-    image:
-      'https://images.unsplash.com/photo-1519677100203-a0e668c92439?auto=format&fit=crop&w=400&q=80',
-  },
-  {
-    id: 4,
-    name: 'Classic Watch',
-    price: '$199.99',
-    image:
-      'https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=400&q=80',
-  },
-];
+  useEffect(() => {
+    fetch('/api/products?limit=8')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setProducts(data?.products || []))
+      .catch(() => {});
+  }, []);
 
-const FeaturedProducts: React.FC = () => (
-  <section className="py-12">
-    <div className="max-w-screen-xl mx-auto px-4">
-      <h2 className="text-2xl font-bold mb-6 text-center">Featured Products</h2>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-        {products.map((p) => (
-          <div
-            key={p.id}
-            className="border border-base-300 rounded-lg overflow-hidden text-center bg-base-100"
-          >
-            <Image
-              src={p.image}
-              alt=""
-              width={300}
-              height={300}
-              className="w-full h-48 object-cover"
-            />
-            <div className="p-4 space-y-1">
-              <h3 className="font-medium">{p.name}</h3>
-              <p className="text-primary font-semibold">{p.price}</p>
-            </div>
-          </div>
-        ))}
+  if (products.length === 0) return null;
+
+  return (
+    <section className="py-12">
+      <div className="max-w-screen-xl mx-auto px-4">
+        <h2 className="text-2xl font-bold mb-6 text-center">
+          Featured Products
+        </h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
+          {products.map((p) => (
+            <ProductCard key={p.id} product={p} className="w-full" />
+          ))}
+        </div>
       </div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};
 
 export default FeaturedProducts;

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -74,9 +74,9 @@ const Footer: FC = () => {
           </form>
         </div>
         <div className="flex items-end justify-end gap-4">
-          <VisaIcon size={32} color="#1A1F71" />
-          <MastercardIcon size={32} color="#EB001B" />
-          <PaypalIcon size={32} color="#003087" />
+          <VisaIcon size={36} className="text-blue-600" />
+          <MastercardIcon size={36} className="text-red-500" />
+          <PaypalIcon size={36} className="text-blue-500" />
         </div>
       </div>
     </footer>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -84,10 +84,10 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
   };
 
   return (
-    <header className="relative bg-base-300 mb-6">
+    <header className="relative bg-base-300 mb-6 py-4">
       <div className="w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-4 gap-y-2">
         <Link href="/" className="btn btn-ghost">
-          <Image src="/images/logo.png" alt="Logo" width={120} height={40} />
+          <Image src="/images/logo.png" alt="Logo" width={140} height={48} />
         </Link>
 
         <div className="flex-1 flex items-center gap-x-4 relative">
@@ -214,9 +214,9 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
             <SearchBar placeholder="Search for products, brands..." />
           )}
           <nav className="hidden lg:flex gap-4 ml-4">
-          <Link href="/products">Shop</Link>
-          <Link href="/about">About</Link>
-          <Link href="/contact">Contact</Link>
+            <Link href="/products">Shop</Link>
+            <Link href="/about">About</Link>
+            <Link href="/contact">Contact</Link>
           </nav>
         </div>
 


### PR DESCRIPTION
## Summary
- fetch products for the home page and render `ProductCard`
- enlarge the header and logo
- adjust payment icons with modern colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685840463e30832fbe7e82391a691e5e