### PR TITLE
Add avatar upload and profile last updated info

### DIFF
--- a/pages/api/user/profile.ts
+++ b/pages/api/user/profile.ts
@@ -5,6 +5,34 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import type { User, ApiMessage } from '../../../types';
+import formidable, { type Fields, type Files, type File } from 'formidable';
+import fs from 'fs';
+import path from 'path';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function parseBody(
+  req: NextApiRequest
+): Promise<{ fields: Fields; files: Files }> {
+  const type = req.headers['content-type'] || '';
+  if (type.includes('application/json')) {
+    const buffers: Uint8Array[] = [];
+    for await (const chunk of req) buffers.push(chunk);
+    const body = Buffer.concat(buffers).toString();
+    return { fields: JSON.parse(body || '{}') as Fields, files: {} as Files };
+  }
+  return new Promise<{ fields: Fields; files: Files }>((resolve, reject) => {
+    const form = formidable({ multiples: true });
+    form.parse(req, (err, fields, files) => {
+      if (err) reject(err);
+      else resolve({ fields, files });
+    });
+  });
+}
 
 export default async function handler(
   req: NextApiRequest,
@@ -20,6 +48,7 @@ export default async function handler(
       return res.status(200).json(userData);
     }
     if (req.method === 'PUT') {
+      const { fields, files } = await parseBody(req);
       const {
         firstName,
         lastName,
@@ -30,7 +59,7 @@ export default async function handler(
         address,
         city,
         country,
-      } = req.body as Partial<User> & { password?: string };
+      } = fields as Partial<User> & { password?: string };
       const update: any = {
         firstName,
         lastName,
@@ -41,7 +70,17 @@ export default async function handler(
         country,
       };
       if (email) update.email = email;
-      if (password) update.password = await bcrypt.hash(password, 10);
+      if (password) update.password = await bcrypt.hash(String(password), 10);
+      const logoFile = files.logo as File | File[] | undefined;
+      if (logoFile) {
+        const file = Array.isArray(logoFile) ? logoFile[0] : logoFile;
+        const dir = path.join(process.cwd(), 'public', 'avatars', String(session.user.id));
+        fs.mkdirSync(dir, { recursive: true });
+        const name = Date.now() + '-' + file.originalFilename;
+        const dest = path.join(dir, name);
+        fs.renameSync(file.filepath, dest);
+        update.logo = `/avatars/${session.user.id}/${name}`;
+      }
       await updateUserProfile(session.user.email, update);
       return res.status(200).json({ message: 'updated' });
     }

--- a/pages/profile/edit.tsx
+++ b/pages/profile/edit.tsx
@@ -1,6 +1,10 @@
 import { useForm, SubmitHandler } from 'react-hook-form';
 import Head from 'next/head';
 import { useEffect, useState } from 'react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
 import useRequireAuth from '../../hooks/useRequireAuth';
 import { getPageTitle } from '../../lib/pageTitle';
 import {
@@ -8,6 +12,7 @@ import {
   PasswordInput,
   TextInput,
   CountrySelect,
+  FileUpload,
 } from '../../components/form-fields';
 import type { User } from '../../types/user';
 
@@ -20,12 +25,14 @@ interface FormValues {
   city: string;
   country: string;
   password: string;
+  logo: FileList | null;
 }
 
 const EditProfile: React.FC = () => {
   const user = useRequireAuth();
   const [editingEmail, setEditingEmail] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
   const {
     register,
     handleSubmit,
@@ -42,6 +49,7 @@ const EditProfile: React.FC = () => {
       city: '',
       country: '',
       password: '',
+      logo: null,
     },
   });
 
@@ -60,7 +68,9 @@ const EditProfile: React.FC = () => {
             city: data.city || '',
             country: data.country || '',
             password: '',
+            logo: null,
           });
+          if (data.updatedAt) setUpdatedAt(new Date(data.updatedAt));
         }
       })
       .finally(() => setLoading(false))
@@ -68,24 +78,43 @@ const EditProfile: React.FC = () => {
   }, [user, reset]);
 
   const submit: SubmitHandler<FormValues> = async (data) => {
+    const formData = new FormData();
+    formData.append('firstName', data.firstName);
+    formData.append('lastName', data.lastName);
+    formData.append('email', data.email);
+    formData.append('phoneNumber', data.phoneNumber);
+    formData.append('address', data.address);
+    formData.append('city', data.city);
+    formData.append('country', data.country);
+    formData.append('password', data.password);
+    if (data.logo && data.logo[0]) {
+      formData.append('logo', data.logo[0]);
+    }
     await fetch('/api/user/profile', {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
+      body: formData,
     });
-    reset({ ...data, password: '' });
+    reset({ ...data, password: '', logo: null });
   };
 
   if (!user) return null;
   if (loading) return <div className="p-4">Loading...</div>;
 
   return (
-    <div className="max-w-md mx-auto">
+    <div className="max-w-2xl mx-auto">
       <Head>
         <title>{getPageTitle('Update Profile')}</title>
       </Head>
-      <h1 className="text-2xl font-bold mb-4">Update Profile</h1>
-      <form onSubmit={handleSubmit(submit)} className="space-y-2">
+      <h1 className="text-2xl font-bold mb-2">Update Profile</h1>
+      {updatedAt && (
+        <p className="text-sm text-right text-gray-500 mb-4">
+          Last updated {dayjs(updatedAt).fromNow()}
+        </p>
+      )}
+      <form
+        onSubmit={handleSubmit(submit)}
+        className="grid grid-cols-1 md:grid-cols-2 gap-4"
+      >
         <TextInput<FormValues>
           label="First Name"
           name="firstName"
@@ -100,7 +129,7 @@ const EditProfile: React.FC = () => {
           rules={{ required: 'Required' }}
           error={errors.lastName?.message}
         />
-        <div className="flex items-end gap-2">
+        <div className="md:col-span-2 flex items-end gap-2">
           <div className="flex-1">
             <EmailInput<FormValues>
               label="Email"
@@ -136,20 +165,24 @@ const EditProfile: React.FC = () => {
           register={register}
           error={errors.address?.message}
         />
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-          <TextInput<FormValues>
-            label="City"
-            name="city"
-            register={register}
-            error={errors.city?.message}
-          />
-          <CountrySelect<FormValues>
-            label="Country"
-            name="country"
-            control={control}
-            error={errors.country?.message as string}
-          />
-        </div>
+        <TextInput<FormValues>
+          label="City"
+          name="city"
+          register={register}
+          error={errors.city?.message}
+        />
+        <CountrySelect<FormValues>
+          label="Country"
+          name="country"
+          control={control}
+          error={errors.country?.message as string}
+        />
+        <FileUpload<FormValues>
+          label="Profile Picture"
+          name="logo"
+          register={register}
+          className="md:col-span-2"
+        />
         <PasswordInput<FormValues>
           label="Password"
           name="password"
@@ -157,7 +190,7 @@ const EditProfile: React.FC = () => {
           rules={{}}
           error={errors.password?.message}
         />
-        <button type="submit" className="btn btn-primary w-full">
+        <button type="submit" className="btn btn-primary md:col-span-2">
           Save
         </button>
       </form>


### PR DESCRIPTION
## Summary
- allow multipart uploads for user profile API
- upload avatar image and save to public/avatars
- show last updated time in profile editor
- restructure profile form into two-column layout with optional avatar

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685cd6d10900832fbb3cdc59105ccf1d