### PR TITLE
Enable category selection and creation for brand products

### DIFF
--- a/components/form-fields/AsyncSelectDropdown.tsx
+++ b/components/form-fields/AsyncSelectDropdown.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+  Control,
+  Controller,
+  RegisterOptions,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
+import AsyncCreatableSelect from 'react-select/async-creatable';
+
+export interface AsyncSelectOption {
+  label: string;
+  value: string | number;
+}
+
+export interface AsyncSelectDropdownProps<T extends FieldValues> {
+  label?: string;
+  name: Path<T>;
+  value?: AsyncSelectOption | AsyncSelectOption[] | null;
+  onChange?: (option: AsyncSelectOption | AsyncSelectOption[] | null) => void;
+  loadOptions: (inputValue: string) => Promise<AsyncSelectOption[]>;
+  onCreateOption?: (value: string) => void;
+  placeholder?: string;
+  isMulti?: boolean;
+  error?: string;
+  className?: string;
+  control?: Control<T>;
+  rules?: RegisterOptions<T, Path<T>>;
+}
+
+const AsyncSelectDropdown = <T extends FieldValues>(
+  props: AsyncSelectDropdownProps<T>
+) => {
+  const {
+    label,
+    name,
+    value,
+    onChange,
+    loadOptions,
+    onCreateOption,
+    placeholder,
+    isMulti = false,
+    error,
+    className = '',
+    control,
+    rules,
+    ...rest
+  } = props;
+  const inputId: string = typeof rest.id === 'string' ? rest.id : String(name);
+
+  const SelectComponent = (
+    <AsyncCreatableSelect
+      cacheOptions
+      defaultOptions
+      loadOptions={loadOptions}
+      onCreateOption={onCreateOption}
+      isMulti={isMulti}
+      inputId={inputId}
+      value={value as any}
+      onChange={(val) => {
+        if (Array.isArray(val)) {
+          onChange?.([...val] as any);
+        } else if (val === null) {
+          onChange?.(null);
+        } else {
+          onChange?.(val as any);
+        }
+      }}
+      placeholder={placeholder}
+      className={`w-full ${className}`}
+      classNamePrefix="react-select"
+      {...rest}
+    />
+  );
+
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 mb-1">
+          {label}
+        </label>
+      )}
+      {control ? (
+        <Controller name={name} control={control} rules={rules} render={({ field }) => React.cloneElement(SelectComponent, { ...field })} />
+      ) : (
+        SelectComponent
+      )}
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default AsyncSelectDropdown;

--- a/components/form-fields/index.ts
+++ b/components/form-fields/index.ts
@@ -8,3 +8,4 @@ export { default as RadioGroup } from './RadioGroup';
 export { default as DatePicker } from './DatePicker';
 export { default as FileUpload } from './FileUpload';
 export { default as CountrySelect } from './CountrySelect';
+export { default as AsyncSelectDropdown } from './AsyncSelectDropdown';

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -211,9 +211,18 @@ export async function addProduct(product: ProductInput): Promise<void> {
         where: { brandName: product.vendor.brandName },
       })
     : null;
-  const category = product.category?.name
-    ? await db.category.findFirst({ where: { name: product.category.name } })
-    : null;
+  let category = null;
+  if (product.category?.id) {
+    category = await db.category.findUnique({
+      where: { id: Number(product.category.id) },
+    });
+  } else if (product.category?.uuid) {
+    category = await db.category.findFirst({
+      where: { uuid: product.category.uuid },
+    });
+  } else if (product.category?.name) {
+    category = await db.category.findFirst({ where: { name: product.category.name } });
+  }
 
   if (!vendor || !category) {
     throw new Error('Invalid vendor or category');
@@ -248,9 +257,18 @@ export async function updateProduct(
         where: { brandName: product.vendor.brandName },
       })
     : null;
-  const category = product.category?.name
-    ? await db.category.findFirst({ where: { name: product.category.name } })
-    : null;
+  let category = null;
+  if (product.category?.id) {
+    category = await db.category.findUnique({
+      where: { id: Number(product.category.id) },
+    });
+  } else if (product.category?.uuid) {
+    category = await db.category.findFirst({
+      where: { uuid: product.category.uuid },
+    });
+  } else if (product.category?.name) {
+    category = await db.category.findFirst({ where: { name: product.category.name } });
+  }
   if (!vendor || !category) {
     throw new Error('Invalid vendor or category');
   }
@@ -500,13 +518,35 @@ export async function getCategoryTree(): Promise<Category[]> {
   return getCategoriesFlat();
 }
 
-export async function createCategory(name: string): Promise<void> {
+export async function getCategoriesPaginated(
+  search: string,
+  limit: number,
+  offset = 0
+): Promise<{ categories: Category[]; total: number }> {
+  const db = getDb();
+  const where: Prisma.CategoryWhereInput = search
+    ? { name: { contains: search, mode: 'insensitive' } }
+    : {};
+  const [total, rows] = await Promise.all([
+    db.category.count({ where }),
+    db.category.findMany({
+      where,
+      orderBy: { name: 'asc' },
+      take: limit,
+      skip: offset,
+    }),
+  ]);
+  return { categories: rows, total };
+}
+
+export async function createCategory(name: string): Promise<Category> {
   const db = getDb();
   const existing = await db.category.findFirst({ where: { name } });
-  if (existing) return;
-  await db.category.create({
+  if (existing) return existing;
+  const cat = await db.category.create({
     data: { name, slug: name.toLowerCase().replace(/\s+/g, '-') },
   });
+  return cat;
 }
 
 export async function renameCategory(

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -1,11 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoriesFlat, createCategory } from '../../../lib/products';
 import { handleApiError } from '../../../lib/utils/handleApiError';
-import type { ApiMessage } from '../../../types';
+import { withRole } from '../../../lib/withRole';
+import type { ApiMessage, Category } from '../../../types';
 
-export default async function handler(
+async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ApiMessage>
+  res: NextApiResponse<{ message: string; category?: Category }>
 ): Promise<void> {
   try {
     if (req.method !== 'POST') {
@@ -16,11 +17,13 @@ export default async function handler(
     const exists = (await getCategoriesFlat()).find(
       (c) => c.name.toLowerCase() === name.toLowerCase()
     );
-    if (!exists) {
-      await createCategory(name);
-    }
-    return res.status(201).json({ message: 'ok' });
+    const category = exists || (await createCategory(name));
+    return res
+      .status(exists ? 200 : 201)
+      .json({ message: 'ok', category });
   } catch (error) {
     return handleApiError(res, error, 'Failed to create category');
   }
 }
+
+export default withRole(['BRAND'])(handler);

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -28,7 +28,7 @@ export default async function handler(
         description,
         product_type,
         tags,
-        category,
+        categoryId,
         quantity,
         min_price,
         max_price,
@@ -42,7 +42,11 @@ export default async function handler(
         description: description ?? existing.description,
         productType: product_type ?? existing.product_type,
         tags: tags ?? existing.tags,
-        category: { name: category ?? existing.category, slug: '' },
+        category: {
+          id: categoryId
+            ? parseInt(String(categoryId), 10)
+            : existing.categoryId,
+        },
         quantity:
           typeof quantity !== 'undefined'
             ? parseInt(quantity, 10)

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -27,16 +27,16 @@ export default async function handler(
         description,
         product_type,
         tags,
-        category,
+        categoryId,
         quantity,
         min_price,
         max_price,
         currency,
       } = req.body || {};
-      if (!id || !sku || !title || !vendor) {
+      if (!id || !sku || !title || !vendor || !categoryId) {
         return res
           .status(400)
-          .json({ message: 'id, sku, title, vendor required' });
+          .json({ message: 'id, sku, title, vendor, categoryId required' });
       }
       const payload: ProductInput = {
         sku,
@@ -47,7 +47,7 @@ export default async function handler(
         description,
         productType: product_type,
         tags,
-        category: { name: category, slug: '' },
+        category: { id: categoryId ? parseInt(String(categoryId), 10) : undefined },
         quantity: quantity ? parseInt(quantity, 10) : 0,
         minPrice: parseFloat(min_price || '0'),
         maxPrice: parseFloat(max_price || '0'),

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -1,5 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getCategoryTree } from '../../lib/products';
+import {
+  getCategoryTree,
+  getCategoriesPaginated,
+} from '../../lib/products';
 import { handleApiError } from '../../lib/utils/handleApiError';
 import type { CategoriesResponse, ApiMessage } from '../../types';
 
@@ -9,6 +12,17 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method === 'GET') {
+      const q = typeof req.query?.q === 'string' ? req.query.q : '';
+      const page = parseInt(String((req.query?.page as string) || '1'), 10);
+      const perPage = parseInt(String((req.query?.perPage as string) || '20'), 10);
+      if (q || req.query?.page || req.query?.perPage) {
+        const { categories, total } = await getCategoriesPaginated(
+          q,
+          perPage,
+          (page - 1) * perPage
+        );
+        return res.status(200).json({ categories, total, page });
+      }
       const categories = await getCategoryTree();
       return res.status(200).json({ categories });
     }

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -9,11 +9,13 @@ import React, {
 import { AppContext } from '../../contexts/AppContext';
 import type { User } from '../../types/user';
 import type { Product, ProductInput } from '../../types/product';
-import { TextInput } from '../../components/form-fields';
+import { TextInput, AsyncSelectDropdown } from '../../components/form-fields';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
 
-type ProductForm = Partial<ProductInput> & { id?: string };
+type ProductForm = Partial<ProductInput> & { id?: string } & {
+  category?: { id?: number; name?: string; slug?: string } | null;
+};
 
 type ProductApi = Product;
 
@@ -25,7 +27,7 @@ const emptyForm: ProductForm = {
   description: '',
   productType: '',
   tags: '',
-  category: { name: '', slug: '' },
+  category: null,
   quantity: 0,
   minPrice: 0,
   maxPrice: 0,
@@ -98,12 +100,6 @@ const BrandDashboard: React.FC = () => {
           vendor: { ...(prev.vendor || { email: '' }), brandName: value },
         };
       }
-      if (name === 'category') {
-        return {
-          ...prev,
-          category: { ...(prev.category || { slug: '' }), name: value },
-        };
-      }
       if (name === 'quantity' || name === 'minPrice' || name === 'maxPrice') {
         const num = Number(value);
         return { ...prev, [name]: num < 0 ? 0 : num };
@@ -121,13 +117,40 @@ const BrandDashboard: React.FC = () => {
     }
   };
 
+  const loadCategoryOptions = async (inputValue: string) => {
+    const res = await fetch(
+      `/api/categories?q=${encodeURIComponent(inputValue)}&perPage=10`
+    );
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (data.categories || []).map((c: any) => ({
+      label: c.name,
+      value: c.id,
+    }));
+  };
+
+  const createCategoryOption = async (name: string) => {
+    const res = await fetch('/api/brand/categories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setForm((prev) => ({
+        ...prev,
+        category: { id: data.category.id, name: data.category.name },
+      }));
+    }
+  };
+
   const submit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const newErrors: Partial<Record<keyof ProductForm, string>> = {};
     requiredFields.forEach((field) => {
       let val: any = (form as any)[field];
       if (field === 'vendor') val = form.vendor?.brandName;
-      if (field === 'category') val = form.category?.name;
+      if (field === 'category') val = form.category?.id;
       if (
         val === undefined ||
         val === null ||
@@ -160,7 +183,7 @@ const BrandDashboard: React.FC = () => {
         description: payload.description,
         product_type: payload.productType,
         tags: payload.tags,
-        category: payload.category?.name,
+        categoryId: payload.category?.id,
         quantity: payload.quantity,
         min_price: payload.minPrice,
         max_price: payload.maxPrice,
@@ -190,10 +213,9 @@ const BrandDashboard: React.FC = () => {
       description: p.description || '',
       productType: p.productType || '',
       tags: p.tags || '',
-      category:
-        typeof p.category === 'string'
-          ? { name: p.category, slug: '' }
-          : p.category || { name: '', slug: '' },
+      category: p.category
+        ? { id: p.category.id, name: p.category.name, slug: p.category.slug }
+        : null,
       quantity: p.totalInventory || 0,
       minPrice: p.minPrice || 0,
       maxPrice: p.maxPrice || 0,
@@ -249,7 +271,6 @@ const BrandDashboard: React.FC = () => {
               'description',
               'productType',
               'tags',
-              'category',
               'quantity',
               'minPrice',
               'maxPrice',
@@ -263,9 +284,7 @@ const BrandDashboard: React.FC = () => {
               value={
                 field === 'vendor'
                   ? form.vendor?.brandName || ''
-                  : field === 'category'
-                    ? form.category?.name || ''
-                    : (form as any)[field]
+                  : (form as any)[field]
               }
               onChange={handleChange as any}
               placeholder={labels[field]}
@@ -286,6 +305,26 @@ const BrandDashboard: React.FC = () => {
               error={errors[field]}
             />
           ))}
+          <AsyncSelectDropdown
+            label={labels.category}
+            name="category"
+            value={
+              form.category
+                ? { label: form.category.name || '', value: form.category.id || '' }
+                : null
+            }
+            onChange={(opt) => {
+              if (!opt || Array.isArray(opt)) return;
+              setForm((prev) => ({
+                ...prev,
+                category: { id: Number(opt.value), name: opt.label },
+              }));
+            }}
+            loadOptions={loadCategoryOptions}
+            onCreateOption={createCategoryOption}
+            placeholder="Select category"
+            error={errors.category}
+          />
           <div className="flex gap-2">
             {editingId && (
               <button type="button" onClick={cancelEdit} className="btn">
@@ -302,7 +341,7 @@ const BrandDashboard: React.FC = () => {
           {products.map((p) => (
             <li key={p.id} className="flex justify-between items-center gap-2">
               <span>
-                {p.title} ({p.sku}) - {p.category || p.productType}
+                {p.title} ({p.sku}) - {p.category?.name || p.productType}
               </span>
               <div className="flex gap-2">
                 <button


### PR DESCRIPTION
## Summary
- create AsyncSelectDropdown component
- paginate categories API and add query support
- secure brand category creation API and return created category
- support category IDs when creating/updating products
- add category dropdown to brand dashboard for product forms

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685cc83b97e8832fa223f77ef8cc4378