### PR TITLE
Enhance storefront UI features

### DIFF
--- a/components/ProductCardSkeleton.tsx
+++ b/components/ProductCardSkeleton.tsx
@@ -1,0 +1,10 @@
+const ProductCardSkeleton = () => (
+  <div className="border border-base-300 rounded-xl p-2 animate-pulse flex flex-col gap-2">
+    <div className="bg-base-300 h-32 rounded w-full" />
+    <div className="h-4 bg-base-300 rounded w-3/4" />
+    <div className="h-3 bg-base-300 rounded w-full" />
+    <div className="h-4 bg-base-300 rounded w-1/2 mt-auto" />
+  </div>
+);
+
+export default ProductCardSkeleton;

--- a/components/ProductGrid.tsx
+++ b/components/ProductGrid.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ProductCard from './ProductCard';
+import ProductCardSkeleton from './ProductCardSkeleton';
 import type { Product } from '../types/product';
 
 interface ProductGridProps {
@@ -16,7 +17,7 @@ const ProductGrid: React.FC<ProductGridProps> = ({
       className={`min-h-[300px] grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3 sm:gap-4 lg:gap-5 ${className}`}
     >
       {products.length === 0 ? (
-        <p className="text-gray-500 col-span-full">No products found.</p>
+        Array.from({ length: 8 }).map((_, i) => <ProductCardSkeleton key={i} />)
       ) : (
         products.map((p) => (
           <ProductCard key={p.id} product={p} className="w-full" />

--- a/components/PromoBanner.tsx
+++ b/components/PromoBanner.tsx
@@ -1,0 +1,51 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import type { FC } from 'react';
+
+const banners = [
+  {
+    image:
+      'https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=900&q=80',
+    text: 'Summer Sale - Up to 50% Off',
+    href: '/products',
+  },
+  {
+    image:
+      'https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=900&q=80',
+    text: 'New Arrivals Just Landed',
+    href: '/products?sort=newest',
+  },
+  {
+    image:
+      'https://images.unsplash.com/photo-1495121605193-b116b5b09c63?auto=format&fit=crop&w=900&q=80',
+    text: 'Most Popular Items',
+    href: '/products?sort=popularity',
+  },
+];
+
+const PromoBanner: FC = () => (
+  <section className="py-8 bg-base-200">
+    <div className="max-w-screen-2xl mx-auto px-4 grid gap-4 md:grid-cols-3">
+      {banners.map((b, i) => (
+        <Link
+          key={i}
+          href={b.href}
+          className="relative block rounded-lg overflow-hidden group"
+        >
+          <Image
+            src={b.image}
+            alt=""
+            width={600}
+            height={200}
+            className="object-cover w-full h-40 md:h-48 group-hover:scale-105 transition-transform"
+          />
+          <span className="absolute inset-0 bg-black/40 flex items-center justify-center text-white font-bold text-lg">
+            {b.text}
+          </span>
+        </Link>
+      ))}
+    </div>
+  </section>
+);
+
+export default PromoBanner;

--- a/components/SortMenu.tsx
+++ b/components/SortMenu.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export type SortValue = 'newest' | 'price_asc' | 'price_desc' | 'popularity';
+
+interface SortMenuProps {
+  value: SortValue;
+  onChange: (v: SortValue) => void;
+}
+
+const SortMenu: React.FC<SortMenuProps> = ({ value, onChange }) => (
+  <div className="mb-4 flex items-center gap-2">
+    <label htmlFor="sort" className="font-medium">
+      Sort by:
+    </label>
+    <select
+      id="sort"
+      className="select select-sm select-bordered"
+      value={value}
+      onChange={(e) => onChange(e.target.value as SortValue)}
+    >
+      <option value="newest">Newest</option>
+      <option value="price_asc">Price: Low to High</option>
+      <option value="price_desc">Price: High to Low</option>
+      <option value="popularity">Popularity</option>
+    </select>
+  </div>
+);
+
+export default SortMenu;

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -6,6 +6,7 @@ import type { Category } from '../types/category';
 import type { Vendor } from '../types/vendor';
 import type { Prisma } from '@prisma/client';
 import client from './typesenseClient';
+import { getBestSellingProducts } from './orders';
 
 type ProductWithRelations = Prisma.ProductGetPayload<{
   include: { category: true; vendor: true };
@@ -410,6 +411,7 @@ export interface PaginatedOptions {
   inStock?: boolean;
   minPrice?: number;
   maxPrice?: number;
+  sort?: 'price_asc' | 'price_desc' | 'popularity' | 'newest';
 }
 
 export interface PaginatedResult {
@@ -443,16 +445,35 @@ export async function getProductsPaginated(
   if (typeof options.maxPrice === 'number') {
     where.minPrice = { ...(where.minPrice as any), lte: options.maxPrice };
   }
-  const [total, rows] = await Promise.all([
-    db.product.count({ where }),
-    db.product.findMany({
-      where,
-      include: { category: true, vendor: true },
-      take: options.limit,
-      skip: options.offset,
-      orderBy: { id: 'asc' },
-    }),
-  ]);
+  const orderBy: Prisma.Enumerable<Prisma.ProductOrderByWithRelationInput> = (() => {
+    switch (options.sort) {
+      case 'price_asc':
+        return { minPrice: 'asc' };
+      case 'price_desc':
+        return { minPrice: 'desc' };
+      case 'newest':
+        return { createdAt: 'desc' };
+      default:
+        return { id: 'asc' };
+    }
+  })();
+
+  if (options.sort === 'popularity') {
+    const popular = await getBestSellingProducts(options.offset + options.limit);
+    return {
+      total: popular.length,
+      products: popular.slice(options.offset, options.offset + options.limit),
+    };
+  }
+
+  let rows = await db.product.findMany({
+    where,
+    include: { category: true, vendor: true },
+    orderBy,
+  });
+
+  const total = rows.length;
+  rows = rows.slice(options.offset, options.offset + options.limit);
   return {
     total,
     products: rows.map((row) =>

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -15,6 +15,7 @@ export interface ProductsQuery {
   page?: string | string[];
   limit?: string | string[];
   offset?: string | string[];
+  sort?: string | string[];
 }
 
 export interface ProductsResponse {
@@ -44,6 +45,12 @@ export default async function handler(
   const maxPriceQuery = getQueryParam(req.query.maxPrice);
   const minPrice = minPriceQuery ? parseFloat(minPriceQuery) : undefined;
   const maxPrice = maxPriceQuery ? parseFloat(maxPriceQuery) : undefined;
+  const sort = getQueryParam(req.query.sort) as
+    | 'price_asc'
+    | 'price_desc'
+    | 'popularity'
+    | 'newest'
+    | undefined;
   try {
     const result = await getProductsPaginated({
       limit,
@@ -53,6 +60,7 @@ export default async function handler(
       inStock,
       minPrice,
       maxPrice,
+      sort,
     });
     return res
       .status(200)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import HomeHero from '../components/HomeHero';
 import FeaturedProducts from '../components/FeaturedProducts';
 import CategoryPromotion from '../components/CategoryPromotion';
+import PromoBanner from '../components/PromoBanner';
 import CategorySlider, { CategoryItem } from '../components/CategorySlider';
 import { getPageTitle } from '../lib/pageTitle';
 import DEFAULT_CATEGORIES from '../lib/defaultCategories';
@@ -41,6 +42,7 @@ const HomePage: React.FC = () => {
       </Head>
       <main className="flex-1">
         <HomeHero />
+        <PromoBanner />
         <FeaturedProducts />
         <CategoryPromotion categories={categories} />
       </main>

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -132,6 +132,14 @@ export default function ProductDetail({
                 : product.minPrice || '0'
             ).toFixed(2)}
           </p>
+          <p className="mb-2 font-medium">
+            Stock:{' '}
+            {product.totalInventory && product.totalInventory > 10
+              ? 'In Stock'
+              : product.totalInventory && product.totalInventory > 0
+              ? 'Low Stock'
+              : 'Out of Stock'}
+          </p>
           <p className="mb-2">
             Rating: {averageRating.toFixed(1)} ({reviewCount})
           </p>

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -120,6 +120,14 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
         {product.currency || ''}{' '}
         {product.minPrice ? product.minPrice.toFixed(2) : 'N/A'}
       </p>
+      <p className="mb-2 font-medium">
+        Stock:{' '}
+        {product.totalInventory && product.totalInventory > 10
+          ? 'In Stock'
+          : product.totalInventory && product.totalInventory > 0
+          ? 'Low Stock'
+          : 'Out of Stock'}
+      </p>
       <p className="mb-2">
         Rating: {averageRating.toFixed(1)} ({reviewCount})
       </p>

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -7,6 +7,7 @@ import ActiveFilters from '../../components/ActiveFilters';
 import ProductGrid from '../../components/ProductGrid';
 import Loader from '../../components/Loader';
 import InfiniteLoader from '../../components/InfiniteLoader';
+import SortMenu, { SortValue } from '../../components/SortMenu';
 import { getPageTitle } from '../../lib/pageTitle';
 import {
   getProductsPaginated,
@@ -38,6 +39,7 @@ export const getServerSideProps: GetServerSideProps<ProductsProps> = async (
   const maxPrice = context.query.maxPrice
     ? parseFloat(context.query.maxPrice as string)
     : undefined;
+  const sort = (context.query.sort as string) || 'newest';
 
   const limit = 20;
   const offset = 0;
@@ -49,6 +51,7 @@ export const getServerSideProps: GetServerSideProps<ProductsProps> = async (
     inStock,
     minPrice,
     maxPrice,
+    sort: sort as any,
   });
 
   const categories = serializeDates(await getCategoriesFlat());
@@ -77,6 +80,9 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
     typeof router.query.maxPrice === 'string' ? router.query.maxPrice : ''
   );
   const [inStock, setInStock] = useState(router.query.inStock === 'true');
+  const [sort, setSort] = useState<SortValue>(
+    (router.query.sort as SortValue) || 'newest'
+  );
   const [items, setItems] = useState<Product[]>(products);
   const [loadingMore, setLoadingMore] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -102,11 +108,12 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
       if (minPrice) query.minPrice = minPrice;
       if (maxPrice) query.maxPrice = maxPrice;
       if (inStock) query.inStock = 'true';
+      if (sort) query.sort = sort;
       const params = new URLSearchParams(query);
       params.set('page', String(p));
       return params;
     },
-    [keyword, selectedCategories, minPrice, maxPrice, inStock]
+    [keyword, selectedCategories, minPrice, maxPrice, inStock, sort]
   );
 
   const getFilterSnapshot = useCallback(() => {
@@ -116,8 +123,9 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
       minPrice,
       maxPrice,
       inStock,
+      sort,
     });
-  }, [keyword, selectedCategories, minPrice, maxPrice, inStock]);
+  }, [keyword, selectedCategories, minPrice, maxPrice, inStock, sort]);
 
   const loadProductsFn = useCallback(
     async (p: number, mode: 'reset' | 'append') => {
@@ -160,6 +168,7 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
           if (minPrice) query.minPrice = minPrice;
           if (maxPrice) query.maxPrice = maxPrice;
           if (inStock) query.inStock = 'true';
+          if (sort) query.sort = sort;
           router.replace({ pathname: router.pathname, query }, undefined, {
             shallow: true,
           });
@@ -181,6 +190,7 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
       minPrice,
       maxPrice,
       inStock,
+      sort,
       router,
     ]
   );
@@ -219,7 +229,7 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
     return () => {
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
     };
-  }, [keyword, selectedCategories, minPrice, maxPrice, inStock]);
+  }, [keyword, selectedCategories, minPrice, maxPrice, inStock, sort]);
 
   const toggleInStock = useCallback(() => {
     setInStock((prev) => !prev);
@@ -288,8 +298,9 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
             />
           </aside>
           <div className="flex-1">
-            <ActiveFilters filters={activeFilters} clearAll={clearAll} />
-            <div className="relative">
+          <ActiveFilters filters={activeFilters} clearAll={clearAll} />
+          <SortMenu value={sort} onChange={(v) => setSort(v)} />
+          <div className="relative">
               <ProductGrid products={items} />
               {loading && (
                 <Loader className="absolute inset-0 bg-base-200/70" />


### PR DESCRIPTION
## Summary
- add promotional banners
- show skeletons while products load
- implement sort dropdown and API support
- support popularity and price sorting in backend
- display stock availability on product pages

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: cannot fetch prisma engines)*

------
https://chatgpt.com/codex/tasks/task_e_685cd6876588832fa49eea9c58fd253a