### PR TITLE
Refactor country selector

### DIFF
--- a/components/form-fields/CountrySelect.tsx
+++ b/components/form-fields/CountrySelect.tsx
@@ -10,14 +10,26 @@ import Select from 'react-select';
 import Flag from 'react-world-flags';
 import countries, { CountryInfo } from '../../data/countries';
 
-interface CountrySelectProps<T extends FieldValues> {
+type FormProps<T extends FieldValues> = {
   name: Path<T>;
-  label?: string;
   control: Control<T>;
   rules?: RegisterOptions<T, Path<T>>;
+};
+
+type StandaloneProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export interface CountrySelectBase {
+  label?: string;
   error?: string;
   className?: string;
 }
+
+type CountrySelectProps<T extends FieldValues> =
+  | (CountrySelectBase & FormProps<T>)
+  | (CountrySelectBase & StandaloneProps);
 
 const formatOptionLabel = (option: CountryInfo) => (
   <div className="flex items-center gap-2">
@@ -28,15 +40,28 @@ const formatOptionLabel = (option: CountryInfo) => (
   </div>
 );
 
-const CountrySelect = <T extends FieldValues>({
-  name,
-  label,
-  control,
-  rules,
-  error,
-  className = '',
-}: CountrySelectProps<T>) => {
-  const inputId = String(name);
+const CountrySelect = <T extends FieldValues>(
+  props: CountrySelectProps<T>
+) => {
+  const { label, error, className = '' } = props;
+  const inputId =
+    'name' in props && props.name
+      ? String(props.name)
+      : 'country-select';
+
+  const select = (fieldProps: any) => (
+    <Select
+      inputId={inputId}
+      {...fieldProps}
+      options={countries}
+      placeholder="Select country"
+      isSearchable
+      className={`w-full ${className}`}
+      classNamePrefix="react-select"
+      formatOptionLabel={formatOptionLabel}
+    />
+  );
+
   return (
     <div className="mb-4 w-full">
       {label && (
@@ -47,23 +72,20 @@ const CountrySelect = <T extends FieldValues>({
           {label}
         </label>
       )}
-      <Controller
-        name={name}
-        control={control}
-        rules={rules}
-        render={({ field }) => (
-          <Select
-            inputId={inputId}
-            {...field}
-            options={countries}
-            placeholder="Select country"
-            isSearchable
-            className={`w-full ${className}`}
-            classNamePrefix="react-select"
-            formatOptionLabel={formatOptionLabel}
-          />
-        )}
-      />
+      {'control' in props ? (
+        <Controller
+          name={props.name}
+          control={props.control}
+          rules={props.rules}
+          render={({ field }) => select(field)}
+        />
+      ) : (
+        select({
+          value: countries.find((c) => c.value === props.value),
+          onChange: (option: CountryInfo | null) =>
+            props.onChange(option ? option.value : ''),
+        })
+      )}
       {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
     </div>
   );

--- a/pages/brand/profile.tsx
+++ b/pages/brand/profile.tsx
@@ -8,7 +8,7 @@ import React, {
 import { useRouter } from 'next/router';
 import { AppContext } from '../../contexts/AppContext';
 import type { User, Vendor } from '../../types';
-import { TextInput, Textarea } from '../../components/form-fields';
+import { TextInput, Textarea, CountrySelect } from '../../components/form-fields';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
 
@@ -130,13 +130,9 @@ export const BrandProfile: React.FC = () => {
           }
           placeholder="City"
         />
-        <TextInput
-          name="country"
+        <CountrySelect
           value={country}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            setCountry(e.target.value)
-          }
-          placeholder="Country"
+          onChange={(val) => setCountry(val)}
         />
         <TextInput
           name="website"

--- a/pages/profile/edit.tsx
+++ b/pages/profile/edit.tsx
@@ -7,6 +7,7 @@ import {
   EmailInput,
   PasswordInput,
   TextInput,
+  CountrySelect,
 } from '../../components/form-fields';
 import type { User } from '../../types/user';
 
@@ -28,6 +29,7 @@ const EditProfile: React.FC = () => {
   const {
     register,
     handleSubmit,
+    control,
     formState: { errors },
     reset,
   } = useForm<FormValues>({
@@ -141,11 +143,11 @@ const EditProfile: React.FC = () => {
             register={register}
             error={errors.city?.message}
           />
-          <TextInput<FormValues>
+          <CountrySelect<FormValues>
             label="Country"
             name="country"
-            register={register}
-            error={errors.country?.message}
+            control={control}
+            error={errors.country?.message as string}
           />
         </div>
         <PasswordInput<FormValues>

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
+import { CountrySelect } from '../../components/form-fields';
 import { useRouter } from 'next/router';
 import { AppContext } from '../../contexts/AppContext';
 import type { User } from '../../types/user';
@@ -21,6 +22,7 @@ export const UserProfile: React.FC = () => {
   const {
     register,
     handleSubmit,
+    control,
     reset,
     formState: { errors },
   } = useForm<ProfileForm>({
@@ -102,10 +104,9 @@ export const UserProfile: React.FC = () => {
           placeholder="City"
           {...register('city')}
         />
-        <input
-          className="input input-bordered w-full"
-          placeholder="Country"
-          {...register('country')}
+        <CountrySelect<ProfileForm>
+          name="country"
+          control={control}
         />
         <button className="btn btn-primary w-full" type="submit">
           Update


### PR DESCRIPTION
## Summary
- update CountrySelect to support form and standalone usage
- replace country inputs with CountrySelect on brand and user profile pages
- use CountrySelect on profile edit form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c3cdb5ad8832fb31efdefe4960e7c