### PR TITLE
Improve product detail page slider and suggestions

### DIFF
--- a/components/ProductImageSlider.tsx
+++ b/components/ProductImageSlider.tsx
@@ -46,6 +46,9 @@ export default function ProductImageSlider({
       </div>
     );
   }
+  const next = () => setIdx((idx + 1) % urls.length);
+  const prev = () => setIdx((idx - 1 + urls.length) % urls.length);
+
   return (
     <div className={`relative ${aspectRatioClass} ${className}`}>
       <Image
@@ -57,18 +60,34 @@ export default function ProductImageSlider({
         onError={() => setErrorMap((m) => ({ ...m, [idx]: true }))}
       />
       {urls.length > 1 && (
-        <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1">
-          {urls.map((_, i) => (
-            <button
-              key={i}
-              type="button"
-              onClick={() => setIdx(i)}
-              className={`w-2 h-2 rounded-full ${
-                i === idx ? 'bg-primary' : 'bg-base-300'
-              }`}
-            />
-          ))}
-        </div>
+        <>
+          <button
+            type="button"
+            onClick={prev}
+            className="absolute left-2 top-1/2 -translate-y-1/2 bg-base-100/70 rounded-full p-1"
+          >
+            <ChevronLeftIcon />
+          </button>
+          <button
+            type="button"
+            onClick={next}
+            className="absolute right-2 top-1/2 -translate-y-1/2 bg-base-100/70 rounded-full p-1"
+          >
+            <ChevronRightIcon />
+          </button>
+          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1">
+            {urls.map((_, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => setIdx(i)}
+                className={`w-2 h-2 rounded-full ${
+                  i === idx ? 'bg-primary' : 'bg-base-300'
+                }`}
+              />
+            ))}
+          </div>
+        </>
       )}
       {zoom && (
         <dialog
@@ -87,13 +106,45 @@ export default function ProductImageSlider({
             >
               ✖
             </button>
-            <Image
-              src={errorMap[idx] ? placeholderUrl : images[idx].url}
-              alt={images[idx].alt || `Image ${idx + 1}`}
-              width={800}
-              height={800}
-              className="w-full h-auto object-contain"
-            />
+            <div className="relative w-full flex items-center justify-center">
+              <Image
+                src={errorMap[idx] ? placeholderUrl : images[idx].url}
+                alt={images[idx].alt || `Image ${idx + 1}`}
+                width={800}
+                height={800}
+                className="w-full h-auto object-contain max-h-[80vh]"
+              />
+              {urls.length > 1 && (
+                <>
+                  <button
+                    type="button"
+                    onClick={prev}
+                    className="absolute left-2 top-1/2 -translate-y-1/2 bg-base-100/70 rounded-full p-1"
+                  >
+                    <ChevronLeftIcon />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={next}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 bg-base-100/70 rounded-full p-1"
+                  >
+                    <ChevronRightIcon />
+                  </button>
+                  <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1">
+                    {urls.map((_, i) => (
+                      <button
+                        key={i}
+                        type="button"
+                        onClick={() => setIdx(i)}
+                        className={`w-2 h-2 rounded-full ${
+                          i === idx ? 'bg-primary' : 'bg-base-300'
+                        }`}
+                      />
+                    ))}
+                  </div>
+                </>
+              )}
+            </div>
             <form
               method="dialog"
               className="modal-backdrop"

--- a/components/RecommendedProducts.tsx
+++ b/components/RecommendedProducts.tsx
@@ -7,24 +7,28 @@ interface RecommendedProductsProps {
   category?: string;
   excludeId?: string;
   title?: string;
+  limit?: number;
 }
 
 const RecommendedProducts: React.FC<RecommendedProductsProps> = ({
   category,
   excludeId,
-  title = 'You may also like',
+  title = 'Suggested Products',
+  limit = 5,
 }) => {
   const [products, setProducts] = useState<Product[]>([]);
 
   useEffect(() => {
     if (!category) return;
     fetch(
-      `/api/search?filterByCategory=${encodeURIComponent(category)}&perPage=10`
+      `/api/search?filterByCategory=${encodeURIComponent(category)}&perPage=${limit}`
     )
       .then((res) => (res.ok ? (res.json() as Promise<SearchResults>) : null))
       .then((data) => {
         if (data && Array.isArray(data.results)) {
-          const filtered = data.results.filter((p) => p.id !== excludeId);
+          const filtered = data.results
+            .filter((p) => p.id !== excludeId)
+            .slice(0, limit);
           setProducts(filtered);
         }
       })

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -100,7 +100,7 @@ export default function ProductDetail({
       <div className="flex flex-col md:flex-row gap-8">
         <div className="md:w-1/2 flex justify-center">
           <ProductImageSlider
-            className="w-11/12 md:w-10/12 mx-auto"
+            className="w-11/12 md:w-10/12 mx-auto max-h-80 md:max-h-96"
             images={
               product.images && product.images.length > 0
                 ? product.images
@@ -226,6 +226,7 @@ export default function ProductDetail({
         <RecommendedProducts
           category={product.category.name}
           excludeId={product.id}
+          limit={5}
         />
       )}
       <div className="mt-4">


### PR DESCRIPTION
## Summary
- enhance `ProductImageSlider` with arrow controls and full-screen modal
- limit and rename `RecommendedProducts` to show a few suggested items
- reduce image height on product detail page and show recommended list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685844dbebf0832fbed6089e9a8aaa0a