### PR TITLE
Add coupon management

### DIFF
--- a/__tests__/coupon.api.test.ts
+++ b/__tests__/coupon.api.test.ts
@@ -1,0 +1,41 @@
+import handler from '../pages/api/coupons/[code]';
+import { findCouponByCode } from '../lib/coupons';
+
+jest.mock('../lib/coupons', () => ({
+  findCouponByCode: jest.fn(),
+}));
+
+test('returns coupon data', async () => {
+  (findCouponByCode as jest.Mock).mockResolvedValue({
+    id: 1,
+    code: 'SAVE',
+    discountType: 'percent',
+    amount: 10,
+    isActive: true,
+    usedCount: 0,
+  });
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const req = { method: 'GET', query: { code: 'SAVE' } } as any;
+  const res = { status } as any;
+  await handler(req, res);
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({
+    id: 1,
+    code: 'SAVE',
+    discountType: 'percent',
+    amount: 10,
+    isActive: true,
+    usedCount: 0,
+  });
+});
+
+test('invalid code', async () => {
+  (findCouponByCode as jest.Mock).mockResolvedValue(null);
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const req = { method: 'GET', query: { code: 'BAD' } } as any;
+  const res = { status } as any;
+  await handler(req, res);
+  expect(status).toHaveBeenCalledWith(404);
+});

--- a/lib/coupons.ts
+++ b/lib/coupons.ts
@@ -1,0 +1,37 @@
+import { getDb } from './db';
+import type { Prisma } from '@prisma/client';
+
+const prisma = getDb();
+
+export function findCouponByCode(code: string) {
+  return prisma.coupon.findFirst({ where: { code: code.toUpperCase() } });
+}
+
+export function listCoupons() {
+  return prisma.coupon.findMany({ orderBy: { createdAt: 'desc' } });
+}
+
+export function createCoupon(data: Prisma.CouponCreateInput) {
+  return prisma.coupon.create({ data });
+}
+
+export function updateCoupon(id: number, data: Prisma.CouponUpdateInput) {
+  return prisma.coupon.update({ where: { id }, data });
+}
+
+export function incrementUsage(id: number) {
+  return prisma.coupon.update({
+    where: { id },
+    data: { usedCount: { increment: 1 } },
+  });
+}
+
+export function recordUsage(couponId: number, userId: number) {
+  return prisma.couponUsage.create({ data: { couponId, userId } });
+}
+
+export function hasUserUsedCoupon(couponId: number, userId: number) {
+  return prisma.couponUsage.findUnique({
+    where: { couponId_userId: { couponId, userId } },
+  });
+}

--- a/pages/admin/coupons.tsx
+++ b/pages/admin/coupons.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState, useContext, ChangeEvent } from 'react';
+import Head from 'next/head';
+import { AppContext } from '../../contexts/AppContext';
+import { TextInput } from '../../components/form-fields';
+import type { Coupon } from '../../types';
+import { getPageTitle } from '../../lib/pageTitle';
+
+export default function AdminCoupons() {
+  const { user } = useContext(AppContext)!;
+  const [coupons, setCoupons] = useState<Coupon[]>([]);
+  const [form, setForm] = useState<Partial<Coupon>>({
+    code: '',
+    discountType: 'percent',
+    amount: 0,
+  });
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [message, setMessage] = useState('');
+
+  const fetchCoupons = () => {
+    fetch('/api/admin/coupons')
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data: Coupon[]) => setCoupons(data))
+      .catch(() => setCoupons([]));
+  };
+
+  useEffect(() => {
+    if (user) fetchCoupons();
+  }, [user]);
+
+  const submit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const method = editingId ? 'PUT' : 'POST';
+    const body = { ...form, id: editingId ?? undefined };
+    const res = await fetch('/api/admin/coupons', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (res.ok) {
+      setMessage(editingId ? 'Coupon updated' : 'Coupon created');
+      setForm({ code: '', discountType: 'percent', amount: 0 });
+      setEditingId(null);
+      fetchCoupons();
+    } else {
+      setMessage('Error saving coupon');
+    }
+  };
+
+  if (!user) return <div className="p-4">Please log in.</div>;
+  if (user.role !== 'super-admin')
+    return <div className="p-4">Admin access required.</div>;
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Manage Coupons')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Coupons</h1>
+      {message && <div className="mb-2 text-green-600">{message}</div>}
+      <form onSubmit={submit} className="space-y-2 max-w-md">
+        <TextInput
+          name="code"
+          value={form.code}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setForm((f) => ({ ...f, code: e.target.value }))
+          }
+          placeholder="CODE"
+        />
+        <select
+          className="select select-bordered w-full"
+          value={form.discountType}
+          onChange={(e) =>
+            setForm((f) => ({
+              ...f,
+              discountType: e.target.value as 'percent' | 'amount',
+            }))
+          }
+        >
+          <option value="percent">Percent</option>
+          <option value="amount">Amount</option>
+        </select>
+        <TextInput
+          name="amount"
+          type="number"
+          value={String(form.amount)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setForm((f) => ({ ...f, amount: parseFloat(e.target.value) }))
+          }
+          placeholder="Amount"
+        />
+        <TextInput
+          name="expirationDate"
+          type="date"
+          value={form.expirationDate?.slice(0, 10) || ''}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setForm((f) => ({ ...f, expirationDate: e.target.value }))
+          }
+        />
+        <TextInput
+          name="usageLimit"
+          type="number"
+          value={form.usageLimit ? String(form.usageLimit) : ''}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setForm((f) => ({ ...f, usageLimit: parseInt(e.target.value, 10) }))
+          }
+          placeholder="Usage Limit"
+        />
+        <div className="flex gap-2">
+          {editingId && (
+            <button
+              type="button"
+              className="btn"
+              onClick={() => {
+                setEditingId(null);
+                setForm({ code: '', discountType: 'percent', amount: 0 });
+              }}
+            >
+              Cancel
+            </button>
+          )}
+          <button className="btn btn-primary" type="submit">
+            {editingId ? 'Update' : 'Create'} Coupon
+          </button>
+        </div>
+      </form>
+      <h2 className="text-xl font-semibold mt-6 mb-2">Existing Coupons</h2>
+      <table className="table w-full">
+        <thead>
+          <tr>
+            <th>Code</th>
+            <th>Type</th>
+            <th>Amount</th>
+            <th>Used</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {coupons.map((c) => (
+            <tr key={c.id} className="hover">
+              <td>{c.code}</td>
+              <td>{c.discountType}</td>
+              <td>{c.amount}</td>
+              <td>{c.usedCount}</td>
+              <td>
+                <button
+                  className="btn btn-sm mr-2"
+                  onClick={() => {
+                    setEditingId(Number(c.id));
+                    setForm({
+                      code: c.code,
+                      discountType: c.discountType,
+                      amount: c.amount,
+                      expirationDate: c.expirationDate,
+                      usageLimit: c.usageLimit,
+                    });
+                  }}
+                >
+                  Edit
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/pages/api/admin/coupons.ts
+++ b/pages/api/admin/coupons.ts
@@ -1,0 +1,61 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { createCoupon, listCoupons, updateCoupon } from '../../../lib/coupons';
+import type { Coupon, ApiMessage } from '../../../types';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Coupon[] | ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method === 'GET') {
+      const rows = await listCoupons();
+      res.status(200).json(rows as unknown as Coupon[]);
+      return;
+    }
+
+    if (req.method === 'POST') {
+      const { code, discountType, amount, expirationDate, usageLimit } =
+        req.body as Partial<Coupon>;
+      if (!code || !discountType || amount === undefined) {
+        res
+          .status(400)
+          .json({ message: 'code, discountType and amount required' });
+        return;
+      }
+      await createCoupon({
+        code: code.toUpperCase(),
+        discountType,
+        amount,
+        expirationDate: expirationDate ? new Date(expirationDate) : undefined,
+        usageLimit: usageLimit ?? null,
+      });
+      res.status(201).json({ message: 'coupon created' });
+      return;
+    }
+
+    if (req.method === 'PUT') {
+      const { id, ...rest } = req.body as Coupon;
+      if (!id) {
+        res.status(400).json({ message: 'id required' });
+        return;
+      }
+      await updateCoupon(Number(id), {
+        ...rest,
+        code: rest.code?.toUpperCase(),
+        expirationDate: rest.expirationDate
+          ? new Date(rest.expirationDate)
+          : undefined,
+      });
+      res.status(200).json({ message: 'coupon updated' });
+      return;
+    }
+
+    res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    handleApiError(res, error, 'Failed to manage coupons');
+  }
+}
+
+export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/coupons/[code].ts
+++ b/pages/api/coupons/[code].ts
@@ -1,41 +1,26 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { findCouponByCode } from '../../../lib/coupons';
 import type { Coupon, ApiMessage } from '../../../types';
 
-const coupons: Record<string, Coupon> = {
-  SAVE10: {
-    id: '1',
-    code: 'SAVE10',
-    discountType: 'percent',
-    value: 10,
-    expiresAt: '2099-12-31T23:59:59Z',
-    minOrderAmount: 0,
-    usageLimit: 100,
-    createdAt: new Date('2023-01-01T00:00:00Z'),
-  },
-  SAVE20: {
-    id: '2',
-    code: 'SAVE20',
-    discountType: 'percent',
-    value: 20,
-    expiresAt: '2099-12-31T23:59:59Z',
-    minOrderAmount: 0,
-    usageLimit: 100,
-    createdAt: new Date('2023-01-01T00:00:00Z'),
-  },
-};
-
-export default function handler(
+export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Coupon | ApiMessage>
-): void {
+): Promise<void> {
   try {
-  const code = getQueryParam(req.query.code);
-  const coupon = code ? coupons[code.toUpperCase()] : undefined;
-    if (!coupon) return res.status(404).json({ message: 'Invalid code' });
-    res.status(200).json(coupon);
+    const code = getQueryParam(req.query.code);
+    if (!code) {
+      res.status(400).json({ message: 'code required' });
+      return;
+    }
+    const coupon = await findCouponByCode(String(code));
+    if (!coupon) {
+      res.status(404).json({ message: 'Invalid code' });
+      return;
+    }
+    res.status(200).json(coupon as unknown as Coupon);
   } catch (error) {
-    return handleApiError(res, error, 'Failed to validate coupon');
+    handleApiError(res, error, 'Failed to validate coupon');
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,3 +126,28 @@ model SearchLog {
 
   user      User?     @relation(fields: [userId], references: [id], onDelete: SetNull)
 }
+
+model Coupon {
+  id            Int       @id @default(autoincrement())
+  code          String    @unique
+  discountType  String
+  amount        Float
+  expirationDate DateTime?
+  usageLimit    Int?
+  usedCount     Int       @default(0)
+  isActive      Boolean   @default(true)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+}
+
+model CouponUsage {
+  id        Int      @id @default(autoincrement())
+  couponId  Int
+  userId    Int
+  createdAt DateTime @default(now())
+
+  coupon Coupon @relation(fields: [couponId], references: [id])
+  user   User   @relation(fields: [userId], references: [id])
+
+  @@unique([couponId, userId])
+}

--- a/types/coupon.ts
+++ b/types/coupon.ts
@@ -1,11 +1,12 @@
 export interface Coupon {
   id?: string | number;
-  uuid?: string;
   code: string;
   discountType: 'percent' | 'amount';
-  value: number;
-  expiresAt?: string;
-  minOrderAmount?: number;
+  amount: number;
+  expirationDate?: string;
   usageLimit?: number;
+  usedCount?: number;
+  isActive?: boolean;
   createdAt?: Date;
+  updatedAt?: Date;
 }


### PR DESCRIPTION
## Summary
- add Coupon and CouponUsage models in Prisma schema
- add coupon management API and admin page
- implement coupon utilities for database access
- update coupon API to fetch from DB
- add unit tests for the coupon API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c36030218832f9c3c4f7fc7062924