### PR TITLE
Implement saved payment methods

### DIFF
--- a/lib/paymentMethods.ts
+++ b/lib/paymentMethods.ts
@@ -1,0 +1,45 @@
+import { getDb } from './db';
+import type { Prisma } from '@prisma/client';
+
+const prisma = getDb();
+
+export function listPaymentMethods(userId: number) {
+  return prisma.paymentMethod.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export function getPaymentMethod(id: number, userId: number) {
+  return prisma.paymentMethod.findFirst({ where: { id, userId } });
+}
+
+export async function createPaymentMethod(
+  userId: number,
+  data: Prisma.PaymentMethodCreateInput
+) {
+  if (data.isDefault) {
+    await prisma.paymentMethod.updateMany({
+      where: { userId },
+      data: { isDefault: false },
+    });
+  }
+  return prisma.paymentMethod.create({
+    data: { ...data, user: { connect: { id: userId } } },
+  });
+}
+
+export async function setDefaultPaymentMethod(userId: number, id: number) {
+  await prisma.paymentMethod.updateMany({
+    where: { userId },
+    data: { isDefault: false },
+  });
+  return prisma.paymentMethod.update({
+    where: { id },
+    data: { isDefault: true },
+  });
+}
+
+export function deletePaymentMethod(id: number) {
+  return prisma.paymentMethod.delete({ where: { id } });
+}

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -1,0 +1,8 @@
+import { getDb } from './db';
+import type { Prisma } from '@prisma/client';
+
+const prisma = getDb();
+
+export function recordPayment(data: Prisma.PaymentCreateInput) {
+  return prisma.payment.create({ data });
+}

--- a/pages/api/payment-methods/[id].ts
+++ b/pages/api/payment-methods/[id].ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import {
+  deletePaymentMethod,
+  setDefaultPaymentMethod,
+} from '../../../lib/paymentMethods';
+import type { ApiMessage, PaymentMethod } from '../../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<PaymentMethod | ApiMessage>
+): Promise<void> {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const userId = (session.user as any).id;
+    const id = Number(req.query.id);
+    if (!id) return res.status(400).json({ message: 'id required' });
+
+    if (req.method === 'DELETE') {
+      await deletePaymentMethod(id);
+      return res.status(200).json({ message: 'deleted' });
+    }
+
+    if (req.method === 'PATCH') {
+      await setDefaultPaymentMethod(Number(userId), id);
+      return res.status(200).json({ message: 'updated' });
+    }
+
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (err) {
+    return handleApiError(res, err, 'Failed to manage payment method');
+  }
+}

--- a/pages/api/payment-methods/index.ts
+++ b/pages/api/payment-methods/index.ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import {
+  listPaymentMethods,
+  createPaymentMethod,
+} from '../../../lib/paymentMethods';
+import type { PaymentMethod, ApiMessage } from '../../../types';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2022-11-15',
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<PaymentMethod[] | PaymentMethod | ApiMessage>
+): Promise<void> {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const userId = (session.user as any).id;
+    if (!userId) return res.status(400).json({ message: 'Invalid user' });
+
+    if (req.method === 'GET') {
+      const methods = await listPaymentMethods(Number(userId));
+      return res.status(200).json(methods as unknown as PaymentMethod[]);
+    }
+
+    if (req.method === 'POST') {
+      const { cardNumber, expMonth, expYear, cvc, isDefault } = req.body || {};
+      if (!cardNumber || !expMonth || !expYear || !cvc) {
+        return res.status(400).json({ message: 'card details required' });
+      }
+      const token = await stripe.tokens.create({
+        card: {
+          number: cardNumber,
+          exp_month: expMonth,
+          exp_year: expYear,
+          cvc,
+        },
+      });
+      const method = await createPaymentMethod(Number(userId), {
+        provider: 'stripe',
+        cardLast4: token.card?.last4 || '',
+        cardBrand: token.card?.brand || '',
+        expMonth: token.card?.exp_month || expMonth,
+        expYear: token.card?.exp_year || expYear,
+        token: token.id,
+        isDefault: !!isDefault,
+      });
+      return res.status(201).json(method as unknown as PaymentMethod);
+    }
+
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (err) {
+    return handleApiError(res, err, 'Failed to manage payment methods');
+  }
+}

--- a/pages/api/payments/charge.ts
+++ b/pages/api/payments/charge.ts
@@ -1,0 +1,110 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import {
+  createPaymentMethod,
+  getPaymentMethod,
+} from '../../../lib/paymentMethods';
+import { recordPayment } from '../../../lib/payments';
+import { addOrder } from '../../../lib/orders';
+import type { OrderIdResponse, ApiMessage } from '../../../types';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2022-11-15',
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<OrderIdResponse | ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'POST') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const userId = (session.user as any).id;
+    const {
+      items,
+      cardNumber,
+      expMonth,
+      expYear,
+      cvc,
+      paymentMethodId,
+      saveMethod,
+      setDefault,
+      total,
+    } = req.body || {};
+    if (!items || items.length === 0)
+      return res.status(400).json({ message: 'items required' });
+    let tokenId: string | null = null;
+    let methodId: number | null = paymentMethodId || null;
+    if (paymentMethodId) {
+      const existing = await getPaymentMethod(
+        Number(paymentMethodId),
+        Number(userId)
+      );
+      if (!existing)
+        return res.status(404).json({ message: 'payment method not found' });
+      tokenId = existing.token;
+    }
+    if (!paymentMethodId) {
+      if (!cardNumber || !expMonth || !expYear || !cvc) {
+        return res.status(400).json({ message: 'card details required' });
+      }
+      const token = await stripe.tokens.create({
+        card: {
+          number: cardNumber,
+          exp_month: expMonth,
+          exp_year: expYear,
+          cvc,
+        },
+      });
+      tokenId = token.id;
+      if (saveMethod) {
+        const method = await createPaymentMethod(Number(userId), {
+          provider: 'stripe',
+          cardLast4: token.card?.last4 || '',
+          cardBrand: token.card?.brand || '',
+          expMonth: token.card?.exp_month || expMonth,
+          expYear: token.card?.exp_year || expYear,
+          token: token.id,
+          isDefault: !!setDefault,
+        });
+        methodId = method.id;
+      }
+    }
+    const charge = await stripe.charges.create({
+      amount: Math.round(total * 100),
+      currency: 'usd',
+      source: tokenId || undefined,
+      description: 'Order payment',
+    });
+
+    const orders = await addOrder({
+      userEmail: session.user.email,
+      items,
+      total,
+      status: charge.status === 'succeeded' ? 'completed' : 'pending',
+    });
+    const orderId =
+      Array.isArray(orders) && orders.length > 0 ? orders[0].id : '';
+
+    await recordPayment({
+      amount: total,
+      provider: 'stripe',
+      status: charge.status,
+      transactionId: charge.id,
+      order: { connect: { id: orderId } },
+      paymentMethod: methodId ? { connect: { id: methodId } } : undefined,
+    });
+
+    return res.status(200).json({ id: orderId });
+  } catch (err) {
+    return handleApiError(res, err, 'Payment failed');
+  }
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -11,6 +11,7 @@ import {
   CountrySelect,
 } from '../components/form-fields';
 import countries from '../data/countries';
+import type { PaymentMethod } from '../types';
 
 interface ProfileFormValues {
   firstName: string;
@@ -45,14 +46,22 @@ const SettingsPage: React.FC = () => {
   const user = useRequireAuth();
   const { addNotification } = useContext(NotificationContext);
   const [active, setActive] = useState<
-    'profile' | 'password' | 'address' | 'email'
+    'profile' | 'password' | 'address' | 'email' | 'payments'
   >('profile');
   const [codeSent, setCodeSent] = useState(false);
+  const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([]);
 
   const profileForm = useForm<ProfileFormValues>();
   const passwordForm = useForm<PasswordFormValues>();
   const addressForm = useForm<AddressFormValues>();
   const emailForm = useForm<EmailFormValues>();
+  const paymentForm = useForm<{
+    cardNumber: string;
+    expMonth: number;
+    expYear: number;
+    cvc: string;
+    isDefault: boolean;
+  }>();
 
   useEffect(() => {
     if (!user) return;
@@ -74,6 +83,14 @@ const SettingsPage: React.FC = () => {
       })
       .catch(() => {});
   }, [user, profileForm, addressForm]);
+
+  useEffect(() => {
+    if (!user) return;
+    fetch('/api/payment-methods')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setPaymentMethods(data || []))
+      .catch(() => {});
+  }, [user]);
 
   const submitProfile: SubmitHandler<ProfileFormValues> = async (values) => {
     const res = await fetch('/api/user/profile', {
@@ -144,6 +161,28 @@ const SettingsPage: React.FC = () => {
     }
   };
 
+  const addCard: SubmitHandler<{
+    cardNumber: string;
+    expMonth: number;
+    expYear: number;
+    cvc: string;
+    isDefault: boolean;
+  }> = async (values) => {
+    const res = await fetch('/api/payment-methods', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    });
+    if (res.ok) {
+      const data: PaymentMethod = await res.json();
+      setPaymentMethods((m) => [...m, data]);
+      paymentForm.reset();
+      addNotification('Card added', 'success');
+    } else {
+      addNotification('Add failed', 'error');
+    }
+  };
+
   if (!user) return null;
 
   return (
@@ -183,6 +222,14 @@ const SettingsPage: React.FC = () => {
               onClick={() => setActive('email')}
             >
               Change Email
+            </button>
+          </li>
+          <li>
+            <button
+              className={active === 'payments' ? 'active' : ''}
+              onClick={() => setActive('payments')}
+            >
+              Payment Methods
             </button>
           </li>
         </ul>
@@ -323,6 +370,101 @@ const SettingsPage: React.FC = () => {
               Confirm
             </button>
           </form>
+        )}
+        {active === 'payments' && (
+          <div className="space-y-4 max-w-md mx-auto">
+            <h2 className="text-xl font-bold mb-2">Payment Methods</h2>
+            <ul className="space-y-2">
+              {paymentMethods.map((m) => (
+                <li
+                  key={m.id}
+                  className="border p-2 flex justify-between rounded"
+                >
+                  <span>
+                    {m.cardBrand} ****{m.cardLast4} exp {m.expMonth}/{m.expYear}
+                    {m.isDefault && ' (Default)'}
+                  </span>
+                  <div className="space-x-2">
+                    {!m.isDefault && (
+                      <button
+                        type="button"
+                        className="btn btn-xs"
+                        onClick={async () => {
+                          await fetch(`/api/payment-methods/${m.id}`, {
+                            method: 'PATCH',
+                          });
+                          setPaymentMethods((list) =>
+                            list.map((x) => ({
+                              ...x,
+                              isDefault: x.id === m.id,
+                            }))
+                          );
+                        }}
+                      >
+                        Set Default
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      className="btn btn-xs"
+                      onClick={async () => {
+                        await fetch(`/api/payment-methods/${m.id}`, {
+                          method: 'DELETE',
+                        });
+                        setPaymentMethods((list) =>
+                          list.filter((x) => x.id !== m.id)
+                        );
+                      }}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <form
+              onSubmit={paymentForm.handleSubmit(addCard)}
+              className="space-y-2"
+            >
+              <TextInput
+                label="Card Number"
+                register={paymentForm.register}
+                name="cardNumber"
+                rules={{ required: 'Required' }}
+                error={paymentForm.formState.errors.cardNumber?.message}
+              />
+              <div className="flex gap-2">
+                <TextInput
+                  label="Exp Month"
+                  register={paymentForm.register}
+                  name="expMonth"
+                  rules={{ required: 'Required' }}
+                  error={paymentForm.formState.errors.expMonth?.message}
+                />
+                <TextInput
+                  label="Exp Year"
+                  register={paymentForm.register}
+                  name="expYear"
+                  rules={{ required: 'Required' }}
+                  error={paymentForm.formState.errors.expYear?.message}
+                />
+              </div>
+              <TextInput
+                label="CVC"
+                register={paymentForm.register}
+                name="cvc"
+                rules={{ required: 'Required' }}
+                error={paymentForm.formState.errors.cvc?.message}
+              />
+              <label className="flex items-center gap-2">
+                <input type="checkbox" {...paymentForm.register('isDefault')} />
+                Set as default
+              </label>
+              <button type="submit" className="btn btn-primary w-full">
+                Add Card
+              </button>
+            </form>
+          </div>
         )}
       </div>
     </div>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model User {
 
   products          Product[]
   orders            Order[]
+  paymentMethods    PaymentMethod[]
   deletionRequests  DeletionRequest[] @relation("BrandDeletionRequests")
   searchLogs        SearchLog[]
 }
@@ -150,4 +151,35 @@ model CouponUsage {
   user   User   @relation(fields: [userId], references: [id])
 
   @@unique([couponId, userId])
+}
+
+model PaymentMethod {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  provider  String
+  cardLast4 String
+  cardBrand String
+  expMonth  Int
+  expYear   Int
+  token     String
+  isDefault Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user     User      @relation(fields: [userId], references: [id])
+  payments Payment[]
+}
+
+model Payment {
+  id              Int       @id @default(autoincrement())
+  orderId         Int
+  amount          Float
+  provider        String
+  status          String
+  paymentMethodId Int
+  transactionId   String
+  createdAt       DateTime  @default(now())
+
+  order         Order         @relation(fields: [orderId], references: [id])
+  paymentMethod PaymentMethod @relation(fields: [paymentMethodId], references: [id])
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -14,3 +14,4 @@ export * from './user';
 export * from './shipping';
 export * from './shared';
 export * from './forms';
+export * from './payment';

--- a/types/payment.ts
+++ b/types/payment.ts
@@ -1,0 +1,10 @@
+import type {
+  Payment as PrismaPayment,
+  PaymentMethod as PrismaPaymentMethod,
+} from '@prisma/client';
+
+export interface PaymentMethod extends PrismaPaymentMethod {}
+
+export interface Payment extends PrismaPayment {
+  paymentMethod: PaymentMethod;
+}


### PR DESCRIPTION
## Summary
- add `PaymentMethod` and `Payment` models to Prisma schema
- expose payment method management API
- implement basic payment charge endpoint
- add utilities for payment methods and payments
- extend settings page with saved card management
- export new payment types

## Testing
- `npx prettier pages/settings.tsx types/index.ts -w`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c38aa25dc832fa2a27ed75a65b893