### PR TITLE
Add enhanced brand product management

### DIFF
--- a/components/ProductForm.tsx
+++ b/components/ProductForm.tsx
@@ -1,0 +1,238 @@
+import React, { useState, useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import CreatableSelect from 'react-select/creatable';
+import type { SelectOption } from './form-fields/SelectDropdown';
+import { TextInput, Textarea, FileUpload, Checkbox } from './form-fields';
+
+export interface ProductFormValues {
+  sku: string;
+  title: string;
+  description: string;
+  productType: string;
+  tags: string;
+  category: string;
+  quantity: number;
+  minPrice: number;
+  maxPrice: number;
+  currency: string;
+  available: boolean;
+}
+
+interface ProductFormProps {
+  initial?: Partial<ProductFormValues>;
+  onSubmit: (data: FormData) => Promise<void> | void;
+  onCancel?: () => void;
+  submitLabel?: string;
+}
+
+const ProductForm: React.FC<ProductFormProps> = ({
+  initial,
+  onSubmit,
+  onCancel,
+  submitLabel = 'Save',
+}) => {
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useForm<ProductFormValues>({
+    defaultValues: {
+      sku: initial?.sku || '',
+      title: initial?.title || '',
+      description: initial?.description || '',
+      productType: initial?.productType || '',
+      tags: initial?.tags || '',
+      category: initial?.category || '',
+      quantity: initial?.quantity ?? 0,
+      minPrice: initial?.minPrice ?? 0,
+      maxPrice: initial?.maxPrice ?? 0,
+      currency: initial?.currency || 'USD',
+      available: initial?.available ?? true,
+    },
+  });
+  const [images, setImages] = useState<File[]>([]);
+  const [categoryOptions, setCategoryOptions] = useState<SelectOption[]>([]);
+  const loadCategories = async () => {
+    if (categoryOptions.length > 0) return;
+    const res = await fetch('/api/categories');
+    if (!res.ok) return;
+    const data = await res.json();
+    const opts = (data.categories || []).map((c: any) => ({
+      label: c.name,
+      value: c.name,
+    }));
+    setCategoryOptions(opts);
+  };
+  useEffect(() => {
+    loadCategories();
+  }, []);
+
+  const onFormSubmit = handleSubmit(async (values) => {
+    const fd = new FormData();
+    fd.append('sku', values.sku);
+    fd.append('title', values.title);
+    fd.append('description', values.description);
+    fd.append('product_type', values.productType);
+    fd.append('tags', values.tags);
+    fd.append('category', values.category);
+    fd.append('quantity', values.available ? String(values.quantity) : '0');
+    fd.append('min_price', String(values.minPrice));
+    fd.append('max_price', String(values.maxPrice));
+    fd.append('currency', values.currency);
+    images.forEach((img) => fd.append('photos', img));
+    await onSubmit(fd);
+  });
+
+  const handleImagesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files ? Array.from(e.target.files) : [];
+    setImages(files);
+  };
+
+  return (
+    <form onSubmit={onFormSubmit} className="space-y-2">
+      <TextInput<ProductFormValues>
+        label="SKU"
+        name="sku"
+        register={register}
+        rules={{ required: 'Required' }}
+        error={errors.sku?.message}
+      />
+      <TextInput<ProductFormValues>
+        label="Title"
+        name="title"
+        register={register}
+        rules={{ required: 'Required' }}
+        error={errors.title?.message}
+      />
+      <Textarea<ProductFormValues>
+        label="Description"
+        name="description"
+        register={register}
+        rules={{ required: 'Required' }}
+        error={errors.description?.message}
+      />
+      <TextInput<ProductFormValues>
+        label="Product Type"
+        name="productType"
+        register={register}
+        error={errors.productType?.message}
+      />
+      <TextInput<ProductFormValues>
+        label="Tags"
+        name="tags"
+        register={register}
+        error={errors.tags?.message}
+      />
+      <Controller
+        name="category"
+        control={control}
+        rules={{ required: 'Required' }}
+        render={({ field }) => (
+          <CreatableSelect
+            {...field}
+            options={categoryOptions}
+            onChange={(val) => {
+              if (!val) return field.onChange('');
+              if (Array.isArray(val)) return;
+              field.onChange(val.value);
+            }}
+            onCreateOption={async (input) => {
+              await fetch('/api/brand/categories', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: input }),
+              });
+              const opt = { label: input, value: input };
+              setCategoryOptions((prev) => [...prev, opt]);
+              field.onChange(input);
+            }}
+            placeholder="Category"
+            classNamePrefix="react-select"
+          />
+        )}
+      />
+      {errors.category && (
+        <p className="text-sm text-red-600">{errors.category.message}</p>
+      )}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <TextInput<ProductFormValues>
+          label="Quantity"
+          name="quantity"
+          type="number"
+          min={0}
+          register={register}
+          rules={{ min: { value: 0, message: 'Must be >= 0' } }}
+          error={errors.quantity?.message}
+        />
+        <Checkbox<ProductFormValues>
+          label="Available"
+          name="available"
+          checked={watch('available')}
+          onChange={(e) => setValue('available', e.target.checked)}
+        />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <TextInput<ProductFormValues>
+          label="Min Price"
+          name="minPrice"
+          type="number"
+          min={0}
+          step="0.01"
+          register={register}
+          rules={{ min: { value: 0, message: 'Must be >= 0' } }}
+          error={errors.minPrice?.message}
+        />
+        <TextInput<ProductFormValues>
+          label="Max Price"
+          name="maxPrice"
+          type="number"
+          min={0}
+          step="0.01"
+          register={register}
+          rules={{ min: { value: 0, message: 'Must be >= 0' } }}
+          error={errors.maxPrice?.message}
+        />
+      </div>
+      <TextInput<ProductFormValues>
+        label="Currency"
+        name="currency"
+        register={register}
+        error={errors.currency?.message}
+      />
+      <FileUpload<ProductFormValues>
+        label="Images"
+        name="images"
+        multiple
+        accept="image/*"
+        onChange={handleImagesChange}
+      />
+      {images.length > 0 && (
+        <div className="flex gap-2 flex-wrap">
+          {images.map((img, idx) => (
+            <img
+              key={idx}
+              src={URL.createObjectURL(img)}
+              alt="preview"
+              className="w-20 h-20 object-cover rounded"
+            />
+          ))}
+        </div>
+      )}
+      <div className="flex gap-2 mt-2">
+        {onCancel && (
+          <button type="button" className="btn" onClick={onCancel}>
+            Cancel
+          </button>
+        )}
+        <button type="submit" className="btn btn-primary">
+          {submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ProductForm;

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -9,6 +9,34 @@ import { hasOrdersForProduct } from '../../../../lib/orders';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../../lib/utils/getQueryParam';
 import type { ApiMessage, ProductInput } from '../../../../types';
+import formidable, { type Fields, type Files, type File } from 'formidable';
+import fs from 'fs';
+import path from 'path';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function parseBody(
+  req: NextApiRequest
+): Promise<{ fields: Fields; files: Files }> {
+  const type = req.headers['content-type'] || '';
+  if (type.includes('application/json')) {
+    const buffers: Uint8Array[] = [];
+    for await (const chunk of req) buffers.push(chunk);
+    const body = Buffer.concat(buffers).toString();
+    return { fields: JSON.parse(body || '{}') as Fields, files: {} as Files };
+  }
+  return new Promise<{ fields: Fields; files: Files }>((resolve, reject) => {
+    const form = formidable({ multiples: true });
+    form.parse(req, (err, fields, files) => {
+      if (err) reject(err);
+      else resolve({ fields, files });
+    });
+  });
+}
 
 export default async function handler(
   req: NextApiRequest,
@@ -21,6 +49,7 @@ export default async function handler(
     if (req.method === 'PUT') {
       const existing = await getProductByUuid(String(uuid));
       if (!existing) return res.status(404).json({ message: 'Not found' });
+      const { fields, files } = await parseBody(req);
       const {
         title,
         sku,
@@ -33,31 +62,47 @@ export default async function handler(
         min_price,
         max_price,
         currency,
-      } = req.body || {};
+      } = fields as Record<string, unknown>;
+      const photos: File[] = files.photos
+        ? Array.isArray(files.photos)
+          ? (files.photos as File[])
+          : [files.photos as File]
+        : [];
+      const destDir = path.join(process.cwd(), 'public', 'uploads', String(uuid));
+      fs.mkdirSync(destDir, { recursive: true });
+      const imagePaths: string[] = [];
+      for (const file of photos) {
+        const name = Date.now() + '-' + file.originalFilename;
+        const destPath = path.join(destDir, name);
+        fs.renameSync(file.filepath, destPath);
+        imagePaths.push(`/uploads/${uuid}/${name}`);
+      }
       const payload: ProductInput & { id?: string } = {
         uuid: String(uuid),
-        sku: sku ?? existing.sku,
-        title: title ?? existing.title,
-        vendor: { email: '', brandName: vendor ?? existing.vendor },
-        description: description ?? existing.description,
-        productType: product_type ?? existing.product_type,
-        tags: tags ?? existing.tags,
-        category: { name: category ?? existing.category, slug: '' },
+        sku: String(sku ?? existing.sku),
+        title: String(title ?? existing.title),
+        vendor: { email: '', brandName: String(vendor ?? existing.vendor) },
+        description: String(description ?? existing.description),
+        productType: String(product_type ?? existing.product_type),
+        tags: String(tags ?? existing.tags),
+        category: { name: String(category ?? existing.category), slug: '' },
         quantity:
           typeof quantity !== 'undefined'
-            ? parseInt(quantity, 10)
+            ? parseInt(String(quantity), 10)
             : existing.quantity,
         minPrice:
           typeof min_price !== 'undefined'
-            ? parseFloat(min_price)
+            ? parseFloat(String(min_price))
             : existing.min_price,
         maxPrice:
           typeof max_price !== 'undefined'
-            ? parseFloat(max_price)
+            ? parseFloat(String(max_price))
             : existing.max_price,
-        currency: currency ?? existing.currency,
+        currency: String(currency ?? existing.currency),
         status: existing.status,
-        images: [],
+        images: imagePaths.length > 0
+          ? imagePaths.map((p) => ({ url: p }))
+          : undefined,
       };
       await updateProduct(payload);
       await loadAndIndexProducts();

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -4,6 +4,34 @@ import { handleApiError } from '../../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../../lib/utils/getQueryParam';
 import { slugify } from '../../../../lib/slugify';
 import type { Product, ProductInput, ApiMessage } from '../../../../types';
+import formidable, { type Fields, type Files, type File } from 'formidable';
+import fs from 'fs';
+import path from 'path';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function parseBody(
+  req: NextApiRequest
+): Promise<{ fields: Fields; files: Files }> {
+  const type = req.headers['content-type'] || '';
+  if (type.includes('application/json')) {
+    const buffers: Uint8Array[] = [];
+    for await (const chunk of req) buffers.push(chunk);
+    const body = Buffer.concat(buffers).toString();
+    return { fields: JSON.parse(body || '{}') as Fields, files: {} as Files };
+  }
+  return new Promise<{ fields: Fields; files: Files }>((resolve, reject) => {
+    const form = formidable({ multiples: true });
+    form.parse(req, (err, fields, files) => {
+      if (err) reject(err);
+      else resolve({ fields, files });
+    });
+  });
+}
 
 export default async function handler(
   req: NextApiRequest,
@@ -19,6 +47,7 @@ export default async function handler(
     }
 
     if (req.method === 'POST') {
+      const { fields, files } = await parseBody(req);
       const {
         id,
         sku,
@@ -32,28 +61,42 @@ export default async function handler(
         min_price,
         max_price,
         currency,
-      } = req.body || {};
+      } = fields as Record<string, unknown>;
       if (!id || !sku || !title || !vendor) {
         return res
           .status(400)
           .json({ message: 'id, sku, title, vendor required' });
       }
+      const photos: File[] = files.photos
+        ? Array.isArray(files.photos)
+          ? (files.photos as File[])
+          : [files.photos as File]
+        : [];
+      const destDir = path.join(process.cwd(), 'public', 'uploads', String(id));
+      fs.mkdirSync(destDir, { recursive: true });
+      const imagePaths: string[] = [];
+      for (const file of photos) {
+        const name = Date.now() + '-' + file.originalFilename;
+        const destPath = path.join(destDir, name);
+        fs.renameSync(file.filepath, destPath);
+        imagePaths.push(`/uploads/${id}/${name}`);
+      }
       const payload: ProductInput = {
-        sku,
-        title,
-        slug: slugify(title || String(id)),
+        sku: String(sku),
+        title: String(title),
+        slug: slugify(String(title || id)),
         uuid: String(id),
-        vendor: { email: '', brandName: vendor },
-        description,
-        productType: product_type,
-        tags,
-        category: { name: category, slug: '' },
-        quantity: quantity ? parseInt(quantity, 10) : 0,
-        minPrice: parseFloat(min_price || '0'),
-        maxPrice: parseFloat(max_price || '0'),
-        currency: currency || 'USD',
+        vendor: { email: '', brandName: String(vendor) },
+        description: String(description || ''),
+        productType: String(product_type || ''),
+        tags: String(tags || ''),
+        category: { name: String(category || ''), slug: '' },
+        quantity: quantity ? parseInt(String(quantity), 10) : 0,
+        minPrice: parseFloat(String(min_price || '0')),
+        maxPrice: parseFloat(String(max_price || '0')),
+        currency: String(currency || 'USD'),
         status: 'approved',
-        images: [],
+        images: imagePaths.map((p) => ({ url: p })),
       };
       await addProduct(payload);
       await loadAndIndexProducts();

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -1,72 +1,20 @@
-import React, {
-  useState,
-  useEffect,
-  useContext,
-  useCallback,
-  ChangeEvent,
-  FormEvent,
-} from 'react';
+import React, { useState, useEffect, useContext, useCallback } from 'react';
 import { AppContext } from '../../contexts/AppContext';
+import { NotificationContext } from '../../contexts/NotificationContext';
 import type { User } from '../../types/user';
-import type { Product, ProductInput } from '../../types/product';
-import { TextInput } from '../../components/form-fields';
+import type { Product } from '../../types/product';
+import ProductForm from '../../components/ProductForm';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
 
-type ProductForm = Partial<ProductInput> & { id?: string };
-
 type ProductApi = Product;
-
-const emptyForm: ProductForm = {
-  id: '',
-  sku: '',
-  title: '',
-  vendor: { email: '', brandName: '' },
-  description: '',
-  productType: '',
-  tags: '',
-  category: { name: '', slug: '' },
-  quantity: 0,
-  minPrice: 0,
-  maxPrice: 0,
-  currency: 'USD',
-};
-
-const labels: Record<keyof ProductForm, string> = {
-  id: 'ID',
-  sku: 'SKU',
-  title: 'Title',
-  vendor: 'Vendor',
-  description: 'Description',
-  productType: 'Product Type',
-  tags: 'Tags',
-  category: 'Category',
-  quantity: 'Quantity',
-  minPrice: 'Min Price',
-  maxPrice: 'Max Price',
-  currency: 'Currency',
-};
-
-const requiredFields: (keyof ProductForm)[] = [
-  'sku',
-  'title',
-  'vendor',
-  'category',
-  'quantity',
-  'minPrice',
-  'maxPrice',
-];
 
 const BrandDashboard: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
-  const [form, setForm] = useState<ProductForm>(emptyForm);
-  const [errors, setErrors] = useState<
-    Partial<Record<keyof ProductForm, string>>
-  >({});
+  const [editing, setEditing] = useState<ProductApi | null>(null);
   const [products, setProducts] = useState<ProductApi[]>([]);
   const [lowStock, setLowStock] = useState<ProductApi[]>([]);
-  const [message, setMessage] = useState<string>('');
-  const [editingId, setEditingId] = useState<string | null>(null);
+  const { addNotification } = useContext(NotificationContext);
 
   const fetchProducts = useCallback(async () => {
     if (!user) return;
@@ -88,123 +36,29 @@ const BrandDashboard: React.FC = () => {
     fetchProducts();
   }, [fetchProducts]);
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setErrors((prev) => ({ ...prev, [name]: undefined }));
-    setForm((prev) => {
-      if (name === 'vendor') {
-        return {
-          ...prev,
-          vendor: { ...(prev.vendor || { email: '' }), brandName: value },
-        };
-      }
-      if (name === 'category') {
-        return {
-          ...prev,
-          category: { ...(prev.category || { slug: '' }), name: value },
-        };
-      }
-      if (name === 'quantity' || name === 'minPrice' || name === 'maxPrice') {
-        const num = Number(value);
-        return { ...prev, [name]: num < 0 ? 0 : num };
-      }
-      return { ...prev, [name]: value };
-    });
-    if (name === 'quantity' || name === 'minPrice' || name === 'maxPrice') {
-      const num = Number(value);
-      if (num < 0) {
-        setErrors((prev) => ({
-          ...prev,
-          [name]: 'Value must be non-negative',
-        }));
-      }
-    }
-  };
-
-  const submit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const newErrors: Partial<Record<keyof ProductForm, string>> = {};
-    requiredFields.forEach((field) => {
-      let val: any = (form as any)[field];
-      if (field === 'vendor') val = form.vendor?.brandName;
-      if (field === 'category') val = form.category?.name;
-      if (
-        val === undefined ||
-        val === null ||
-        (typeof val === 'string' && val.trim() === '')
-      ) {
-        newErrors[field] = 'This field is required';
-      }
-    });
-    ['quantity', 'minPrice', 'maxPrice'].forEach((f) => {
-      const val = (form as any)[f];
-      if (typeof val === 'number' && val < 0) {
-        newErrors[f as keyof ProductForm] = 'Value must be non-negative';
-      }
-    });
-    setErrors(newErrors);
-    if (Object.keys(newErrors).length > 0) return;
-    const payload = editingId ? { ...form, id: editingId } : form;
-    const url = editingId
-      ? `/api/brand/products/${editingId}`
-      : '/api/brand/products';
-    const method = editingId ? 'PUT' : 'POST';
-    const res = await fetch(url, {
-      method,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        id: payload.id,
-        sku: payload.sku,
-        title: payload.title,
-        vendor: payload.vendor?.brandName,
-        description: payload.description,
-        product_type: payload.productType,
-        tags: payload.tags,
-        category: payload.category?.name,
-        quantity: payload.quantity,
-        min_price: payload.minPrice,
-        max_price: payload.maxPrice,
-        currency: payload.currency,
-      }),
-    });
+  const submitProduct = async (
+    values: FormData,
+    id?: string
+  ): Promise<void> => {
+    const url = id ? `/api/brand/products/${id}` : '/api/brand/products';
+    const method = id ? 'PUT' : 'POST';
+    const res = await fetch(url, { method, body: values });
     if (res.ok) {
-      setMessage(editingId ? 'Product updated' : 'Product added');
-      setForm(emptyForm);
-      setEditingId(null);
+      addNotification(id ? 'Product updated' : 'Product added', 'success');
+      setEditing(null);
       fetchProducts();
     } else {
-      const data = await res.json();
-      setMessage(data.message || 'Error');
+      const data = await res.json().catch(() => ({ message: 'Error' }));
+      addNotification(data.message || 'Error', 'error');
     }
   };
 
   const handleEdit = (p: ProductApi) => {
-    setForm({
-      id: p.id,
-      sku: p.sku || '',
-      title: p.title || '',
-      vendor:
-        typeof p.vendor === 'string'
-          ? { email: '', brandName: p.vendor }
-          : p.vendor || { email: '', brandName: '' },
-      description: p.description || '',
-      productType: p.productType || '',
-      tags: p.tags || '',
-      category:
-        typeof p.category === 'string'
-          ? { name: p.category, slug: '' }
-          : p.category || { name: '', slug: '' },
-      quantity: p.totalInventory || 0,
-      minPrice: p.minPrice || 0,
-      maxPrice: p.maxPrice || 0,
-      currency: p.currency || 'USD',
-    });
-    setEditingId(p.id);
+    setEditing(p);
   };
 
   const cancelEdit = () => {
-    setEditingId(null);
-    setForm(emptyForm);
+    setEditing(null);
   };
 
   const handleDelete = async (id: string) => {
@@ -213,7 +67,10 @@ const BrandDashboard: React.FC = () => {
       method: 'DELETE',
     });
     if (res.ok) {
+      addNotification('Product deleted', 'success');
       fetchProducts();
+    } else {
+      addNotification('Delete failed', 'error');
     }
   };
 
@@ -237,66 +94,26 @@ const BrandDashboard: React.FC = () => {
             {lowStock.length > 1 ? 's' : ''}.
           </div>
         )}
-        {message && <div className="mb-4 text-green-600">{message}</div>}
 
-        <form onSubmit={submit} className="space-y-2 mb-6">
-          {(
-            [
-              'id',
-              'sku',
-              'title',
-              'vendor',
-              'description',
-              'productType',
-              'tags',
-              'category',
-              'quantity',
-              'minPrice',
-              'maxPrice',
-              'currency',
-            ] as (keyof ProductForm)[]
-          ).map((field) => (
-            <TextInput
-              key={field}
-              label={labels[field]}
-              name={field as keyof ProductForm}
-              value={
-                field === 'vendor'
-                  ? form.vendor?.brandName || ''
-                  : field === 'category'
-                    ? form.category?.name || ''
-                    : (form as any)[field]
-              }
-              onChange={handleChange as any}
-              placeholder={labels[field]}
-              type={
-                field === 'quantity' ||
-                field === 'minPrice' ||
-                field === 'maxPrice'
-                  ? 'number'
-                  : 'text'
-              }
-              min={
-                field === 'quantity' ||
-                field === 'minPrice' ||
-                field === 'maxPrice'
-                  ? 0
-                  : undefined
-              }
-              error={errors[field]}
-            />
-          ))}
-          <div className="flex gap-2">
-            {editingId && (
-              <button type="button" onClick={cancelEdit} className="btn">
-                Cancel
-              </button>
-            )}
-            <button type="submit" className="btn btn-primary">
-              {editingId ? 'Update Product' : 'Add Product'}
-            </button>
-          </div>
-        </form>
+        <ProductForm
+          key={editing?.id || 'new'}
+          initial={editing ? {
+            sku: editing.sku,
+            title: editing.title,
+            description: editing.description,
+            productType: editing.productType,
+            tags: editing.tags,
+            category: typeof editing.category === 'string' ? editing.category : editing.category?.name,
+            quantity: editing.totalInventory || 0,
+            minPrice: editing.minPrice,
+            maxPrice: editing.maxPrice,
+            currency: editing.currency,
+            available: (editing.totalInventory ?? editing.quantity ?? 0) > 0,
+          } : undefined}
+          onSubmit={(fd) => submitProduct(fd, editing?.id)}
+          onCancel={editing ? () => setEditing(null) : undefined}
+          submitLabel={editing ? 'Update Product' : 'Add Product'}
+        />
         <h2 className="text-xl font-semibold mb-2">Existing Products</h2>
         <ul className="space-y-1">
           {products.map((p) => (


### PR DESCRIPTION
## Summary
- add reusable `ProductForm` component with validation and image upload
- update brand dashboard to use new form and notifications
- support uploading images in brand product API endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cc8bc3f14832fba93b53aa70c41bc