### PR TITLE
Add coupon usage back-relations

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   orders            Order[]
   deletionRequests  DeletionRequest[] @relation("BrandDeletionRequests")
   searchLogs        SearchLog[]
+  couponUsages      CouponUsage[]
 }
 
 model Category {
@@ -138,6 +139,7 @@ model Coupon {
   isActive      Boolean   @default(true)
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
+  usages        CouponUsage[]
 }
 
 model CouponUsage {


### PR DESCRIPTION
## Summary
- add `couponUsages` relation on `User` model
- add `usages` relation on `Coupon` model

## Testing
- `npx prisma format` *(fails: Failed to fetch sha256 checksum)*
- `npx prisma generate` *(fails: Failed to fetch sha256 checksum)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3963f94c832fa1a573911f86fc71