### PR TITLE
Improve category slider and header styles

### DIFF
--- a/__tests__/ThemeToggle.test.tsx
+++ b/__tests__/ThemeToggle.test.tsx
@@ -4,7 +4,7 @@ import Layout from '../components/Layout';
 import { AppContext } from '../contexts/AppContext';
 
 jest.mock('next/router', () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: jest.fn(), pathname: '/' }),
 }));
 
 jest.mock('next-auth/react', () => ({

--- a/components/CategoryCard.tsx
+++ b/components/CategoryCard.tsx
@@ -23,7 +23,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({ category }) => {
   return (
     <Link
       href={`/categories/${encodeURIComponent(category.name)}`}
-      className="group border border-base-300 rounded-xl p-4 flex flex-col items-center text-center transition-transform duration-200 hover:shadow-lg hover:-translate-y-1 hover:border-primary"
+      className="group border border-base-300 rounded-xl p-5 flex flex-col items-center text-center gap-2 transition-transform duration-200 hover:shadow-lg hover:-translate-y-1 hover:border-primary"
     >
       {iconMap[category.name] ?? <div className="w-8 h-8 mb-2" />}
       <span className="capitalize font-medium">{category.name}</span>

--- a/components/CategoryPromotion.tsx
+++ b/components/CategoryPromotion.tsx
@@ -6,9 +6,10 @@ interface CategoryPromotionProps {
 }
 
 const CategoryPromotion: React.FC<CategoryPromotionProps> = ({ categories }) => (
-  <section className="py-12">
-    <div className="max-w-screen-xl mx-auto px-4">
-      <h2 className="text-3xl font-bold mb-6 text-center">Browse Categories</h2>
+  <section className="py-12 bg-primary text-white">
+    <div className="max-w-screen-xl mx-auto px-4 text-center">
+      <h2 className="text-3xl font-bold mb-2">Browse Categories</h2>
+      <p className="mb-6">Find exactly what you need…</p>
       <CategorySlider categories={categories} />
       <div className="text-center mt-8">
         <Link

--- a/components/CategorySlider.module.css
+++ b/components/CategorySlider.module.css
@@ -6,6 +6,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding: 0.5rem;
 }
 .imageWrapper {
   position: relative;
@@ -20,4 +21,9 @@
   margin-top: 0.5rem;
   font-weight: 500;
   text-align: center;
+}
+
+.swiper-button-next,
+.swiper-button-prev {
+  color: #fff;
 }

--- a/components/CategorySlider.tsx
+++ b/components/CategorySlider.tsx
@@ -2,8 +2,9 @@ import { FC } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { A11y } from 'swiper/modules';
+import { A11y, Navigation } from 'swiper/modules';
 import 'swiper/css';
+import 'swiper/css/navigation';
 
 import styles from './CategorySlider.module.css';
 
@@ -24,8 +25,9 @@ const CategorySlider: FC<CategorySliderProps> = ({ categories }) => {
 
   return (
     <Swiper
-      modules={[A11y]}
-      spaceBetween={10}
+      modules={[Navigation, A11y]}
+      navigation
+      spaceBetween={16}
       slidesPerView={2.5}
       breakpoints={{
         640: { slidesPerView: 3.5 },

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -147,7 +147,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                           aria-expanded={hoveredCat?.name === cat.name}
                           onFocus={() => setHoveredCat(cat)}
                           onMouseEnter={() => setHoveredCat(cat)}
-                          className="w-full flex items-center gap-1 text-left font-medium text-gray-800 tracking-wide hover:text-primary transition-colors duration-200 focus:outline-none capitalize whitespace-nowrap truncate"
+                          className="w-full flex items-center gap-1 text-left font-medium text-gray-800 tracking-wide hover:text-accent transition-colors duration-200 focus:outline-none capitalize whitespace-nowrap truncate"
                         >
                           {iconMap[cat.name] || null}
                           {cat.name}
@@ -173,7 +173,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                               <Link
                                 href={`/categories/${encodeURIComponent(hoveredCat.name)}?type=${encodeURIComponent(sub)}`}
                                 role="menuitem"
-                                className="block font-medium text-gray-800 tracking-wide hover:text-primary transition-colors duration-200 whitespace-nowrap truncate"
+                                className="block font-medium text-gray-800 tracking-wide hover:text-accent transition-colors duration-200 whitespace-nowrap truncate"
                               >
                                 {sub}
                               </Link>
@@ -196,7 +196,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                   key={cat.name}
                   className="border-b border-base-200 last:border-none"
                 >
-                  <summary className="flex items-center gap-2 py-2 cursor-pointer list-none transition-colors duration-200 hover:text-primary">
+                  <summary className="flex items-center gap-2 py-2 cursor-pointer list-none transition-colors duration-200 hover:text-accent">
                     {iconMap[cat.name] || null}
                     <span className="capitalize">{cat.name}</span>
                   </summary>
@@ -206,7 +206,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                         <li key={sub} className="capitalize">
                           <Link
                             href={`/categories/${encodeURIComponent(cat.name)}?type=${encodeURIComponent(sub)}`}
-                            className="block py-1 transition-colors duration-200 hover:text-primary hover:underline"
+                            className="block py-1 transition-colors duration-200 hover:text-accent hover:underline"
                           >
                             {sub}
                           </Link>
@@ -226,19 +226,19 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
           <nav className="hidden lg:flex gap-4 ml-4">
             <Link
               href="/products"
-              className={`transition-colors duration-200 hover:text-primary hover:underline ${pathname.startsWith('/products') ? 'text-primary underline' : ''}`}
+              className={`transition-colors duration-200 hover:text-accent hover:underline ${pathname.startsWith('/products') ? 'text-accent underline font-semibold' : ''}`}
             >
               Shop
             </Link>
             <Link
               href="/about"
-              className={`transition-colors duration-200 hover:text-primary hover:underline ${pathname === '/about' ? 'text-primary underline' : ''}`}
+              className={`transition-colors duration-200 hover:text-accent hover:underline ${pathname === '/about' ? 'text-accent underline font-semibold' : ''}`}
             >
               About
             </Link>
             <Link
               href="/contact"
-              className={`transition-colors duration-200 hover:text-primary hover:underline ${pathname === '/contact' ? 'text-primary underline' : ''}`}
+              className={`transition-colors duration-200 hover:text-accent hover:underline ${pathname === '/contact' ? 'text-accent underline font-semibold' : ''}`}
             >
               Contact
             </Link>
@@ -248,7 +248,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
         <nav className="flex items-center gap-2">
           <Link
             href="/cart"
-            className="relative p-2 transition-colors duration-200 hover:text-primary"
+            className="relative p-2 transition-colors duration-200 hover:text-accent"
           >
             <CartIcon className="w-5 h-5" />
             {itemCount > 0 && (
@@ -297,7 +297,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                 <li>
                   <Link
                     href="/orders"
-                    className="transition-colors duration-200 hover:text-primary"
+                    className="transition-colors duration-200 hover:text-accent"
                   >
                     My Orders
                   </Link>
@@ -305,7 +305,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                 <li>
                   <Link
                     href="/profile"
-                    className="transition-colors duration-200 hover:text-primary"
+                    className="transition-colors duration-200 hover:text-accent"
                   >
                     Profile
                   </Link>
@@ -313,7 +313,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                 <li>
                   <Link
                     href="/profile/edit"
-                    className="transition-colors duration-200 hover:text-primary"
+                    className="transition-colors duration-200 hover:text-accent"
                   >
                     Update Profile
                   </Link>
@@ -321,7 +321,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                 <li>
                   <Link
                     href="/settings"
-                    className="transition-colors duration-200 hover:text-primary"
+                    className="transition-colors duration-200 hover:text-accent"
                   >
                     Settings
                   </Link>
@@ -329,7 +329,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                 <li>
                   <button
                     onClick={logout}
-                    className="transition-colors duration-200 hover:text-primary"
+                    className="transition-colors duration-200 hover:text-accent"
                   >
                     Logout
                   </button>


### PR DESCRIPTION
## Summary
- refine header link hover and active states
- style category promotion section with white text
- add navigation to category slider
- tweak category card spacing
- fix tests to include pathname in router mock

## Testing
- `npx next lint`
- `npm test`
- `npm run type-check` *(fails: CountrySelect types, lib/products ProductWhereInput, pages/index slug)*

------
https://chatgpt.com/codex/tasks/task_e_68598f77d5d8832f86dc4fa6f6e1065f