### PR TITLE
Improve filter loading UX

### DIFF
--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface LoaderProps {
+  className?: string;
+}
+
+const Loader: React.FC<LoaderProps> = ({ className = '' }) => (
+  <div className={`flex items-center justify-center w-full h-full ${className}`}>
+    <span className="loading loading-spinner" />
+  </div>
+);
+
+export default Loader;

--- a/components/ProductGrid.tsx
+++ b/components/ProductGrid.tsx
@@ -4,25 +4,19 @@ import type { Product } from '../types/product';
 
 interface ProductGridProps {
   products: Product[];
-  loading: boolean;
+  className?: string;
 }
 
-const ProductGrid: React.FC<ProductGridProps> = ({ products, loading }) => {
-  if (loading) {
-    return (
-      <div className="flex justify-center my-4">
-        <span className="loading loading-spinner" />
-      </div>
-    );
-  }
-  if (products.length === 0) {
-    return <p className="text-gray-500">No products found.</p>;
-  }
+const ProductGrid: React.FC<ProductGridProps> = ({ products, className = '' }) => {
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3 sm:gap-4 lg:gap-5">
-      {products.map((p) => (
-        <ProductCard key={p.id} product={p} className="w-full" />
-      ))}
+    <div
+      className={`min-h-[300px] grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3 sm:gap-4 lg:gap-5 ${className}`}
+    >
+      {products.length === 0 ? (
+        <p className="text-gray-500 col-span-full">No products found.</p>
+      ) : (
+        products.map((p) => <ProductCard key={p.id} product={p} className="w-full" />)
+      )}
     </div>
   );
 };

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import ProductFilters from '../../components/ProductFilters';
 import ActiveFilters from '../../components/ActiveFilters';
 import ProductGrid from '../../components/ProductGrid';
+import Loader from '../../components/Loader';
 import InfiniteLoader from '../../components/InfiniteLoader';
 import { getPageTitle } from '../../lib/pageTitle';
 import {
@@ -167,7 +168,6 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
     filterChangedRef.current = Date.now();
     debounceTimerRef.current = setTimeout(() => {
       requestedRef.current.clear();
-      setItems([]);
       setHasMore(true);
       initializingRef.current = true;
       loadProductsRef.current?.(1, 'reset');
@@ -247,7 +247,12 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
           </aside>
           <div className="flex-1">
             <ActiveFilters filters={activeFilters} clearAll={clearAll} />
-            <ProductGrid products={items} loading={loading} />
+            <div className="relative">
+              <ProductGrid products={items} />
+              {loading && (
+                <Loader className="absolute inset-0 bg-base-200/70" />
+              )}
+            </div>
             <InfiniteLoader
               onLoadMore={handleLoadMore}
               hasMore={hasMore}

--- a/types/shared.ts
+++ b/types/shared.ts
@@ -13,7 +13,7 @@ export interface ActiveFilter {
 
 export interface ProductGridProps {
   products: import('./product').Product[];
-  loading: boolean;
+  className?: string;
 }
 
 export interface InfiniteLoaderProps {


### PR DESCRIPTION
## Summary
- add reusable `Loader` component
- update `ProductGrid` to always reserve space
- overlay loader on Products page and delay clearing results
- update shared types for `ProductGrid`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68597a11bf88832f91d945b6befed851