### PR TITLE
Increase product card width on products page

### DIFF
--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -399,7 +399,7 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
             ) : (
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3 sm:gap-4 lg:gap-5">
                 {items.map((p) => (
-                  <ProductCard key={p.id} product={p} />
+                  <ProductCard key={p.id} product={p} className="w-full" />
                 ))}
               </div>
             )}


### PR DESCRIPTION
## Summary
- widen `ProductCard` usage in products page so each card fills the grid cell

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68584b69fc9c832f8e714268119d3166