### PR TITLE
Fix logo display sizes

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -23,11 +23,12 @@ const Footer: FC = () => {
       <div className="w-full grid grid-cols-1 md:grid-cols-4 gap-8">
         <div>
           <Image
-            src="/images/logo.png"
+            src="/images/logo-medium.png"
             alt="Logo"
             width={120}
             height={40}
-            className="mb-2"
+            className="mb-2 max-h-10 w-auto"
+            priority
           />
           <p className="text-sm text-gray-600">
             Everything you need, all in one place.

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -87,7 +87,14 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
     <header className="relative bg-base-300 mb-6 py-4">
       <div className="w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-4 gap-y-2">
         <Link href="/" className="btn btn-ghost p-0 flex items-center">
-          <Image src="/images/logo.png" alt="Logo" width={120} height={40} />
+          <Image
+            src="/images/logo-medium.png"
+            alt="Logo"
+            width={120}
+            height={40}
+            className="max-h-10 w-auto"
+            priority
+          />
         </Link>
 
         <div className="flex-1 flex items-center gap-x-4 relative">


### PR DESCRIPTION
## Summary
- update header and footer to use the medium logo variant without committing image assets
- remove generated logo variant images from the repo

## Testing
- `npm install --silent` *(fails: prisma binaries download blocked)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68584f23510c832f921bf0bd9c1f6440