### PR TITLE
Enable Stripe Connect for brand payouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,9 @@
 DATABASE_URL=postgresql://user:password@localhost:5432/ecommerce_platform
 # Stripe credentials
 STRIPE_SECRET_KEY="sk_test_yourkey"
+STRIPE_PUBLISHABLE_KEY="pk_test_yourkey"
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_yourkey"
+STRIPE_WEBHOOK_SECRET="whsec_..."
 
 # Resend API key for email confirmations
 RESEND_API_KEY=""

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,0 +1,5 @@
+import Stripe from 'stripe';
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2022-11-15',
+});

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -20,6 +20,7 @@ export async function addUser({
   businessDescription,
   logo,
   taxId,
+  stripeAccountId,
   role = 'USER',
   verificationToken,
 }: UserInput): Promise<void> {
@@ -40,6 +41,7 @@ export async function addUser({
       businessDescription,
       logo,
       taxId,
+      stripeAccountId,
       role: role as Role,
       disabled: false,
       verificationToken,
@@ -49,6 +51,10 @@ export async function addUser({
 
 export function findUser(email: string) {
   return prisma.user.findUnique({ where: { email } });
+}
+
+export function findUserById(id: number | string) {
+  return prisma.user.findUnique({ where: { id: Number(id) } });
 }
 
 export function getAllUsers() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@types/jest": "^29.5.10",
         "@types/node": "^24.0.3",
         "@types/react": "^18.3.23",
+        "@types/stripe": "^8.0.416",
         "autoprefixer": "^10.4.19",
         "babel-jest": "^30.0.0-beta.3",
         "daisyui": "^4.12.24",
@@ -4196,6 +4197,16 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/stripe": {
+      "version": "8.0.416",
+      "resolved": "https://registry.npmjs.org/@types/stripe/-/stripe-8.0.416.tgz",
+      "integrity": "sha512-LDA574j7g30dg4R+SI1JIpkS+rkIuXgbe6+/qlf62avd7ZNntbbl2DYZwAIj9CfJYVh7FG/PLeoNB5OXTsEehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stripe": "*"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/jest": "^29.5.10",
     "@types/node": "^24.0.3",
     "@types/react": "^18.3.23",
+    "@types/stripe": "^8.0.416",
     "autoprefixer": "^10.4.19",
     "babel-jest": "^30.0.0-beta.3",
     "daisyui": "^4.12.24",

--- a/pages/api/brand/earnings.ts
+++ b/pages/api/brand/earnings.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getOrdersForVendor } from '../../../lib/orders';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import type { EarningsData, ApiMessage } from '../../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<EarningsData | ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const vendor = getQueryParam(req.query.vendor);
+    if (!vendor) {
+      return res.status(400).json({ message: 'vendor required' });
+    }
+    const orders = await getOrdersForVendor(vendor);
+    const totalEarned = orders.reduce((s, o) => s + (o.total || 0), 0);
+    const pending = orders
+      .filter((o) => o.status !== 'completed')
+      .reduce((s, o) => s + (o.total || 0), 0);
+    const data: EarningsData = {
+      totalEarned,
+      pending,
+      orders,
+    };
+    return res.status(200).json(data);
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to get earnings');
+  }
+}

--- a/pages/api/brand/stripe-account.ts
+++ b/pages/api/brand/stripe-account.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { stripe } from '../../../lib/stripe';
+import { findUser, updateUserProfile } from '../../../lib/users';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ url: string } | { message: string }>
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.status(405).json({ message: 'Method Not Allowed' });
+    return;
+  }
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email;
+  if (!email) {
+    res.status(401).json({ message: 'Unauthorized' });
+    return;
+  }
+  const user = await findUser(email);
+  if (!user) {
+    res.status(404).json({ message: 'User not found' });
+    return;
+  }
+  let accountId = user.stripeAccountId || '';
+  if (!accountId) {
+    const account = await stripe.accounts.create({ type: 'express', email });
+    accountId = account.id;
+    await updateUserProfile(email, { stripeAccountId: accountId });
+  }
+  const link = await stripe.accountLinks.create({
+    account: accountId,
+    refresh_url: `${req.headers.origin}/brand/dashboard`,
+    return_url: `${req.headers.origin}/brand/dashboard`,
+    type: 'account_onboarding',
+  });
+  res.status(200).json({ url: link.url });
+}

--- a/pages/api/checkout/create-session.ts
+++ b/pages/api/checkout/create-session.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
+import { getProductByUuid } from '../../../lib/db';
+import { findUserById } from '../../../lib/users';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import type { CheckoutSessionResponse, ApiMessage } from '../../../types';
 
@@ -19,6 +21,18 @@ export default async function handler(
     return res.status(400).json({ message: 'items and email required' });
   }
   try {
+    let stripeAccountId: string | undefined;
+    if (items.length > 0) {
+      const product = await getProductByUuid(
+        String(items[0].uuid || items[0].id)
+      );
+      if (product) {
+        const vendor = await findUserById(product.vendorId);
+        if (vendor && vendor.stripeAccountId) {
+          stripeAccountId = vendor.stripeAccountId;
+        }
+      }
+    }
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ['card'],
       line_items: items.map((it: any) => ({
@@ -32,6 +46,9 @@ export default async function handler(
       mode: 'payment',
       success_url: `${req.headers.origin}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${req.headers.origin}/checkout/cancel`,
+      payment_intent_data: stripeAccountId
+        ? { transfer_data: { destination: stripeAccountId } }
+        : undefined,
       metadata: {
         email,
         shippingName: shipping?.name || '',

--- a/pages/api/stripe/webhook.ts
+++ b/pages/api/stripe/webhook.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { stripe } from '../../../lib/stripe';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.status(405).end('Method Not Allowed');
+    return;
+  }
+  const sig = req.headers['stripe-signature'] as string;
+  const buf = await new Promise<Buffer>((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      buf,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET || ''
+    );
+  } catch (err) {
+    res.status(400).end(`Webhook Error: ${(err as Error).message}`);
+    return;
+  }
+  // Handle events here if needed
+  res.json({ received: true });
+}

--- a/pages/brand/analytics.tsx
+++ b/pages/brand/analytics.tsx
@@ -14,9 +14,15 @@ type AnalyticsData = {
   topProducts: TopProduct[];
 };
 
+type EarningsData = {
+  totalEarned: number;
+  pending: number;
+};
+
 const BrandAnalytics: React.FC = () => {
   const { user } = useContext(AppContext)!;
   const [data, setData] = useState<AnalyticsData | null>(null);
+  const [earnings, setEarnings] = useState<EarningsData | null>(null);
 
   useEffect(() => {
     if (!user) return;
@@ -25,6 +31,11 @@ const BrandAnalytics: React.FC = () => {
     )
       .then((res) => (res.ok ? res.json() : null))
       .then(setData);
+    fetch(
+      `/api/brand/earnings?vendor=${encodeURIComponent(user.brandName || '')}`
+    )
+      .then((res) => (res.ok ? res.json() : null))
+      .then(setEarnings);
   }, [user]);
 
   if (!user) return <div className="p-4">Please log in.</div>;
@@ -41,6 +52,12 @@ const BrandAnalytics: React.FC = () => {
       <h1 className="text-2xl font-bold mb-4">Sales Summary</h1>
       <p>Total Orders: {data.totalOrders}</p>
       <p>Total Revenue: £{data.totalRevenue.toFixed(2)}</p>
+      {earnings && (
+        <div className="my-2 space-y-1">
+          <p>Total Earned: £{earnings.totalEarned.toFixed(2)}</p>
+          <p>Pending Payouts: £{earnings.pending.toFixed(2)}</p>
+        </div>
+      )}
       <h2 className="text-xl font-semibold mt-4 mb-2">Top Products</h2>
       <ul className="list-disc list-inside">
         {data.topProducts.length > 0 ? (

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   businessDescription String?
   logo                String?
   taxId               String?
+  stripeAccountId     String?
   role                Role      @default(USER)
   verified            Boolean   @default(false)
   disabled            Boolean   @default(false)

--- a/types/brand.ts
+++ b/types/brand.ts
@@ -8,3 +8,9 @@ export interface Brand {
   createdAt?: Date;
   updatedAt?: Date;
 }
+
+export interface EarningsData {
+  totalEarned: number;
+  pending: number;
+  orders: import('./order').Order[];
+}

--- a/types/user.ts
+++ b/types/user.ts
@@ -18,6 +18,7 @@ export interface User {
   businessDescription?: string;
   logo?: string;
   taxId?: string;
+  stripeAccountId?: string;
   verificationToken?: string;
   resetToken?: string;
   resetExpires?: Date;
@@ -45,6 +46,7 @@ export interface UserInput {
   businessDescription?: string;
   logo?: string;
   taxId?: string;
+  stripeAccountId?: string;
   role?: Role;
   verificationToken?: string;
 }


### PR DESCRIPTION
## Summary
- add Stripe Connect account helper and webhooks
- store `stripeAccountId` on users
- allow checkout sessions to route funds to a brand
- expose brand earnings via API and dashboard
- document new Stripe env vars
- include `@types/stripe`

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685cc1eb7978832f9698e43b09933e75