### PR TITLE
Extract filters UI into ProductFilters component

### DIFF
--- a/components/ProductFilters.tsx
+++ b/components/ProductFilters.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import type { Category } from '../types/category';
+
+interface ProductFiltersProps {
+  keyword: string;
+  setKeyword: React.Dispatch<React.SetStateAction<string>>;
+  selectedCategories: string[];
+  setSelectedCategories: React.Dispatch<React.SetStateAction<string[]>>;
+  minPrice: string;
+  setMinPrice: React.Dispatch<React.SetStateAction<string>>;
+  maxPrice: string;
+  setMaxPrice: React.Dispatch<React.SetStateAction<string>>;
+  inStock: boolean;
+  setInStock: React.Dispatch<React.SetStateAction<boolean>>;
+  categories: Category[];
+  clearAll: () => void;
+}
+
+const ProductFilters: React.FC<ProductFiltersProps> = ({
+  keyword,
+  setKeyword,
+  selectedCategories,
+  setSelectedCategories,
+  minPrice,
+  setMinPrice,
+  maxPrice,
+  setMaxPrice,
+  inStock,
+  setInStock,
+  categories,
+  clearAll,
+}) => {
+  return (
+    <form onSubmit={(e) => e.preventDefault()} className="space-y-4 sticky top-4">
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          className="checkbox checkbox-primary"
+          checked={inStock}
+          onChange={(e) => setInStock(e.target.checked)}
+        />
+        <span>In Stock Only</span>
+      </label>
+      <details open className="collapse bg-base-100 rounded-box">
+        <summary className="collapse-title font-medium">Category</summary>
+        <div className="collapse-content max-h-48 overflow-y-auto">
+          {categories.map((c) => (
+            <label key={c.slug} className="block mb-1">
+              <input
+                type="checkbox"
+                className="checkbox mr-2"
+                value={c.slug}
+                checked={selectedCategories.includes(c.slug || '')}
+                onChange={(e) => {
+                  const slug = c.slug || '';
+                  setSelectedCategories((prev) =>
+                    e.target.checked ? [...prev, slug] : prev.filter((s) => s !== slug)
+                  );
+                }}
+              />
+              {c.name}
+            </label>
+          ))}
+        </div>
+      </details>
+      <details className="collapse bg-base-100 rounded-box">
+        <summary className="collapse-title font-medium">Price Range</summary>
+        <div className="collapse-content space-y-2">
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              placeholder="Min"
+              className="input input-sm input-bordered w-full"
+              value={minPrice}
+              onChange={(e) => setMinPrice(e.target.value)}
+            />
+            <span>-</span>
+            <input
+              type="number"
+              placeholder="Max"
+              className="input input-sm input-bordered w-full"
+              value={maxPrice}
+              onChange={(e) => setMaxPrice(e.target.value)}
+            />
+          </div>
+        </div>
+      </details>
+      <details className="collapse bg-base-100 rounded-box">
+        <summary className="collapse-title font-medium">Keyword</summary>
+        <div className="collapse-content">
+          <input
+            type="text"
+            placeholder="Search name"
+            className="input input-sm input-bordered w-full"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+          />
+        </div>
+      </details>
+      <div className="flex justify-end">
+        <button type="button" className="btn btn-sm btn-ghost" onClick={clearAll}>
+          Clear All
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ProductFilters;

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useRef, useState, useContext } from 'react';
 import ProductCard from '../../components/ProductCard';
+import ProductFilters from '../../components/ProductFilters';
 import { getPageTitle } from '../../lib/pageTitle';
 import {
   getProductsPaginated,
@@ -290,93 +291,20 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
         <h1 className="text-3xl font-bold mb-4">Products</h1>
         <div className="flex flex-col md:flex-row gap-6">
           <aside className="md:w-80 w-full flex-shrink-0">
-            <form
-              onSubmit={(e) => e.preventDefault()}
-              className="space-y-4 sticky top-4"
-            >
-              <label className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  className="checkbox checkbox-primary"
-                  checked={inStock}
-                  onChange={toggleInStock}
-                />
-                <span>In Stock Only</span>
-              </label>
-              <details open className="collapse bg-base-100 rounded-box">
-                <summary className="collapse-title font-medium">
-                  Category
-                </summary>
-                <div className="collapse-content max-h-48 overflow-y-auto">
-                  {categories.map((c) => (
-                    <label key={c.slug} className="block mb-1">
-                      <input
-                        type="checkbox"
-                        className="checkbox mr-2"
-                        value={c.slug}
-                        checked={selectedCategories.includes(c.slug || '')}
-                        onChange={(e) => {
-                          const slug = c.slug || '';
-                          setSelectedCategories((prev) =>
-                            e.target.checked
-                              ? [...prev, slug]
-                              : prev.filter((s) => s !== slug)
-                          );
-                        }}
-                      />
-                      {c.name}
-                    </label>
-                  ))}
-                </div>
-              </details>
-              <details className="collapse bg-base-100 rounded-box">
-                <summary className="collapse-title font-medium">
-                  Price Range
-                </summary>
-                <div className="collapse-content space-y-2">
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="number"
-                      placeholder="Min"
-                      className="input input-sm input-bordered w-full"
-                      value={minPrice}
-                      onChange={(e) => setMinPrice(e.target.value)}
-                    />
-                    <span>-</span>
-                    <input
-                      type="number"
-                      placeholder="Max"
-                      className="input input-sm input-bordered w-full"
-                      value={maxPrice}
-                      onChange={(e) => setMaxPrice(e.target.value)}
-                    />
-                  </div>
-                </div>
-              </details>
-              <details className="collapse bg-base-100 rounded-box">
-                <summary className="collapse-title font-medium">
-                  Keyword
-                </summary>
-                <div className="collapse-content">
-                  <input
-                    type="text"
-                    placeholder="Search name"
-                    className="input input-sm input-bordered w-full"
-                    value={keyword}
-                    onChange={(e) => setKeyword(e.target.value)}
-                  />
-                </div>
-              </details>
-              <div className="flex justify-end">
-                <button
-                  type="button"
-                  className="btn btn-sm btn-ghost"
-                  onClick={clearAll}
-                >
-                  Clear All
-                </button>
-              </div>
-            </form>
+            <ProductFilters
+              keyword={keyword}
+              setKeyword={setKeyword}
+              selectedCategories={selectedCategories}
+              setSelectedCategories={setSelectedCategories}
+              minPrice={minPrice}
+              setMinPrice={setMinPrice}
+              maxPrice={maxPrice}
+              setMaxPrice={setMaxPrice}
+              inStock={inStock}
+              setInStock={setInStock}
+              categories={categories}
+              clearAll={clearAll}
+            />
           </aside>
           <div className="flex-1">
             {activeFilters.length > 0 && (


### PR DESCRIPTION
## Summary
- create `ProductFilters` component
- move filter UI out of products page
- use new component inside products listing

## Testing
- `npm run lint`
- `npm run type-check` *(fails: missing Prisma engines)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685931a96288832f88008f57adfb772c