### PR TITLE
Add category slider inside promotion section

### DIFF
--- a/components/CategoryPromotion.tsx
+++ b/components/CategoryPromotion.tsx
@@ -1,18 +1,23 @@
 import Link from 'next/link';
+import CategorySlider, { CategoryItem } from './CategorySlider';
 
-const CategoryPromotion: React.FC = () => (
-  <section className="bg-primary text-primary-content py-12">
-    <div className="max-w-screen-xl mx-auto px-4 text-center">
-      <h3 className="text-2xl font-bold mb-4">Shop by Category</h3>
-      <p className="mb-6">
-        Find exactly what you need by browsing our categories.
-      </p>
-      <Link
-        href="/categories"
-        className="btn btn-outline bg-white text-primary hover:bg-white"
-      >
-        Browse Categories
-      </Link>
+interface CategoryPromotionProps {
+  categories: CategoryItem[];
+}
+
+const CategoryPromotion: React.FC<CategoryPromotionProps> = ({ categories }) => (
+  <section className="py-12">
+    <div className="max-w-screen-xl mx-auto px-4">
+      <h2 className="text-3xl font-bold mb-6 text-center">Browse Categories</h2>
+      <CategorySlider categories={categories} />
+      <div className="text-center mt-8">
+        <Link
+          href="/categories"
+          className="btn btn-outline bg-white text-primary hover:bg-white"
+        >
+          Browse Categories
+        </Link>
+      </div>
     </div>
   </section>
 );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -53,10 +53,6 @@ const HomePage: React.FC = () => {
       </Head>
       <main className="flex-1">
         <HomeHero />
-        <section className="max-w-screen-xl mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-4">Shop by Category</h2>
-          <CategorySlider categories={categories} />
-        </section>
         <FeaturedProducts />
         <CategoryPromotion categories={categories} />
       </main>


### PR DESCRIPTION
## Summary
- add category slider component to the CategoryPromotion section
- remove the separate slider from the home hero

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm ci` *(fails: prisma binaries blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68597f48c058832fa3302bb4564c416f