### PR TITLE
Add saved payment methods

### DIFF
--- a/lib/paymentMethods.ts
+++ b/lib/paymentMethods.ts
@@ -1,0 +1,47 @@
+import { getDb } from './db';
+
+export async function addPaymentMethod(
+  userId: number,
+  data: {
+    provider: string;
+    cardLast4: string;
+    cardBrand: string;
+    expMonth: number;
+    expYear: number;
+    token: string;
+    isDefault?: boolean;
+  }
+) {
+  const db = getDb();
+  if (data.isDefault) {
+    await db.paymentMethod.updateMany({
+      where: { userId },
+      data: { isDefault: false },
+    });
+  }
+  return db.paymentMethod.create({
+    data: { ...data, userId, isDefault: data.isDefault || false },
+  });
+}
+
+export function getPaymentMethodsForUser(userId: number) {
+  const db = getDb();
+  return db.paymentMethod.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function setDefaultPaymentMethod(userId: number, id: number) {
+  const db = getDb();
+  await db.paymentMethod.updateMany({
+    where: { userId },
+    data: { isDefault: false },
+  });
+  await db.paymentMethod.update({ where: { id }, data: { isDefault: true } });
+}
+
+export function deletePaymentMethod(id: number) {
+  const db = getDb();
+  return db.paymentMethod.delete({ where: { id } });
+}

--- a/lib/paymentProvider.ts
+++ b/lib/paymentProvider.ts
@@ -1,0 +1,50 @@
+export interface TokenizedCard {
+  token: string;
+  cardLast4: string;
+  cardBrand: string;
+  expMonth: number;
+  expYear: number;
+}
+
+export interface PaymentCharge {
+  transactionId: string;
+  status: 'succeeded' | 'failed';
+}
+
+export interface PaymentProvider {
+  tokenizeCard(card: {
+    number: string;
+    expMonth: number;
+    expYear: number;
+    cvc: string;
+  }): Promise<TokenizedCard>;
+
+  charge(token: string, amount: number): Promise<PaymentCharge>;
+}
+
+// A simple mock provider used for development/testing without network calls
+export class MockPaymentProvider implements PaymentProvider {
+  async tokenizeCard(card: {
+    number: string;
+    expMonth: number;
+    expYear: number;
+    cvc: string;
+  }): Promise<TokenizedCard> {
+    return {
+      token: 'tok_' + Math.random().toString(36).substring(2),
+      cardLast4: card.number.slice(-4),
+      cardBrand: 'mock',
+      expMonth: card.expMonth,
+      expYear: card.expYear,
+    };
+  }
+
+  async charge(token: string, amount: number): Promise<PaymentCharge> {
+    return {
+      transactionId: 'ch_' + Math.random().toString(36).substring(2),
+      status: 'succeeded',
+    };
+  }
+}
+
+export const paymentProvider: PaymentProvider = new MockPaymentProvider();

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -1,0 +1,13 @@
+import { getDb } from './db';
+
+export function recordPayment(data: {
+  orderId: number;
+  amount: number;
+  provider: string;
+  status: string;
+  paymentMethodId: number;
+  transactionId: string;
+}) {
+  const db = getDb();
+  return db.payment.create({ data });
+}

--- a/pages/api/payment-methods/[id].ts
+++ b/pages/api/payment-methods/[id].ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import {
+  setDefaultPaymentMethod,
+  deletePaymentMethod,
+  getPaymentMethodsForUser,
+} from '../../../lib/paymentMethods';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user?.id)
+      return res.status(401).json({ message: 'Unauthorized' });
+    const userId = Number(session.user.id);
+    const id = parseInt(String(req.query.id));
+    if (isNaN(id)) return res.status(400).json({ message: 'invalid id' });
+    if (req.method === 'DELETE') {
+      await deletePaymentMethod(id);
+      const methods = await getPaymentMethodsForUser(userId);
+      return res.status(200).json(methods);
+    }
+    if (req.method === 'PATCH') {
+      const { makeDefault } = req.body || {};
+      if (makeDefault) {
+        await setDefaultPaymentMethod(userId, id);
+      }
+      const methods = await getPaymentMethodsForUser(userId);
+      return res.status(200).json(methods);
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage payment methods');
+  }
+}

--- a/pages/api/payment-methods/index.ts
+++ b/pages/api/payment-methods/index.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { paymentProvider } from '../../../lib/paymentProvider';
+import {
+  addPaymentMethod,
+  getPaymentMethodsForUser,
+} from '../../../lib/paymentMethods';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user?.id)
+      return res.status(401).json({ message: 'Unauthorized' });
+    const userId = Number(session.user.id);
+    if (req.method === 'GET') {
+      const methods = await getPaymentMethodsForUser(userId);
+      return res.status(200).json(methods);
+    }
+    if (req.method === 'POST') {
+      const { number, expMonth, expYear, cvc, setDefault } = req.body || {};
+      if (!number || !expMonth || !expYear || !cvc)
+        return res.status(400).json({ message: 'card details required' });
+      const tokenized = await paymentProvider.tokenizeCard({
+        number,
+        expMonth: Number(expMonth),
+        expYear: Number(expYear),
+        cvc,
+      });
+      const method = await addPaymentMethod(userId, {
+        provider: 'mock',
+        cardLast4: tokenized.cardLast4,
+        cardBrand: tokenized.cardBrand,
+        expMonth: tokenized.expMonth,
+        expYear: tokenized.expYear,
+        token: tokenized.token,
+        isDefault: !!setDefault,
+      });
+      return res.status(200).json(method);
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage payment methods');
+  }
+}

--- a/pages/api/payments/charge.ts
+++ b/pages/api/payments/charge.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { paymentProvider } from '../../../lib/paymentProvider';
+import { recordPayment } from '../../../lib/payments';
+import { getDb } from '../../../lib/db';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user?.id)
+      return res.status(401).json({ message: 'Unauthorized' });
+    if (req.method !== 'POST')
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    const { orderId, paymentMethodId, amount } = req.body || {};
+    if (!orderId || !paymentMethodId || !amount)
+      return res.status(400).json({ message: 'missing fields' });
+    const db = getDb();
+    const method = await db.paymentMethod.findUnique({
+      where: { id: Number(paymentMethodId) },
+    });
+    if (!method) return res.status(400).json({ message: 'method not found' });
+    const charge = await paymentProvider.charge(method.token, Number(amount));
+    await recordPayment({
+      orderId: Number(orderId),
+      amount: Number(amount),
+      provider: method.provider,
+      status: charge.status,
+      paymentMethodId: method.id,
+      transactionId: charge.transactionId,
+    });
+    if (charge.status === 'succeeded') {
+      await db.order.update({
+        where: { id: Number(orderId) },
+        data: { status: 'completed' },
+      });
+    }
+    return res.status(200).json(charge);
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to process payment');
+  }
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -11,6 +11,7 @@ import {
   CountrySelect,
 } from '../components/form-fields';
 import countries from '../data/countries';
+import type { PaymentMethod } from '../types';
 
 interface ProfileFormValues {
   firstName: string;
@@ -45,7 +46,7 @@ const SettingsPage: React.FC = () => {
   const user = useRequireAuth();
   const { addNotification } = useContext(NotificationContext);
   const [active, setActive] = useState<
-    'profile' | 'password' | 'address' | 'email'
+    'profile' | 'password' | 'address' | 'email' | 'payments'
   >('profile');
   const [codeSent, setCodeSent] = useState(false);
 
@@ -53,6 +54,14 @@ const SettingsPage: React.FC = () => {
   const passwordForm = useForm<PasswordFormValues>();
   const addressForm = useForm<AddressFormValues>();
   const emailForm = useForm<EmailFormValues>();
+  const [methods, setMethods] = useState<PaymentMethod[]>([]);
+
+  const loadMethods = () => {
+    fetch('/api/payment-methods')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setMethods(data))
+      .catch(() => {});
+  };
 
   useEffect(() => {
     if (!user) return;
@@ -74,6 +83,11 @@ const SettingsPage: React.FC = () => {
       })
       .catch(() => {});
   }, [user, profileForm, addressForm]);
+
+  useEffect(() => {
+    if (!user) return;
+    if (active === 'payments') loadMethods();
+  }, [user, active]);
 
   const submitProfile: SubmitHandler<ProfileFormValues> = async (values) => {
     const res = await fetch('/api/user/profile', {
@@ -183,6 +197,14 @@ const SettingsPage: React.FC = () => {
               onClick={() => setActive('email')}
             >
               Change Email
+            </button>
+          </li>
+          <li>
+            <button
+              className={active === 'payments' ? 'active' : ''}
+              onClick={() => setActive('payments')}
+            >
+              Payment Methods
             </button>
           </li>
         </ul>
@@ -323,6 +345,101 @@ const SettingsPage: React.FC = () => {
               Confirm
             </button>
           </form>
+        )}
+        {active === 'payments' && (
+          <div className="space-y-2 max-w-md mx-auto">
+            <h2 className="text-xl font-bold mb-2">Payment Methods</h2>
+            <ul className="space-y-1">
+              {methods.map((m) => (
+                <li key={m.id} className="flex justify-between items-center">
+                  <span>
+                    {m.cardBrand} ****{m.cardLast4} exp {m.expMonth}/{m.expYear}
+                    {m.isDefault && ' (default)'}
+                  </span>
+                  <div className="flex gap-2">
+                    {!m.isDefault && (
+                      <button
+                        className="btn btn-xs"
+                        onClick={() =>
+                          fetch(`/api/payment-methods/${m.id}`, {
+                            method: 'PATCH',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ makeDefault: true }),
+                          }).then(loadMethods)
+                        }
+                      >
+                        Make Default
+                      </button>
+                    )}
+                    <button
+                      className="btn btn-xs"
+                      onClick={() =>
+                        fetch(`/api/payment-methods/${m.id}`, {
+                          method: 'DELETE',
+                        }).then(loadMethods)
+                      }
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                const form = e.currentTarget as HTMLFormElement;
+                const data = {
+                  number: (form.number as HTMLInputElement).value,
+                  expMonth: (form.expMonth as HTMLInputElement).value,
+                  expYear: (form.expYear as HTMLInputElement).value,
+                  cvc: (form.cvc as HTMLInputElement).value,
+                  setDefault: (form.default as HTMLInputElement).checked,
+                };
+                fetch('/api/payment-methods', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify(data),
+                })
+                  .then(() => {
+                    form.reset();
+                    loadMethods();
+                  })
+                  .catch(() => {});
+              }}
+              className="space-y-2"
+            >
+              <input
+                name="number"
+                className="input input-bordered w-full"
+                placeholder="Card Number"
+              />
+              <div className="flex gap-2">
+                <input
+                  name="expMonth"
+                  className="input input-bordered w-full"
+                  placeholder="MM"
+                />
+                <input
+                  name="expYear"
+                  className="input input-bordered w-full"
+                  placeholder="YYYY"
+                />
+              </div>
+              <input
+                name="cvc"
+                className="input input-bordered w-full"
+                placeholder="CVC"
+              />
+              <label className="flex items-center gap-2">
+                <input type="checkbox" name="default" className="checkbox" />
+                Set as default
+              </label>
+              <button type="submit" className="btn btn-primary w-full">
+                Add Card
+              </button>
+            </form>
+          </div>
         )}
       </div>
     </div>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,3 +152,34 @@ model CouponUsage {
 
   @@unique([couponId, userId])
 }
+
+model PaymentMethod {
+  id          Int      @id @default(autoincrement())
+  userId      Int
+  provider    String
+  cardLast4   String
+  cardBrand   String
+  expMonth    Int
+  expYear     Int
+  token       String
+  isDefault   Boolean   @default(false)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  user User @relation(fields: [userId], references: [id])
+  payments Payment[]
+}
+
+model Payment {
+  id             Int      @id @default(autoincrement())
+  orderId        Int
+  amount         Float
+  provider       String
+  status         String
+  paymentMethodId Int
+  transactionId  String
+  createdAt      DateTime @default(now())
+
+  order         Order        @relation(fields: [orderId], references: [id])
+  paymentMethod PaymentMethod @relation(fields: [paymentMethodId], references: [id])
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -14,3 +14,5 @@ export * from './user';
 export * from './shipping';
 export * from './shared';
 export * from './forms';
+export * from './paymentMethod';
+export * from './payment';

--- a/types/payment.ts
+++ b/types/payment.ts
@@ -1,0 +1,3 @@
+import type { Payment as PrismaPayment } from '@prisma/client';
+
+export interface Payment extends PrismaPayment {}

--- a/types/paymentMethod.ts
+++ b/types/paymentMethod.ts
@@ -1,0 +1,3 @@
+import type { PaymentMethod as PrismaPaymentMethod } from '@prisma/client';
+
+export interface PaymentMethod extends PrismaPaymentMethod {}


### PR DESCRIPTION
## Summary
- add new PaymentMethod and Payment models
- mock payment provider
- store and manage cards in `paymentMethods` table
- charge payments using saved methods
- expose API endpoints for payment management
- show card management UI on Settings page

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685c423b9c24832f82b73a186e6e792d