### PR TITLE
Refactor CategoryPromotion for Tailwind compatibility

### DIFF
--- a/components/CategoryPromotion.module.css
+++ b/components/CategoryPromotion.module.css
@@ -1,14 +1,11 @@
-.grid {
-  @apply grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4;
-}
 .card {
-  @apply relative h-40 sm:h-48 rounded-lg overflow-hidden group;
+  @apply relative h-40 sm:h-48 rounded-lg overflow-hidden;
 }
 .image {
   @apply object-cover transition-transform duration-300;
 }
 .card:hover .image {
-  @apply scale-105;
+  transform: scale(1.05);
 }
 .overlay {
   @apply absolute inset-0 flex items-center justify-center bg-black bg-opacity-40 text-white font-semibold;

--- a/components/CategoryPromotion.tsx
+++ b/components/CategoryPromotion.tsx
@@ -14,19 +14,23 @@ interface CategoryPromotionProps {
 
 const placeholder = '/placeholder.png';
 
-const CategoryPromotion: React.FC<CategoryPromotionProps> = ({ categories }) => {
+const CategoryPromotion: React.FC<CategoryPromotionProps> = ({
+  categories,
+}) => {
   if (!categories || categories.length === 0) return null;
 
   return (
     <section className="py-12">
       <div className="max-w-screen-xl mx-auto px-4">
-        <h2 className="text-3xl font-bold mb-6 text-center">Browse Categories</h2>
-        <div className={styles.grid}>
+        <h2 className="text-3xl font-bold mb-6 text-center">
+          Browse Categories
+        </h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
           {categories.map((cat) => (
             <Link
               key={cat.slug ?? cat.name}
               href={`/products?category=${encodeURIComponent(cat.slug ?? cat.name)}`}
-              className={styles.card}
+              className={`${styles.card} group`}
             >
               <Image
                 src={cat.image || placeholder}


### PR DESCRIPTION
## Summary
- remove grid class from `CategoryPromotion.module.css`
- move grid layout and group class directly into JSX
- use standard CSS scale transform for hover
- keep other utility classes intact

## Testing
- `npm run lint`
- `npm test`

Some commands failed during dependency install due to blocked network requests.

------
https://chatgpt.com/codex/tasks/task_e_68597bcc0b20832f89b2caace10b57da