### PR TITLE
Add shipping, privacy, and terms pages; update logo behavior

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -22,14 +22,16 @@ const Footer: FC = () => {
     <footer className="bg-base-300 mt-12 py-8 text-base-content px-4 sm:px-6 lg:px-8">
       <div className="w-full grid grid-cols-1 md:grid-cols-4 gap-8">
         <div>
-          <Image
-            src="/images/logo-medium.png"
-            alt="Logo"
-            width={120}
-            height={40}
-            className="mb-2 max-h-10 w-auto"
-            priority
-          />
+          <Link href="/">
+            <Image
+              src="/images/logo-medium.png"
+              alt="Logo"
+              width={120}
+              height={40}
+              className="mb-2 max-h-10 w-auto"
+              priority
+            />
+          </Link>
           <p className="text-sm text-gray-600">
             Everything you need, all in one place.
           </p>
@@ -50,10 +52,10 @@ const Footer: FC = () => {
               <Link href="/shipping">Shipping</Link>
             </li>
             <li>
-              <Link href="/privacy">Privacy Policy</Link>
+              <Link href="/privacy-policy">Privacy Policy</Link>
             </li>
             <li>
-              <Link href="/terms">Terms &amp; Conditions</Link>
+              <Link href="/terms-and-conditions">Terms &amp; Conditions</Link>
             </li>
           </ul>
         </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -86,7 +86,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
   return (
     <header className="relative bg-base-300 mb-6 py-4">
       <div className="w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-4 gap-y-2">
-        <Link href="/" className="btn btn-ghost p-0 flex items-center">
+        <Link href="/" className="p-0 flex items-center">
           <Image
             src="/images/logo-medium.png"
             alt="Logo"

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
+
+const PrivacyPolicyPage: React.FC = () => {
+  return (
+    <div className="max-w-3xl mx-auto space-y-4">
+      <Head>
+        <title>{getPageTitle('Privacy Policy')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Privacy Policy</h1>
+      <p>
+        This page explains how your personal data is collected, used, and
+        protected. Replace this text with your actual privacy policy.
+      </p>
+    </div>
+  );
+};
+
+export default PrivacyPolicyPage;

--- a/pages/shipping.tsx
+++ b/pages/shipping.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
+
+const ShippingPage: React.FC = () => {
+  return (
+    <div className="max-w-3xl mx-auto space-y-4">
+      <Head>
+        <title>{getPageTitle('Shipping')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Shipping</h1>
+      <p>
+        This is where your shipping information will go. It includes details on
+        delivery times, costs, and methods.
+      </p>
+    </div>
+  );
+};
+
+export default ShippingPage;

--- a/pages/terms-and-conditions.tsx
+++ b/pages/terms-and-conditions.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+import { getPageTitle } from '../lib/pageTitle';
+
+const TermsPage: React.FC = () => {
+  return (
+    <div className="max-w-3xl mx-auto space-y-4">
+      <Head>
+        <title>{getPageTitle('Terms & Conditions')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Terms &amp; Conditions</h1>
+      <p>
+        Here you can outline the rules and regulations for using your website
+        and services. Replace this text with your official terms and conditions.
+      </p>
+    </div>
+  );
+};
+
+export default TermsPage;


### PR DESCRIPTION
## Summary
- make the header logo static by removing hover styling
- link the footer logo to the home page
- update footer to link to new informational pages
- add Shipping, Privacy Policy and Terms & Conditions pages

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685976fe9634832fb0f50f94f66dea7b