### PR TITLE
Implement invoice PDF and admin orders view

### DIFF
--- a/lib/invoice.ts
+++ b/lib/invoice.ts
@@ -1,0 +1,22 @@
+import PDFDocument from 'pdfkit';
+import type { Order } from '../types';
+
+export function generateInvoice(order: Order): Buffer {
+  const doc = new PDFDocument({ margin: 50 });
+  const chunks: Buffer[] = [];
+  doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+
+  doc.fontSize(20).text('Order Invoice', { align: 'center' });
+  doc.moveDown();
+  doc.fontSize(12).text(`Order ID: ${order.uuid}`);
+  doc.text(`Date: ${order.createdAt.toDateString()}`);
+  doc.text(`Status: ${order.status}`);
+  doc.moveDown();
+  doc.text(`Product: ${order.product.title}`);
+  doc.text(`Quantity: ${order.quantity}`);
+  doc.text(`Total: £${order.total}`);
+
+  doc.end();
+
+  return Buffer.concat(chunks);
+}

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -118,6 +118,39 @@ export async function getAllOrders(): Promise<Order[]> {
   return rows.map(mapOrderRow);
 }
 
+export async function getAllOrdersFiltered(params: {
+  status?: string;
+  search?: string;
+}): Promise<Order[]> {
+  const db = getDb();
+  const { status, search } = params;
+  const rows: OrderWithRelations[] = await db.order.findMany({
+    where: {
+      AND: [
+        status ? { status } : {},
+        search
+          ? {
+              OR: [
+                { user: { email: { contains: search, mode: 'insensitive' } } },
+                {
+                  product: {
+                    title: { contains: search, mode: 'insensitive' },
+                  },
+                },
+              ],
+            }
+          : {},
+      ],
+    },
+    include: {
+      user: true,
+      product: { include: { vendor: true, category: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+  return rows.map(mapOrderRow);
+}
+
 export async function getOrdersForVendor(vendor: string): Promise<Order[]> {
   const db = getDb();
   const rows: OrderWithRelations[] = await db.order.findMany({

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "next": "^14.2.29",
         "next-auth": "^4.24.6",
         "nodemailer": "^6.10.1",
+        "pdfkit": "^0.17.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.50.0",
@@ -5524,6 +5525,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bcryptjs": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
@@ -5571,6 +5592,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -5940,6 +5970,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6274,6 +6313,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-select": {
       "version": "5.1.0",
@@ -6699,6 +6744,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -7663,8 +7714,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -7849,6 +7899,32 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/for-each": {
@@ -10502,6 +10578,12 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10691,6 +10773,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -12069,6 +12170,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12197,6 +12304,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/pdfkit": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.1.tgz",
+      "integrity": "sha512-Kkf1I9no14O/uo593DYph5u3QwiMfby7JsBSErN1WqeyTgCBNJE3K4pXBn3TgkdKUIVu+buSl4bYUNC+8Up4xg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -12300,6 +12420,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -13005,6 +13130,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -14010,6 +14141,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -14571,6 +14708,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
@@ -14579,6 +14726,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "next": "^14.2.29",
     "next-auth": "^4.24.6",
     "nodemailer": "^6.10.1",
+    "pdfkit": "^0.17.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.50.0",

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -162,6 +162,9 @@ export default function Admin() {
         <Link href="/admin/policies" className="btn btn-sm">
           Policies
         </Link>
+        <Link href="/admin/orders" className="btn btn-sm">
+          Orders
+        </Link>
         <Link href="/admin/support" className="btn btn-sm">
           Support
         </Link>

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import type { Order } from '../../types';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
+
+export default function AdminOrders() {
+  const { data: session } = useSession();
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [status, setStatus] = useState('');
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!session?.user) return;
+    const params = new URLSearchParams();
+    if (status) params.append('status', status);
+    if (search) params.append('search', search);
+    setLoading(true);
+    fetch(`/api/admin/orders?${params.toString()}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => {
+        setOrders(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [session, status, search]);
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Orders')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">All Orders</h1>
+      <div className="flex gap-2 mb-4">
+        <select
+          className="select select-bordered"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+        >
+          <option value="">All Status</option>
+          <option value="pending">Pending</option>
+          <option value="shipped">Shipped</option>
+          <option value="completed">Completed</option>
+        </select>
+        <input
+          className="input input-bordered flex-1"
+          placeholder="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </div>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="table w-full">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>User</th>
+                <th>Product</th>
+                <th>Status</th>
+                <th>Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.map((o) => (
+                <tr key={o.id}>
+                  <td>{o.id}</td>
+                  <td>{o.user.email}</td>
+                  <td>{o.product.title}</td>
+                  <td>{o.status}</td>
+                  <td>£{o.total}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {orders.length === 0 && <p>No orders found.</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/api/admin/orders.ts
+++ b/pages/api/admin/orders.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAllOrdersFiltered, updateOrderStatus } from '../../../lib/orders';
+import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import type { Order, ApiMessage } from '../../../types';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Order[] | ApiMessage>
+) {
+  try {
+    if (req.method === 'GET') {
+      const status = getQueryParam(req.query.status);
+      const search = getQueryParam(req.query.search);
+      const orders = await getAllOrdersFiltered({ status: status || undefined, search: search || undefined });
+      return res.status(200).json(orders);
+    }
+    if (req.method === 'PATCH') {
+      const uuid = getQueryParam(req.query.uuid);
+      const { status } = req.body || {};
+      if (!uuid || !status) {
+        return res.status(400).json({ message: 'uuid and status required' });
+      }
+      await updateOrderStatus(uuid, status);
+      return res.status(200).json({ message: 'updated' });
+    }
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (e) {
+    return handleApiError(res, e, 'Failed to manage orders');
+  }
+}
+
+export default withRole(['SUPER_ADMIN'])(handler);

--- a/pages/api/orders/[uuid]/invoice.ts
+++ b/pages/api/orders/[uuid]/invoice.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getOrderByUuid } from '../../../../lib/orders';
+import { generateInvoice } from '../../../../lib/invoice';
+import { handleApiError } from '../../../../lib/utils/handleApiError';
+import { getQueryParam } from '../../../../lib/utils/getQueryParam';
+import { withRole } from '../../../../lib/withRole';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const uuid = getQueryParam(req.query.uuid);
+    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    const order = await getOrderByUuid(uuid);
+    if (!order) return res.status(404).json({ message: 'Not found' });
+    const pdf = generateInvoice(order);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="invoice-${uuid}.pdf"`);
+    return res.status(200).end(pdf);
+  } catch (e) {
+    return handleApiError(res, e, 'Failed to generate invoice');
+  }
+}
+
+export default withRole(['USER', 'BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -52,6 +52,7 @@ const Orders: React.FC<OrdersProps> = (_props) => {
                 <th>Total</th>
                 <th>Date</th>
                 <th>Chat</th>
+                <th>Invoice</th>
               </tr>
             </thead>
             <tbody>
@@ -88,6 +89,14 @@ const Orders: React.FC<OrdersProps> = (_props) => {
                   <td>{new Date(o.createdAt).toLocaleDateString()}</td>
                   <td>
                     <a className="link" href={`/messages/${o.uuid}`}>Chat</a>
+                  </td>
+                  <td>
+                    <a
+                      className="link"
+                      href={`/api/orders/${o.uuid}/invoice`}
+                    >
+                      PDF
+                    </a>
                   </td>
                 </tr>
               ))}

--- a/pages/orders/[uuid].tsx
+++ b/pages/orders/[uuid].tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import type { Order } from '../../types';
+import Head from 'next/head';
+import { getPageTitle } from '../../lib/pageTitle';
+
+export default function OrderDetail() {
+  const router = useRouter();
+  const { uuid } = router.query;
+  const [order, setOrder] = useState<Order | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!uuid) return;
+    fetch(`/api/orders/${uuid}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((d) => {
+        setOrder(d);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [uuid]);
+
+  if (loading) return <p className="p-4">Loading...</p>;
+  if (!order) return <p className="p-4">Order not found.</p>;
+
+  return (
+    <div className="max-w-xl mx-auto space-y-2">
+      <Head>
+        <title>{getPageTitle(`Order ${order.id}`)}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Order #{order.id}</h1>
+      <p>Status: {order.status}</p>
+      <p>Product: {order.product.title}</p>
+      <p>Quantity: {order.quantity}</p>
+      <p>Total: £{order.total}</p>
+      <a
+        className="btn btn-primary mt-4"
+        href={`/api/orders/${order.uuid}/invoice`}
+      >
+        Download Invoice
+      </a>
+    </div>
+  );
+}

--- a/pages/user/orders.tsx
+++ b/pages/user/orders.tsx
@@ -50,6 +50,11 @@ const UserOrders: React.FC = () => {
               </li>
             </ul>
             <p>Total: £{o.total}</p>
+            <p>
+              <a className="link" href={`/api/orders/${o.uuid}/invoice`}>
+                Download Invoice
+              </a>
+            </p>
           </li>
         ))}
         {!loading && orders.length === 0 && <li>No orders found.</li>}

--- a/types/custom/pdfkit.d.ts
+++ b/types/custom/pdfkit.d.ts
@@ -1,0 +1,1 @@
+declare module 'pdfkit';


### PR DESCRIPTION
## Summary
- integrate pdfkit
- generate invoices in API route
- allow downloads from order listings
- add detailed order page
- create admin orders dashboard

## Testing
- `npm run type-check` *(fails: numerous TS errors)*
- `npm test` *(fails: categories.api.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_685cd6e0d520832fb42ed1e782674e59