### PR TITLE
Add dashboard overview for brands and admins

### DIFF
--- a/components/dashboard/BestSellersCard.tsx
+++ b/components/dashboard/BestSellersCard.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import DashboardCard from './DashboardCard';
+
+interface Props {
+  brand?: string;
+}
+
+interface Product {
+  id: string;
+  title: string;
+  quantity: number;
+}
+
+const BestSellersCard: React.FC<Props> = ({ brand }) => {
+  const [products, setProducts] = useState<Product[] | null>(null);
+  const [error, setError] = useState<string>('');
+  useEffect(() => {
+    setProducts(null);
+    setError('');
+    const url =
+      '/api/dashboard/best-sellers' +
+      (brand ? `?brand=${encodeURIComponent(brand)}` : '');
+    fetch(url)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => setProducts(data.products))
+      .catch(() => setError('Failed to load'));
+  }, [brand]);
+
+  return (
+    <DashboardCard
+      title="Best-Selling Products"
+      loading={!products && !error}
+      error={error}
+    >
+      {products && products.length > 0 ? (
+        <ul className="list-disc pl-4 space-y-1">
+          {products.map((p) => (
+            <li key={p.id}>
+              {p.title} - {p.quantity}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        !error && <p>No sales yet.</p>
+      )}
+    </DashboardCard>
+  );
+};
+
+export default BestSellersCard;

--- a/components/dashboard/DashboardCard.tsx
+++ b/components/dashboard/DashboardCard.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface Props {
+  title: string;
+  loading?: boolean;
+  error?: string;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+const DashboardCard: React.FC<Props> = ({
+  title,
+  loading = false,
+  error,
+  children,
+  className = '',
+}) => {
+  return (
+    <div className={`border rounded-lg shadow p-4 bg-base-100 ${className}`}>
+      \<h3 className="font-semibold mb-2">{title}</h3>
+      {loading ? (
+        <p>Loading...</p>
+      ) : error ? (
+        <p className="text-red-600">{error}</p>
+      ) : (
+        children
+      )}
+    </div>
+  );
+};
+
+export default DashboardCard;

--- a/components/dashboard/InventoryAlertsCard.tsx
+++ b/components/dashboard/InventoryAlertsCard.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import DashboardCard from './DashboardCard';
+
+interface Props {
+  brand?: string;
+  threshold?: number;
+}
+
+interface Product {
+  id: string;
+  title: string;
+  quantity: number;
+}
+
+const InventoryAlertsCard: React.FC<Props> = ({ brand, threshold = 10 }) => {
+  const [products, setProducts] = useState<Product[] | null>(null);
+  const [error, setError] = useState<string>('');
+  useEffect(() => {
+    setProducts(null);
+    setError('');
+    const params = new URLSearchParams();
+    if (brand) params.set('brand', brand);
+    if (threshold) params.set('threshold', String(threshold));
+    const url =
+      '/api/dashboard/inventory-alerts' +
+      (params.toString() ? `?${params.toString()}` : '');
+    fetch(url)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => setProducts(data.products))
+      .catch(() => setError('Failed to load'));
+  }, [brand, threshold]);
+
+  return (
+    <DashboardCard
+      title="Inventory Alerts"
+      loading={!products && !error}
+      error={error}
+    >
+      {products && products.length > 0 ? (
+        <ul className="list-disc pl-4 space-y-1">
+          {products.map((p) => (
+            <li key={p.id}>
+              {p.title} - {p.quantity} left
+            </li>
+          ))}
+        </ul>
+      ) : (
+        !error && <p>All good!</p>
+      )}
+    </DashboardCard>
+  );
+};
+
+export default InventoryAlertsCard;

--- a/components/dashboard/OrdersThisMonthCard.tsx
+++ b/components/dashboard/OrdersThisMonthCard.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import DashboardCard from './DashboardCard';
+
+interface Props {
+  brand?: string;
+}
+
+interface Data {
+  count: number;
+  revenue: number;
+}
+
+const OrdersThisMonthCard: React.FC<Props> = ({ brand }) => {
+  const [data, setData] = useState<Data | null>(null);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    setData(null);
+    setError('');
+    const url =
+      '/api/dashboard/orders-this-month' +
+      (brand ? `?brand=${encodeURIComponent(brand)}` : '');
+    fetch(url)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then(setData)
+      .catch(() => setError('Failed to load'));
+  }, [brand]);
+
+  return (
+    <DashboardCard
+      title="Orders This Month"
+      loading={!data && !error}
+      error={error}
+    >
+      {data && (
+        <div>
+          <p className="text-3xl font-bold">{data.count}</p>
+          <p className="text-sm">£{data.revenue.toFixed(2)}</p>
+        </div>
+      )}
+    </DashboardCard>
+  );
+};
+
+export default OrdersThisMonthCard;

--- a/components/dashboard/TotalProductsCard.tsx
+++ b/components/dashboard/TotalProductsCard.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import DashboardCard from './DashboardCard';
+
+interface Props {
+  brand?: string;
+}
+
+const TotalProductsCard: React.FC<Props> = ({ brand }) => {
+  const [count, setCount] = useState<number | null>(null);
+  const [error, setError] = useState<string>('');
+  useEffect(() => {
+    setCount(null);
+    setError('');
+    const url =
+      '/api/dashboard/total-products' +
+      (brand ? `?brand=${encodeURIComponent(brand)}` : '');
+    fetch(url)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => setCount(data.count))
+      .catch(() => setError('Failed to load'));
+  }, [brand]);
+
+  return (
+    <DashboardCard
+      title="Total Products"
+      loading={count === null && !error}
+      error={error}
+    >
+      {count !== null && <p className="text-3xl font-bold">{count}</p>}
+    </DashboardCard>
+  );
+};
+
+export default TotalProductsCard;

--- a/components/dashboard/TotalSalesCard.tsx
+++ b/components/dashboard/TotalSalesCard.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import DashboardCard from './DashboardCard';
+
+interface Props {
+  brand?: string;
+}
+
+const TotalSalesCard: React.FC<Props> = ({ brand }) => {
+  const [total, setTotal] = useState<number | null>(null);
+  const [error, setError] = useState<string>('');
+  useEffect(() => {
+    setTotal(null);
+    setError('');
+    const url =
+      '/api/dashboard/total-sales' +
+      (brand ? `?brand=${encodeURIComponent(brand)}` : '');
+    fetch(url)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => setTotal(data.total))
+      .catch(() => setError('Failed to load'));
+  }, [brand]);
+
+  return (
+    <DashboardCard
+      title="Total Sales"
+      loading={total === null && !error}
+      error={error}
+    >
+      {total !== null && (
+        <p className="text-3xl font-bold">£{total.toFixed(2)}</p>
+      )}
+    </DashboardCard>
+  );
+};
+
+export default TotalSalesCard;

--- a/pages/api/dashboard/best-sellers.ts
+++ b/pages/api/dashboard/best-sellers.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDb } from '../../../lib/db';
+import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import type { ApiMessage } from '../../../types';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    { products: { id: string; title: string; quantity: number }[] } | ApiMessage
+  >
+) {
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const db = getDb();
+    const user = (req as any).user as { brandName?: string } | undefined;
+    const brand = user?.brandName || getQueryParam(req.query.brand);
+    const where: any = {};
+    if (brand) where.product = { vendor: { brandName: brand } };
+    const grouped = await db.order.groupBy({
+      by: ['productId'],
+      where,
+      _sum: { quantity: true },
+      orderBy: { _sum: { quantity: 'desc' } },
+      take: 5,
+    });
+    const ids = grouped.map((g) => g.productId);
+    const products = await db.product.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, title: true },
+    });
+    const map = new Map(products.map((p) => [p.id, p.title]));
+    const result = grouped.map((g) => ({
+      id: String(g.productId),
+      title: map.get(g.productId) || '',
+      quantity: g._sum.quantity || 0,
+    }));
+    return res.status(200).json({ products: result });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load best sellers');
+  }
+}
+
+export default withRole(['BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/api/dashboard/inventory-alerts.ts
+++ b/pages/api/dashboard/inventory-alerts.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDb } from '../../../lib/db';
+import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import type { ApiMessage } from '../../../types';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    { products: { id: string; title: string; quantity: number }[] } | ApiMessage
+  >
+) {
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const db = getDb();
+    const user = (req as any).user as { brandName?: string } | undefined;
+    const brand = user?.brandName || getQueryParam(req.query.brand);
+    const threshold = parseInt(getQueryParam(req.query.threshold) || '10', 10);
+    const where: any = { quantity: { lt: threshold } };
+    if (brand) where.vendor = { brandName: brand };
+    const products = await db.product.findMany({
+      where,
+      select: { id: true, title: true, quantity: true },
+    });
+    const result = products.map((p) => ({
+      id: String(p.id),
+      title: p.title,
+      quantity: p.quantity,
+    }));
+    return res.status(200).json({ products: result });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load inventory alerts');
+  }
+}
+
+export default withRole(['BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/api/dashboard/orders-this-month.ts
+++ b/pages/api/dashboard/orders-this-month.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import dayjs from 'dayjs';
+import { getDb } from '../../../lib/db';
+import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import type { ApiMessage } from '../../../types';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ count: number; revenue: number } | ApiMessage>
+) {
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const db = getDb();
+    const user = (req as any).user as { brandName?: string } | undefined;
+    const brand = user?.brandName || getQueryParam(req.query.brand);
+    const start = dayjs().startOf('month').toDate();
+    const where: any = {
+      createdAt: { gte: start },
+      status: 'completed',
+    };
+    if (brand) where.product = { vendor: { brandName: brand } };
+    const count = await db.order.count({ where });
+    const result = await db.order.aggregate({ where, _sum: { total: true } });
+    return res.status(200).json({ count, revenue: result._sum.total ?? 0 });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load orders');
+  }
+}
+
+export default withRole(['BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/api/dashboard/total-products.ts
+++ b/pages/api/dashboard/total-products.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDb } from '../../../lib/db';
+import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import type { ApiMessage } from '../../../types';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ count: number } | ApiMessage>
+) {
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const db = getDb();
+    const user = (req as any).user as { brandName?: string } | undefined;
+    const brand = user?.brandName || getQueryParam(req.query.brand);
+    const where = brand ? { vendor: { brandName: brand } } : {};
+    const count = await db.product.count({ where });
+    return res.status(200).json({ count });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load total products');
+  }
+}
+
+export default withRole(['BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDb } from '../../../lib/db';
+import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import type { ApiMessage } from '../../../types';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ total: number } | ApiMessage>
+) {
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const db = getDb();
+    const user = (req as any).user as { brandName?: string } | undefined;
+    const brand = user?.brandName || getQueryParam(req.query.brand);
+    const where: any = { status: 'completed' };
+    if (brand) where.product = { vendor: { brandName: brand } };
+    const result = await db.order.aggregate({ where, _sum: { total: true } });
+    return res.status(200).json({ total: result._sum.total ?? 0 });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load total sales');
+  }
+}
+
+export default withRole(['BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,38 @@
+import React, { useContext } from 'react';
+import Head from 'next/head';
+import { AppContext } from '../contexts/AppContext';
+import { getPageTitle } from '../lib/pageTitle';
+import TotalProductsCard from '../components/dashboard/TotalProductsCard';
+import TotalSalesCard from '../components/dashboard/TotalSalesCard';
+import OrdersThisMonthCard from '../components/dashboard/OrdersThisMonthCard';
+import BestSellersCard from '../components/dashboard/BestSellersCard';
+import InventoryAlertsCard from '../components/dashboard/InventoryAlertsCard';
+
+const DashboardPage: React.FC = () => {
+  const { user } = useContext(AppContext) as { user: any };
+  if (!user)
+    return <div className="p-4">Please log in to view the dashboard.</div>;
+  const role = (user.role || '').toLowerCase();
+  if (role !== 'brand' && role !== 'super_admin') {
+    return <div className="p-4">Access denied.</div>;
+  }
+  const brand = user.brandName || undefined;
+
+  return (
+    <div className="space-y-4">
+      <Head>
+        <title>{getPageTitle('Dashboard')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold">Dashboard Overview</h1>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <TotalProductsCard brand={brand} />
+        <TotalSalesCard brand={brand} />
+        <OrdersThisMonthCard brand={brand} />
+        <BestSellersCard brand={brand} />
+        <InventoryAlertsCard brand={brand} />
+      </div>
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -1,0 +1,18 @@
+export interface DashboardProduct {
+  id: string;
+  title: string;
+  quantity: number;
+}
+
+export interface OrdersThisMonth {
+  count: number;
+  revenue: number;
+}
+
+export interface DashboardMetrics {
+  totalProducts: number;
+  totalSales: number;
+  ordersThisMonth: OrdersThisMonth;
+  bestSellers: DashboardProduct[];
+  lowStock: DashboardProduct[];
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -16,3 +16,5 @@ export * from './shared';
 export * from './forms';
 export * from './paymentMethod';
 export * from './payment';
+
+export * from "./dashboard";


### PR DESCRIPTION
## Summary
- provide new dashboard widgets for business metrics
- implement API routes to supply dashboard data
- export dashboard types
- add `/dashboard` page showing totals, trends and alerts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cc87c20a0832f8bcd2ade07c298c3