### PR TITLE
Improve brand add product form

### DIFF
--- a/components/form-fields/TextInput.tsx
+++ b/components/form-fields/TextInput.tsx
@@ -24,9 +24,7 @@ export interface TextInputProps<T extends FieldValues>
   rules?: RegisterOptions<T, Path<T>>;
 }
 
-const TextInput = <T extends FieldValues>(
-  props: TextInputProps<T>
-) => {
+const TextInput = <T extends FieldValues>(props: TextInputProps<T>) => {
   const {
     label,
     name,
@@ -85,7 +83,11 @@ const TextInput = <T extends FieldValues>(
           </span>
         )}
       </div>
-      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+      {error && (
+        <p role="alert" className="text-sm text-red-600 mt-1">
+          {error}
+        </p>
+      )}
     </div>
   );
 };

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -32,9 +32,27 @@ const emptyForm: ProductForm = {
   currency: 'USD',
 };
 
+const labels: Record<keyof ProductForm, string> = {
+  id: 'ID',
+  sku: 'SKU',
+  title: 'Title',
+  vendor: 'Vendor',
+  description: 'Description',
+  productType: 'Product Type',
+  tags: 'Tags',
+  category: 'Category',
+  quantity: 'Quantity',
+  minPrice: 'Min Price',
+  maxPrice: 'Max Price',
+  currency: 'Currency',
+};
+
 const BrandDashboard: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
   const [form, setForm] = useState<ProductForm>(emptyForm);
+  const [errors, setErrors] = useState<
+    Partial<Record<keyof ProductForm, string>>
+  >({});
   const [products, setProducts] = useState<ProductApi[]>([]);
   const [lowStock, setLowStock] = useState<ProductApi[]>([]);
   const [message, setMessage] = useState<string>('');
@@ -62,6 +80,7 @@ const BrandDashboard: React.FC = () => {
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
+    setErrors((prev) => ({ ...prev, [name]: undefined }));
     setForm((prev) => {
       if (name === 'vendor') {
         return {
@@ -75,18 +94,34 @@ const BrandDashboard: React.FC = () => {
           category: { ...(prev.category || { slug: '' }), name: value },
         };
       }
-      return {
-        ...prev,
-        [name]:
-          name === 'quantity' || name === 'minPrice' || name === 'maxPrice'
-            ? Number(value)
-            : value,
-      };
+      if (name === 'quantity' || name === 'minPrice' || name === 'maxPrice') {
+        const num = Number(value);
+        return { ...prev, [name]: num < 0 ? 0 : num };
+      }
+      return { ...prev, [name]: value };
     });
+    if (name === 'quantity' || name === 'minPrice' || name === 'maxPrice') {
+      const num = Number(value);
+      if (num < 0) {
+        setErrors((prev) => ({
+          ...prev,
+          [name]: 'Value must be non-negative',
+        }));
+      }
+    }
   };
 
   const submit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const newErrors: Partial<Record<keyof ProductForm, string>> = {};
+    ['quantity', 'minPrice', 'maxPrice'].forEach((f) => {
+      const val = (form as any)[f];
+      if (typeof val === 'number' && val < 0) {
+        newErrors[f as keyof ProductForm] = 'Value must be non-negative';
+      }
+    });
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) return;
     const payload = editingId ? { ...form, id: editingId } : form;
     const url = editingId
       ? `/api/brand/products/${editingId}`
@@ -180,81 +215,92 @@ const BrandDashboard: React.FC = () => {
         </div>
       )}
       {message && <div className="mb-4 text-green-600">{message}</div>}
-      <form onSubmit={submit} className="space-y-2 mb-6">
-        {(
-          [
-            'id',
-            'sku',
-            'title',
-            'vendor',
-            'description',
-            'productType',
-            'tags',
-            'category',
-            'quantity',
-            'minPrice',
-            'maxPrice',
-            'currency',
-          ] as (keyof ProductForm)[]
-        ).map((field) => (
-          <TextInput
-            key={field}
-            name={field as keyof ProductForm}
-            value={
-              field === 'vendor'
-                ? form.vendor?.brandName || ''
-                : field === 'category'
-                  ? form.category?.name || ''
-                  : (form as any)[field]
-            }
-            onChange={handleChange as any}
-            placeholder={field}
-            type={
-              field === 'quantity' ||
-              field === 'minPrice' ||
-              field === 'maxPrice'
-                ? 'number'
-                : 'text'
-            }
-          />
-        ))}
-        <div className="flex gap-2">
-          {editingId && (
-            <button type="button" onClick={cancelEdit} className="btn">
-              Cancel
+      <div className="max-w-2xl mx-auto">
+        <form onSubmit={submit} className="space-y-2 mb-6">
+          {(
+            [
+              'id',
+              'sku',
+              'title',
+              'vendor',
+              'description',
+              'productType',
+              'tags',
+              'category',
+              'quantity',
+              'minPrice',
+              'maxPrice',
+              'currency',
+            ] as (keyof ProductForm)[]
+          ).map((field) => (
+            <TextInput
+              key={field}
+              label={labels[field]}
+              name={field as keyof ProductForm}
+              value={
+                field === 'vendor'
+                  ? form.vendor?.brandName || ''
+                  : field === 'category'
+                    ? form.category?.name || ''
+                    : (form as any)[field]
+              }
+              onChange={handleChange as any}
+              placeholder={labels[field]}
+              type={
+                field === 'quantity' ||
+                field === 'minPrice' ||
+                field === 'maxPrice'
+                  ? 'number'
+                  : 'text'
+              }
+              min={
+                field === 'quantity' ||
+                field === 'minPrice' ||
+                field === 'maxPrice'
+                  ? 0
+                  : undefined
+              }
+              error={errors[field]}
+            />
+          ))}
+          <div className="flex gap-2">
+            {editingId && (
+              <button type="button" onClick={cancelEdit} className="btn">
+                Cancel
+              </button>
+            )}
+            <button type="submit" className="btn btn-primary">
+              {editingId ? 'Update Product' : 'Add Product'}
             </button>
-          )}
-          <button type="submit" className="btn btn-primary">
-            {editingId ? 'Update Product' : 'Add Product'}
-          </button>
-        </div>
-      </form>
-      <h2 className="text-xl font-semibold mb-2">Existing Products</h2>
-      <ul className="space-y-1">
-        {products.map((p) => (
-          <li key={p.id} className="flex justify-between items-center gap-2">
-            <span>
-              {p.title} ({p.sku}) - {p.category || p.productType}
-            </span>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                className="btn btn-sm"
-                onClick={() => handleEdit(p)}
-              >
-                Edit
-              </button>
-              <button
-                type="button"
-                className="btn btn-sm btn-error"
-                onClick={() => handleDelete(p.id)}
-              >
-                Delete
-              </button>
-            </div>
-          </li>
-        ))}
-      </ul>
+          </div>
+        </form>
+        <h2 className="text-xl font-semibold mb-2">Existing Products</h2>
+        <ul className="space-y-1">
+          {products.map((p) => (
+            <li key={p.id} className="flex justify-between items-center gap-2">
+              <span>
+                {p.title} ({p.sku}) - {p.category || p.productType}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className="btn btn-sm"
+                  onClick={() => handleEdit(p)}
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-error"
+                  onClick={() => handleDelete(p.id)}
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enhance accessibility of TextInput error messages
- add labels, layout container, validation logic in Brand Dashboard
- prevent negative numbers and show inline errors

## Testing
- `npx prettier -w components/form-fields/TextInput.tsx pages/brand/dashboard.tsx`
- `npm test` *(fails: jest not installed)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3e95e828832fb971dcc1728a91c4