### PR TITLE
Fix analytics page to handle empty datasets

### DIFF
--- a/components/BarChart.tsx
+++ b/components/BarChart.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+interface DataPoint {
+  label: string;
+  value: number;
+}
+
+interface BarChartProps {
+  data?: DataPoint[];
+  height?: number;
+}
+
+const BarChart: React.FC<BarChartProps> = ({ data = [], height = 200 }) => {
+  const max = data.reduce((m, d) => Math.max(m, d.value), 0);
+
+  return (
+    <div className="relative border p-2 bg-base-100" style={{ height }}>
+      {data.length === 0 ? (
+        <div className="flex items-center justify-center h-full text-gray-500">
+          No Data Available
+        </div>
+      ) : (
+        <div className="flex items-end h-full space-x-1">
+          {data.map((d) => (
+            <div key={d.label} className="flex-1 flex flex-col items-center">
+              <div
+                className="bg-primary w-full"
+                style={{ height: `${(d.value / max) * 100}%` }}
+              />
+              <span className="text-xs mt-1 truncate" title={d.label}>
+                {d.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      <svg className="absolute inset-0 w-full h-full pointer-events-none">
+        <line x1="32" y1="0" x2="32" y2="100%" stroke="#ccc" strokeWidth="1" />
+        <line
+          x1="32"
+          y1="100%"
+          x2="100%"
+          y2="100%"
+          stroke="#ccc"
+          strokeWidth="1"
+        />
+      </svg>
+    </div>
+  );
+};
+
+export default BarChart;

--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -5,23 +5,29 @@ import { AnalyticsData } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
+import BarChart from '../../components/BarChart';
 
 export default function AdminAnalytics() {
   const { user } = useContext(AppContext)!;
   const [data, setData] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!user) return;
+    setLoading(true);
     fetchJson<AnalyticsData>('/api/admin/analytics')
-      .then(setData)
-      .catch(() => setData(null));
+      .then((res) => setData(res))
+      .catch(() =>
+        setData({ totalOrders: 0, totalRevenue: 0, topProducts: [] })
+      )
+      .finally(() => setLoading(false));
   }, [user]);
 
   if (!user) return <div className="p-4">Please log in to view analytics.</div>;
   if (user.role !== 'super-admin')
     return <div className="p-4">Admin access required.</div>;
 
-  if (!data) return <div className="p-4">Loading...</div>;
+  if (loading || data === null) return <div className="p-4">Loading...</div>;
 
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
@@ -54,6 +60,11 @@ export default function AdminAnalytics() {
         ))}
         {data.topProducts.length === 0 && <li>No sales yet.</li>}
       </ul>
+      <div className="mt-4">
+        <BarChart
+          data={data.topProducts.map((p) => ({ label: p.id, value: p.qty }))}
+        />
+      </div>
     </div>
   );
 }

--- a/pages/brand/analytics.tsx
+++ b/pages/brand/analytics.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
+import BarChart from '../../components/BarChart';
 
 type TopProduct = {
   id: string;
@@ -22,15 +23,20 @@ type EarningsData = {
 const BrandAnalytics: React.FC = () => {
   const { user } = useContext(AppContext)!;
   const [data, setData] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
   const [earnings, setEarnings] = useState<EarningsData | null>(null);
 
   useEffect(() => {
     if (!user) return;
+    setLoading(true);
     fetch(
       `/api/brand/analytics?vendor=${encodeURIComponent(user.brandName || '')}`
     )
       .then((res) => (res.ok ? res.json() : null))
-      .then(setData);
+      .then((d) =>
+        setData(d || { totalOrders: 0, totalRevenue: 0, topProducts: [] })
+      )
+      .finally(() => setLoading(false));
     fetch(
       `/api/brand/earnings?vendor=${encodeURIComponent(user.brandName || '')}`
     )
@@ -42,7 +48,7 @@ const BrandAnalytics: React.FC = () => {
   if (user.role !== 'brand')
     return <div className="p-4">Brand access required.</div>;
 
-  if (!data) return <div className="p-4">Loading...</div>;
+  if (loading || data === null) return <div className="p-4">Loading...</div>;
 
   return (
     <div className="max-w-2xl mx-auto">
@@ -70,6 +76,11 @@ const BrandAnalytics: React.FC = () => {
           <li>No sales yet.</li>
         )}
       </ul>
+      <div className="mt-4">
+        <BarChart
+          data={data.topProducts.map((p) => ({ label: p.id, value: p.qty }))}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add simple `BarChart` component to visualize analytics
- update admin analytics page to display charts and handle empty datasets
- update brand analytics page with placeholder chart and correct loading state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685cdb420e08832fab39de636bd5cc94