### PR TITLE
Implement notifications and basic messaging

### DIFF
--- a/components/BrandHeader.tsx
+++ b/components/BrandHeader.tsx
@@ -8,6 +8,7 @@ import { AppContext } from '../contexts/AppContext';
 import MoonIcon from './icons/MoonIcon';
 import SunIcon from './icons/SunIcon';
 import UserIcon from './icons/UserIcon';
+import NotificationBell from './NotificationBell';
 import type { User } from '../types/user';
 
 interface HeaderProps {
@@ -71,6 +72,7 @@ const BrandHeader: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
           )}
         </nav>
         <nav className="flex items-center gap-2">
+          <NotificationBell />
           <label className="swap swap-rotate">
             <input
               type="checkbox"

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import BellIcon from './icons/BellIcon';
+import type { Notification } from '../types';
+
+export default function NotificationBell() {
+  const [items, setItems] = useState<Notification[]>([]);
+
+  const fetchNotifications = () => {
+    fetch('/api/brand/notifications')
+      .then((res) => (res.ok ? res.json() : []))
+      .then(setItems)
+      .catch(() => {});
+  };
+
+  useEffect(() => {
+    fetchNotifications();
+    const i = setInterval(fetchNotifications, 10000);
+    return () => clearInterval(i);
+  }, []);
+
+  const markAll = () => {
+    fetch('/api/brand/notifications', { method: 'PATCH' })
+      .then(() => fetchNotifications())
+      .catch(() => {});
+  };
+
+  const unread = items.filter((n) => !n.read).length;
+
+  return (
+    <div className="dropdown dropdown-end">
+      <div tabIndex={0} role="button" className="btn btn-ghost btn-circle">
+        <div className="indicator">
+          <BellIcon className="w-5 h-5" />
+          {unread > 0 && (
+            <span className="badge badge-sm indicator-item">{unread}</span>
+          )}
+        </div>
+      </div>
+      <ul
+        tabIndex={0}
+        className="dropdown-content menu p-2 shadow bg-base-100 rounded w-52 space-y-1"
+      >
+        <li className="flex justify-between items-center">
+          <span className="font-semibold">Notifications</span>
+          {unread > 0 && (
+            <button type="button" className="btn btn-xs" onClick={markAll}>
+              Mark all as read
+            </button>
+          )}
+        </li>
+        {items.map((n) => (
+          <li key={n.id} className={n.read ? '' : 'font-semibold'}>
+            <span>{n.message}</span>
+          </li>
+        ))}
+        {items.length === 0 && <li>No notifications</li>}
+      </ul>
+    </div>
+  );
+}

--- a/components/icons/BellIcon.tsx
+++ b/components/icons/BellIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const BellIcon: React.FC<IconProps> = ({
+  size = 24,
+  color = 'currentColor',
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M14.5 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m5.5 0v1a3.5 3.5 0 11-7 0v-1m7.5 0h-8"
+    />
+  </svg>
+);
+
+export default BellIcon;

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,0 +1,18 @@
+import { prisma } from './prisma';
+import type { Message } from '../types';
+
+export async function createMessage(data: {
+  senderId: number;
+  receiverId: number;
+  orderId: number;
+  content: string;
+}): Promise<Message> {
+  return prisma.message.create({ data });
+}
+
+export async function getMessagesForOrder(orderId: number): Promise<Message[]> {
+  return prisma.message.findMany({
+    where: { orderId },
+    orderBy: { createdAt: 'asc' },
+  });
+}

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,0 +1,24 @@
+import { prisma } from './prisma';
+import type { Notification } from '../types';
+
+export async function createNotification(data: {
+  userId: number;
+  orderId: number;
+  message: string;
+}): Promise<Notification> {
+  return prisma.notification.create({ data });
+}
+
+export async function getNotificationsForUser(userId: number): Promise<Notification[]> {
+  return prisma.notification.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function markNotificationsRead(userId: number): Promise<void> {
+  await prisma.notification.updateMany({
+    where: { userId, read: false },
+    data: { read: true },
+  });
+}

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -1,6 +1,7 @@
 import { Order, Product } from '../types';
 import { getDb } from './db';
 import { mapDbRowToProduct } from './products';
+import { createNotification } from './notifications';
 import type { Prisma } from '@prisma/client';
 
 type OrderWithRelations = Prisma.OrderGetPayload<{
@@ -75,6 +76,16 @@ export async function addOrder({
           user: true,
           product: { include: { vendor: true, category: true } },
         },
+      })
+    )
+  );
+
+  await Promise.all(
+    createdOrders.map((o) =>
+      createNotification({
+        userId: o.product.vendor.id,
+        orderId: o.id,
+        message: `New order for ${o.product.title}`,
       })
     )
   );

--- a/pages/api/brand/notifications.ts
+++ b/pages/api/brand/notifications.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { getNotificationsForUser, markNotificationsRead } from '../../../lib/notifications';
+import { findUser } from '../../../lib/users';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { Notification, ApiMessage } from '../../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Notification[] | ApiMessage>
+): Promise<void> {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
+    const user = await findUser(session.user.email);
+    if (!user) return res.status(404).json({ message: 'User not found' });
+
+    if (req.method === 'GET') {
+      const notes = await getNotificationsForUser(user.id);
+      return res.status(200).json(notes);
+    }
+
+    if (req.method === 'PATCH') {
+      await markNotificationsRead(user.id);
+      const notes = await getNotificationsForUser(user.id);
+      return res.status(200).json(notes);
+    }
+
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage notifications');
+  }
+}

--- a/pages/api/messages/[orderId].ts
+++ b/pages/api/messages/[orderId].ts
@@ -1,0 +1,55 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { createMessage, getMessagesForOrder } from '../../../lib/messages';
+import { getOrderByUuid } from '../../../lib/orders';
+import { findUser } from '../../../lib/users';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import type { Message, ApiMessage } from '../../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Message[] | Message | ApiMessage>
+): Promise<void> {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
+
+    const orderUuid = getQueryParam(req.query.orderId);
+    if (!orderUuid) return res.status(400).json({ message: 'orderId required' });
+    const order = await getOrderByUuid(String(orderUuid));
+    if (!order) return res.status(404).json({ message: 'Order not found' });
+
+    const user = await findUser(session.user.email);
+    if (!user) return res.status(404).json({ message: 'User not found' });
+
+    const isBuyer = order.userId === user.id;
+    const isVendor = order.product.vendor.id === user.id;
+    if (!isBuyer && !isVendor && user.role !== 'SUPER_ADMIN') {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    if (req.method === 'GET') {
+      const msgs = await getMessagesForOrder(order.id);
+      return res.status(200).json(msgs);
+    }
+
+    if (req.method === 'POST') {
+      const { content } = req.body as { content?: string };
+      if (!content) return res.status(400).json({ message: 'content required' });
+      const receiverId = isBuyer ? order.product.vendor.id : order.userId;
+      const msg = await createMessage({
+        senderId: user.id,
+        receiverId,
+        orderId: order.id,
+        content,
+      });
+      return res.status(201).json(msg);
+    }
+
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage messages');
+  }
+}

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -46,11 +46,14 @@ const BrandOrders: React.FC = () => {
       )}
       <ul className="space-y-2">
         {orders.map((o) => (
-          <li key={o.id} className="border p-2">
+          <li key={o.id} className="border p-2 space-y-1">
             <p>
               Order #{o.id} - {o.status}
             </p>
             <p>Total: £{o.total}</p>
+            <p>
+              <a className="link" href={`/messages/${o.uuid}`}>Chat</a>
+            </p>
           </li>
         ))}
         {!loading && orders.length === 0 && <li>No orders found.</li>}

--- a/pages/messages/[orderId].tsx
+++ b/pages/messages/[orderId].tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import useRequireAuth from '../../hooks/useRequireAuth';
+import type { Message } from '../../types';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
+
+export default function OrderMessages() {
+  const user = useRequireAuth();
+  const router = useRouter();
+  const { orderId } = router.query;
+  const [msgs, setMsgs] = useState<Message[]>([]);
+  const [text, setText] = useState('');
+
+  const fetchMsgs = () => {
+    if (!orderId) return;
+    fetch(`/api/messages/${orderId}`)
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setMsgs(data))
+      .catch(() => {});
+  };
+
+  useEffect(() => {
+    fetchMsgs();
+    const i = setInterval(fetchMsgs, 5000);
+    return () => clearInterval(i);
+  }, [orderId]);
+
+  const send = () => {
+    if (!text.trim()) return;
+    fetch(`/api/messages/${orderId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: text }),
+    })
+      .then((res) => res.ok && res.json())
+      .then(() => {
+        setText('');
+        fetchMsgs();
+      })
+      .catch(() => {});
+  };
+
+  if (!user) return null;
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <Head>
+        <title>{getPageTitle('Messages')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Order Messages</h1>
+      <div className="border rounded p-2 h-64 overflow-y-auto mb-2 space-y-1">
+        {msgs.map((m) => (
+          <div key={m.id}>
+            <span className="text-xs text-gray-500 mr-2">
+              {new Date(m.createdAt).toLocaleString()}
+            </span>
+            <span>{m.content}</span>
+          </div>
+        ))}
+        {msgs.length === 0 && <p>No messages</p>}
+      </div>
+      <div className="flex gap-2">
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="input input-bordered flex-1"
+          placeholder="Message"
+        />
+        <button type="button" className="btn btn-primary" onClick={send}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -51,6 +51,7 @@ const Orders: React.FC<OrdersProps> = (_props) => {
                 <th>Status</th>
                 <th>Total</th>
                 <th>Date</th>
+                <th>Chat</th>
               </tr>
             </thead>
             <tbody>
@@ -85,6 +86,9 @@ const Orders: React.FC<OrdersProps> = (_props) => {
                   </td>
                   <td>£{o.total}</td>
                   <td>{new Date(o.createdAt).toLocaleDateString()}</td>
+                  <td>
+                    <a className="link" href={`/messages/${o.uuid}`}>Chat</a>
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/pages/vendor/orders.tsx
+++ b/pages/vendor/orders.tsx
@@ -80,6 +80,9 @@ export default function VendorOrders() {
               ))}
             </select>
             <p>Total: £{o.total}</p>
+            <p>
+              <a className="link" href={`/messages/${o.uuid}`}>Chat</a>
+            </p>
           </li>
         ))}
         {!loading && orders.length === 0 && <li>No orders found.</li>}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -186,3 +186,28 @@ model Payment {
   order         Order         @relation(fields: [orderId], references: [id])
   paymentMethod PaymentMethod @relation(fields: [paymentMethodId], references: [id])
 }
+
+model Notification {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  orderId   Int
+  message   String
+  read      Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  user  User  @relation(fields: [userId], references: [id])
+  order Order @relation(fields: [orderId], references: [id])
+}
+
+model Message {
+  id         Int      @id @default(autoincrement())
+  senderId   Int
+  receiverId Int
+  orderId    Int
+  content    String
+  createdAt  DateTime @default(now())
+
+  sender   User  @relation("SentMessages", fields: [senderId], references: [id])
+  receiver User  @relation("ReceivedMessages", fields: [receiverId], references: [id])
+  order    Order @relation(fields: [orderId], references: [id])
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,3 +18,5 @@ export * from './paymentMethod';
 export * from './payment';
 
 export * from "./dashboard";
+export * from './notification';
+export * from './message';

--- a/types/message.ts
+++ b/types/message.ts
@@ -1,0 +1,3 @@
+import type { Message as PrismaMessage } from '@prisma/client';
+
+export interface Message extends PrismaMessage {}

--- a/types/notification.ts
+++ b/types/notification.ts
@@ -1,0 +1,3 @@
+import type { Notification as PrismaNotification } from '@prisma/client';
+
+export interface Notification extends PrismaNotification {}


### PR DESCRIPTION
## Summary
- add NotificationBell UI component with new BellIcon
- notify brand users of orders via API
- store notifications/messages in Prisma models
- brand header shows unread order notifications
- add messaging endpoints and simple conversation page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ccca5215c832f8c703674d9c549b1