### PR TITLE
Add category slider to home page

### DIFF
--- a/components/CategorySlider.module.css
+++ b/components/CategorySlider.module.css
@@ -1,0 +1,23 @@
+.slider {
+  width: 100%;
+  padding: 1rem 0;
+}
+.slide {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.imageWrapper {
+  position: relative;
+  width: 100px;
+  height: 100px;
+}
+.image {
+  border-radius: 0.5rem;
+  object-fit: cover;
+}
+.name {
+  margin-top: 0.5rem;
+  font-weight: 500;
+  text-align: center;
+}

--- a/components/CategorySlider.tsx
+++ b/components/CategorySlider.tsx
@@ -1,0 +1,61 @@
+import { FC } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { A11y } from 'swiper/modules';
+import 'swiper/css';
+
+import styles from './CategorySlider.module.css';
+
+export interface CategoryItem {
+  name: string;
+  slug?: string;
+  image?: string;
+}
+
+interface CategorySliderProps {
+  categories: CategoryItem[];
+}
+
+const placeholder = '/placeholder.png';
+
+const CategorySlider: FC<CategorySliderProps> = ({ categories }) => {
+  if (!categories || categories.length === 0) return null;
+
+  return (
+    <Swiper
+      modules={[A11y]}
+      spaceBetween={10}
+      slidesPerView={2.5}
+      breakpoints={{
+        640: { slidesPerView: 3.5 },
+        768: { slidesPerView: 4.5 },
+        1024: { slidesPerView: 5.5 },
+      }}
+      className={styles.slider}
+    >
+      {categories.map((cat) => (
+        <SwiperSlide key={cat.slug ?? cat.name} className={styles.slide}>
+          <Link
+            href={`/products?category=${encodeURIComponent(
+              cat.slug ?? cat.name
+            )}`}
+            className="block"
+          >
+            <div className={styles.imageWrapper}>
+              <Image
+                src={cat.image || placeholder}
+                alt={cat.name}
+                fill
+                className={styles.image}
+              />
+            </div>
+            <span className={styles.name}>{cat.name}</span>
+          </Link>
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
+};
+
+export default CategorySlider;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,51 @@
 import Head from 'next/head';
+import { useEffect, useState } from 'react';
 import HomeHero from '../components/HomeHero';
 import FeaturedProducts from '../components/FeaturedProducts';
 import CategoryPromotion from '../components/CategoryPromotion';
+import CategorySlider, { CategoryItem } from '../components/CategorySlider';
 import { getPageTitle } from '../lib/pageTitle';
+import DEFAULT_CATEGORIES from '../lib/defaultCategories';
+
+const categoryImages: Record<string, string> = {
+  Electronics:
+    'https://images.unsplash.com/photo-1510557880182-3b5af3a1fb0b?auto=format&fit=crop&w=400&q=80',
+  Fashion:
+    'https://images.unsplash.com/photo-1521335629791-ce4aec67dd52?auto=format&fit=crop&w=400&q=80',
+  Home:
+    'https://images.unsplash.com/photo-1505692794403-44a6e5478626?auto=format&fit=crop&w=400&q=80',
+  Toys:
+    'https://images.unsplash.com/photo-1608837010774-e0e6759e9721?auto=format&fit=crop&w=400&q=80',
+  Sports:
+    'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=400&q=80',
+};
 
 const HomePage: React.FC = () => {
+  const [categories, setCategories] = useState<CategoryItem[]>([]);
+
+  useEffect(() => {
+    fetch('/api/categories')
+      .then((res) => (res.ok ? res.json() : { categories: DEFAULT_CATEGORIES }))
+      .then((data: { categories: { name: string; slug?: string }[] } | any) => {
+        const list = Array.isArray(data) ? data : data.categories;
+        const mapped = (list || DEFAULT_CATEGORIES).map((c: any) => ({
+          name: c.name,
+          slug: c.slug,
+          image: categoryImages[c.name],
+        }));
+        setCategories(mapped);
+      })
+      .catch(() => {
+        setCategories(
+          DEFAULT_CATEGORIES.map((c) => ({
+            name: c.name,
+            slug: c.slug,
+            image: categoryImages[c.name],
+          }))
+        );
+      });
+  }, []);
+
   return (
     <div className="flex flex-col min-h-screen">
       <Head>
@@ -12,6 +53,10 @@ const HomePage: React.FC = () => {
       </Head>
       <main className="flex-1">
         <HomeHero />
+        <section className="max-w-screen-xl mx-auto px-4">
+          <h2 className="text-3xl font-bold mb-4">Shop by Category</h2>
+          <CategorySlider categories={categories} />
+        </section>
         <FeaturedProducts />
         <CategoryPromotion />
       </main>


### PR DESCRIPTION
## Summary
- add `CategorySlider` component with Swiper-based slider
- style the slider with a new CSS module
- fetch categories and display a "Shop by Category" section on the home page

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_685976ffb0e0832fa3aaa961a1564f68