### PR TITLE
Improve category cards visuals

### DIFF
--- a/components/CategoryCard.tsx
+++ b/components/CategoryCard.tsx
@@ -1,32 +1,34 @@
 import React from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import type { Category } from '../types';
-import ElectronicsIcon from './icons/ElectronicsIcon';
-import FashionIcon from './icons/FashionIcon';
-import HomeIcon from './icons/HomeIcon';
-import ToysIcon from './icons/ToysIcon';
-import SportsIcon from './icons/SportsIcon';
+import CATEGORY_IMAGES from '../lib/categoryImages';
 
 interface CategoryCardProps {
   category: Category;
 }
 
-const iconMap: Record<string, JSX.Element> = {
-  Electronics: <ElectronicsIcon className="w-8 h-8 mb-2" />,
-  Fashion: <FashionIcon className="w-8 h-8 mb-2" />,
-  Home: <HomeIcon className="w-8 h-8 mb-2" />,
-  Toys: <ToysIcon className="w-8 h-8 mb-2" />,
-  Sports: <SportsIcon className="w-8 h-8 mb-2" />,
-};
+const placeholder = '/placeholder.png';
 
 const CategoryCard: React.FC<CategoryCardProps> = ({ category }) => {
   return (
     <Link
       href={`/categories/${encodeURIComponent(category.name)}`}
-      className="group border border-base-300 rounded-xl p-5 flex flex-col items-center text-center gap-2 transition-transform duration-200 hover:shadow-lg hover:-translate-y-1 hover:border-primary"
+      className="group block border border-base-300 rounded-xl overflow-hidden shadow-sm transition-transform duration-200 hover:shadow-lg hover:-translate-y-1"
     >
-      {iconMap[category.name] ?? <div className="w-8 h-8 mb-2" />}
-      <span className="capitalize font-medium">{category.name}</span>
+      <div className="relative w-full aspect-square bg-base-200">
+        <Image
+          src={CATEGORY_IMAGES[category.name] || placeholder}
+          alt={category.name}
+          fill
+          className="object-cover"
+        />
+      </div>
+      <div className="p-3 h-14 flex items-center justify-center">
+        <span className="font-medium text-center line-clamp-2">
+          {category.name}
+        </span>
+      </div>
     </Link>
   );
 };

--- a/lib/categoryImages.ts
+++ b/lib/categoryImages.ts
@@ -1,0 +1,14 @@
+export const CATEGORY_IMAGES: Record<string, string> = {
+  Electronics:
+    'https://images.unsplash.com/photo-1510557880182-3b5af3a1fb0b?auto=format&fit=crop&w=400&q=80',
+  Fashion:
+    'https://images.unsplash.com/photo-1521335629791-ce4aec67dd52?auto=format&fit=crop&w=400&q=80',
+  Home:
+    'https://images.unsplash.com/photo-1505692794403-44a6e5478626?auto=format&fit=crop&w=400&q=80',
+  Toys:
+    'https://images.unsplash.com/photo-1608837010774-e0e6759e9721?auto=format&fit=crop&w=400&q=80',
+  Sports:
+    'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=400&q=80',
+};
+
+export default CATEGORY_IMAGES;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,19 +6,7 @@ import CategoryPromotion from '../components/CategoryPromotion';
 import CategorySlider, { CategoryItem } from '../components/CategorySlider';
 import { getPageTitle } from '../lib/pageTitle';
 import DEFAULT_CATEGORIES from '../lib/defaultCategories';
-
-const categoryImages: Record<string, string> = {
-  Electronics:
-    'https://images.unsplash.com/photo-1510557880182-3b5af3a1fb0b?auto=format&fit=crop&w=400&q=80',
-  Fashion:
-    'https://images.unsplash.com/photo-1521335629791-ce4aec67dd52?auto=format&fit=crop&w=400&q=80',
-  Home:
-    'https://images.unsplash.com/photo-1505692794403-44a6e5478626?auto=format&fit=crop&w=400&q=80',
-  Toys:
-    'https://images.unsplash.com/photo-1608837010774-e0e6759e9721?auto=format&fit=crop&w=400&q=80',
-  Sports:
-    'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=400&q=80',
-};
+import CATEGORY_IMAGES from '../lib/categoryImages';
 
 const HomePage: React.FC = () => {
   const [categories, setCategories] = useState<CategoryItem[]>([]);
@@ -31,7 +19,7 @@ const HomePage: React.FC = () => {
         const mapped = (list || DEFAULT_CATEGORIES).map((c: any) => ({
           name: c.name,
           slug: c.slug,
-          image: categoryImages[c.name],
+          image: CATEGORY_IMAGES[c.name],
         }));
         setCategories(mapped);
       })
@@ -40,7 +28,7 @@ const HomePage: React.FC = () => {
           DEFAULT_CATEGORIES.map((c) => ({
             name: c.name,
             slug: c.slug,
-            image: categoryImages[c.name],
+            image: CATEGORY_IMAGES[c.name],
           }))
         );
       });


### PR DESCRIPTION
## Summary
- refresh `CategoryCard` to use images instead of icons
- centralize category placeholder images
- reference new images in the home page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685994dea9c8832fadaa3695587bf1c8