### PR TITLE
Fix profile auth redirect

### DIFF
--- a/__tests__/profile.ssr.test.ts
+++ b/__tests__/profile.ssr.test.ts
@@ -1,0 +1,25 @@
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('../pages/api/auth/[...nextauth]', () => ({ authOptions: {} }));
+
+import { getServerSideProps } from '../pages/profile';
+import { getServerSession } from 'next-auth/next';
+
+const mockedGetServerSession = getServerSession as jest.Mock;
+
+describe('profile getServerSideProps', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects to login when unauthenticated', async () => {
+    mockedGetServerSession.mockResolvedValueOnce(null);
+    const result = (await getServerSideProps({ req: {}, res: {} } as any)) as any;
+    expect(result).toEqual({ redirect: { destination: '/login', permanent: false } });
+  });
+
+  it('returns props when authenticated', async () => {
+    mockedGetServerSession.mockResolvedValueOnce({ user: { email: 'a@a.com' } });
+    const result = (await getServerSideProps({ req: {}, res: {} } as any)) as any;
+    expect(result).toEqual({ props: {} });
+  });
+});

--- a/__tests__/useRequireAuth.test.tsx
+++ b/__tests__/useRequireAuth.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import useRequireAuth from '../hooks/useRequireAuth';
+import { AppContext } from '../contexts/AppContext';
+import { useRouter } from 'next/router';
+import { useSession } from 'next-auth/react';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('next-auth/react');
+
+const TestComp = () => {
+  useRequireAuth();
+  return <div>test</div>;
+};
+
+const renderWithContext = (value: any) =>
+  render(<AppContext.Provider value={value}><TestComp /></AppContext.Provider>);
+
+const mockedUseRouter = useRouter as jest.Mock;
+const mockedUseSession = useSession as jest.Mock;
+
+describe('useRequireAuth', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not redirect while loading', () => {
+    mockedUseSession.mockReturnValue({ data: null, status: 'loading' });
+    const replace = jest.fn();
+    mockedUseRouter.mockReturnValue({ replace });
+    renderWithContext({ user: null });
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('redirects when unauthenticated', () => {
+    mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+    const replace = jest.fn();
+    mockedUseRouter.mockReturnValue({ replace });
+    renderWithContext({ user: null });
+    expect(replace).toHaveBeenCalledWith('/login');
+  });
+
+  it('does not redirect when authenticated', () => {
+    mockedUseSession.mockReturnValue({ data: { user: { email: 'a' } }, status: 'authenticated' });
+    const replace = jest.fn();
+    mockedUseRouter.mockReturnValue({ replace });
+    renderWithContext({ user: { email: 'a' } });
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/hooks/useRequireAuth.ts
+++ b/hooks/useRequireAuth.ts
@@ -1,16 +1,19 @@
 import { useRouter } from 'next/router';
 import { useContext, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
 import { AppContext } from '../contexts/AppContext';
 import type { User } from '../types/user';
 
 export default function useRequireAuth() {
   const { user } = useContext(AppContext) as { user: User | null };
+  const { data: session, status } = useSession();
   const router = useRouter();
   useEffect(() => {
-    if (user === null) {
+    if (status === 'loading') return;
+    if (!session) {
       router.replace('/login');
     }
-  }, [user, router]);
+  }, [status, session, router]);
   return user;
 }
 

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState } from 'react';
 import useRequireAuth from '../hooks/useRequireAuth';
 import { getPageTitle } from '../lib/pageTitle';
 import type { User } from '../types/user';
+import type { GetServerSideProps } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './api/auth/[...nextauth]';
 
 const Profile: React.FC = () => {
   const user = useRequireAuth();
@@ -134,3 +137,17 @@ const Profile: React.FC = () => {
   );
 };
 export default Profile;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getServerSession(
+    context.req,
+    context.res,
+    authOptions
+  );
+  if (!session?.user) {
+    return {
+      redirect: { destination: '/login', permanent: false },
+    };
+  }
+  return { props: {} };
+};


### PR DESCRIPTION
## Summary
- prevent redirect during session loading in useRequireAuth
- validate auth server-side for profile page
- add tests for auth hook and profile SSR

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_685c37f6e8c4832f8edbbee93856d045