### PR TITLE
Add category promotion grid

### DIFF
--- a/components/CategoryPromotion.module.css
+++ b/components/CategoryPromotion.module.css
@@ -1,0 +1,15 @@
+.grid {
+  @apply grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4;
+}
+.card {
+  @apply relative h-40 sm:h-48 rounded-lg overflow-hidden group;
+}
+.image {
+  @apply object-cover transition-transform duration-300;
+}
+.card:hover .image {
+  @apply scale-105;
+}
+.overlay {
+  @apply absolute inset-0 flex items-center justify-center bg-black bg-opacity-40 text-white font-semibold;
+}

--- a/components/CategoryPromotion.tsx
+++ b/components/CategoryPromotion.tsx
@@ -1,20 +1,46 @@
+import Image from 'next/image';
 import Link from 'next/link';
+import styles from './CategoryPromotion.module.css';
 
-const CategoryPromotion: React.FC = () => (
-  <section className="bg-primary text-primary-content py-12">
-    <div className="max-w-screen-xl mx-auto px-4 text-center">
-      <h3 className="text-2xl font-bold mb-4">Shop by Category</h3>
-      <p className="mb-6">
-        Find exactly what you need by browsing our categories.
-      </p>
-      <Link
-        href="/categories"
-        className="btn btn-outline bg-white text-primary hover:bg-white"
-      >
-        Browse Categories
-      </Link>
-    </div>
-  </section>
-);
+export interface PromotionCategory {
+  name: string;
+  slug?: string;
+  image?: string;
+}
+
+interface CategoryPromotionProps {
+  categories: PromotionCategory[];
+}
+
+const placeholder = '/placeholder.png';
+
+const CategoryPromotion: React.FC<CategoryPromotionProps> = ({ categories }) => {
+  if (!categories || categories.length === 0) return null;
+
+  return (
+    <section className="py-12">
+      <div className="max-w-screen-xl mx-auto px-4">
+        <h2 className="text-3xl font-bold mb-6 text-center">Browse Categories</h2>
+        <div className={styles.grid}>
+          {categories.map((cat) => (
+            <Link
+              key={cat.slug ?? cat.name}
+              href={`/products?category=${encodeURIComponent(cat.slug ?? cat.name)}`}
+              className={styles.card}
+            >
+              <Image
+                src={cat.image || placeholder}
+                alt={cat.name}
+                fill
+                className={styles.image}
+              />
+              <span className={styles.overlay}>{cat.name}</span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
 
 export default CategoryPromotion;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -58,7 +58,7 @@ const HomePage: React.FC = () => {
           <CategorySlider categories={categories} />
         </section>
         <FeaturedProducts />
-        <CategoryPromotion />
+        <CategoryPromotion categories={categories} />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- create new `CategoryPromotion` component to show category cards
- style category promotion grid and hover overlay
- display the component on the homepage below featured products

## Testing
- `npm install` *(fails: Command failed)*
- `npm run lint` *(fails: next not found)*
- `npm run test` *(not run due to install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68597987d2a4832fa0d69f7944684cb9