### PR TITLE
Enhance category dropdown with creation modal

### DIFF
--- a/components/ProductForm.tsx
+++ b/components/ProductForm.tsx
@@ -3,6 +3,8 @@ import { useForm, Controller } from 'react-hook-form';
 import AsyncCreatableSelect from 'react-select/async-creatable';
 import type { SelectOption } from './form-fields/SelectDropdown';
 import { TextInput, Textarea, FileUpload, Checkbox } from './form-fields';
+import { GenericInput, GenericModal } from './ui';
+import { slugify } from '../lib/slugify';
 
 export interface ProductFormValues {
   sku: string;
@@ -54,12 +56,60 @@ const ProductForm: React.FC<ProductFormProps> = ({
     },
   });
   const [images, setImages] = useState<File[]>([]);
-  const loadCategoryOptions = async (inputValue: string): Promise<SelectOption[]> => {
+  const [categoryOption, setCategoryOption] = useState<SelectOption | null>(
+    initial?.categoryId
+      ? { label: '', value: String(initial.categoryId) }
+      : null
+  );
+  const [showCatModal, setShowCatModal] = useState(false);
+  const [newCatName, setNewCatName] = useState('');
+  const [newCatSlug, setNewCatSlug] = useState('');
+  const [catError, setCatError] = useState('');
+  const loadCategoryOptions = async (
+    inputValue: string
+  ): Promise<SelectOption[]> => {
     const params = new URLSearchParams({ search: inputValue, limit: '20' });
     const res = await fetch(`/api/categories?${params.toString()}`);
     if (!res.ok) return [];
     const data = await res.json();
-    return (data.categories || []).map((c: any) => ({ label: c.name, value: String(c.id) }));
+    return (data.categories || []).map((c: any) => ({
+      label: c.name,
+      value: String(c.id),
+    }));
+  };
+
+  const openCreateCategory = (input: string) => {
+    const name = input.trim();
+    setNewCatName(name);
+    setNewCatSlug(slugify(name));
+    setCatError('');
+    setShowCatModal(true);
+  };
+
+  const handleCreateCategory = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newCatName.trim()) {
+      setCatError('Name required');
+      return;
+    }
+    const res = await fetch('/api/brand/categories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: newCatName.trim(),
+        slug: newCatSlug.trim(),
+      }),
+    });
+    if (res.ok) {
+      const cat = await res.json();
+      const opt = { label: cat.name, value: String(cat.id) } as SelectOption;
+      setCategoryOption(opt);
+      setValue('categoryId', opt.value);
+      setShowCatModal(false);
+    } else {
+      const data = await res.json().catch(() => ({ message: 'Error' }));
+      setCatError(data.message || 'Error');
+    }
   };
 
   const onFormSubmit = handleSubmit(async (values) => {
@@ -123,33 +173,70 @@ const ProductForm: React.FC<ProductFormProps> = ({
         control={control}
         rules={{ required: 'Required' }}
         render={({ field }) => (
-          <AsyncCreatableSelect
-            inputId="category-select"
-            ref={field.ref}
-            name={field.name}
-            value={field.value ? { label: '', value: field.value } : null}
-            defaultOptions
-            loadOptions={loadCategoryOptions}
-            onBlur={field.onBlur}
-            onChange={(val) => {
-              if (!val) return field.onChange('');
-              if (Array.isArray(val)) return;
-              field.onChange(val.value);
-            }}
-            onCreateOption={async (input) => {
-              const res = await fetch('/api/brand/categories', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name: input }),
-              });
-              if (res.ok) {
-                const cat = await res.json();
-                field.onChange(String(cat.id));
+          <>
+            <AsyncCreatableSelect
+              inputId="category-select"
+              ref={field.ref}
+              value={categoryOption}
+              defaultOptions
+              loadOptions={loadCategoryOptions}
+              onBlur={field.onBlur}
+              onChange={(val) => {
+                if (!val) {
+                  setCategoryOption(null);
+                  field.onChange('');
+                } else if (!Array.isArray(val)) {
+                  setCategoryOption(val as SelectOption);
+                  field.onChange(val.value);
+                }
+              }}
+              onCreateOption={openCreateCategory}
+              formatCreateLabel={() => 'Create New Category'}
+              isValidNewOption={(input, _value, options) =>
+                input.trim().length > 0 && options.length === 0
               }
-            }}
-            placeholder="Category"
-            classNamePrefix="react-select"
-          />
+              placeholder="Category"
+              classNamePrefix="react-select"
+            />
+            <GenericModal
+              isOpen={showCatModal}
+              onClose={() => setShowCatModal(false)}
+              title="Create Category"
+            >
+              <form onSubmit={handleCreateCategory} className="space-y-2">
+                <GenericInput
+                  label="Category Name"
+                  name="category-name"
+                  value={newCatName}
+                  onChange={(e) => {
+                    setNewCatName(e.target.value);
+                    setNewCatSlug(slugify(e.target.value));
+                  }}
+                  required
+                />
+                <GenericInput
+                  label="Slug"
+                  name="category-slug"
+                  value={newCatSlug}
+                  onChange={(e) => setNewCatSlug(e.target.value)}
+                  required
+                />
+                {catError && <p className="text-sm text-red-600">{catError}</p>}
+                <div className="flex justify-end gap-2">
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={() => setShowCatModal(false)}
+                  >
+                    Cancel
+                  </button>
+                  <button type="submit" className="btn btn-primary">
+                    Save
+                  </button>
+                </div>
+              </form>
+            </GenericModal>
+          </>
         )}
       />
       {errors.categoryId && (

--- a/components/ui/GenericInput.tsx
+++ b/components/ui/GenericInput.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export interface GenericInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+}
+
+const GenericInput = React.forwardRef<HTMLInputElement, GenericInputProps>(
+  ({ label, error, className = '', id, required, ...rest }, ref) => {
+    const inputId = id || rest.name;
+    return (
+      <div className="mb-4 w-full">
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            {label} {required && <span className="text-red-500">*</span>}
+          </label>
+        )}
+        <input
+          id={inputId}
+          ref={ref}
+          required={required}
+          className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+            error ? 'border-red-500' : 'border-gray-300'
+          } ${className}`}
+          {...rest}
+        />
+        {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+      </div>
+    );
+  }
+);
+
+GenericInput.displayName = 'GenericInput';
+export default GenericInput;

--- a/components/ui/GenericModal.tsx
+++ b/components/ui/GenericModal.tsx
@@ -1,0 +1,44 @@
+import React, { useRef } from 'react';
+
+interface GenericModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+const GenericModal: React.FC<GenericModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+}) => {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  if (!isOpen) return null;
+  return (
+    <dialog
+      ref={dialogRef}
+      open
+      className="modal"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) onClose();
+      }}
+    >
+      <div className="modal-box">
+        <div className="flex justify-between items-center mb-2">
+          {title && <h2 className="font-semibold text-lg">{title}</h2>}
+          <button
+            type="button"
+            className="btn btn-sm btn-circle"
+            onClick={onClose}
+          >
+            ✕
+          </button>
+        </div>
+        {children}
+      </div>
+    </dialog>
+  );
+};
+
+export default GenericModal;

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,0 +1,3 @@
+export { default as InputField } from './InputField';
+export { default as GenericInput } from './GenericInput';
+export { default as GenericModal } from './GenericModal';

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -213,10 +213,12 @@ export async function addProduct(product: ProductInput): Promise<void> {
       })
     : null;
   const category = product.category?.id
-    ? await db.category.findUnique({ where: { id: Number(product.category.id) } })
+    ? await db.category.findUnique({
+        where: { id: Number(product.category.id) },
+      })
     : product.category?.name
-    ? await db.category.findFirst({ where: { name: product.category.name } })
-    : null;
+      ? await db.category.findFirst({ where: { name: product.category.name } })
+      : null;
 
   if (!vendor || !category) {
     throw new Error('Invalid vendor or category');
@@ -252,10 +254,12 @@ export async function updateProduct(
       })
     : null;
   const category = product.category?.id
-    ? await db.category.findUnique({ where: { id: Number(product.category.id) } })
+    ? await db.category.findUnique({
+        where: { id: Number(product.category.id) },
+      })
     : product.category?.name
-    ? await db.category.findFirst({ where: { name: product.category.name } })
-    : null;
+      ? await db.category.findFirst({ where: { name: product.category.name } })
+      : null;
   if (!vendor || !category) {
     throw new Error('Invalid vendor or category');
   }
@@ -445,21 +449,24 @@ export async function getProductsPaginated(
   if (typeof options.maxPrice === 'number') {
     where.minPrice = { ...(where.minPrice as any), lte: options.maxPrice };
   }
-  const orderBy: Prisma.Enumerable<Prisma.ProductOrderByWithRelationInput> = (() => {
-    switch (options.sort) {
-      case 'price_asc':
-        return { minPrice: 'asc' };
-      case 'price_desc':
-        return { minPrice: 'desc' };
-      case 'newest':
-        return { createdAt: 'desc' };
-      default:
-        return { id: 'asc' };
-    }
-  })();
+  const orderBy: Prisma.Enumerable<Prisma.ProductOrderByWithRelationInput> =
+    (() => {
+      switch (options.sort) {
+        case 'price_asc':
+          return { minPrice: 'asc' };
+        case 'price_desc':
+          return { minPrice: 'desc' };
+        case 'newest':
+          return { createdAt: 'desc' };
+        default:
+          return { id: 'asc' };
+      }
+    })();
 
   if (options.sort === 'popularity') {
-    const popular = await getBestSellingProducts(options.offset + options.limit);
+    const popular = await getBestSellingProducts(
+      options.offset + options.limit
+    );
     return {
       total: popular.length,
       products: popular.slice(options.offset, options.offset + options.limit),
@@ -542,13 +549,17 @@ export async function getCategoriesPaginated(
   });
 }
 
-export async function createCategory(name: string): Promise<Category> {
+export async function createCategory(
+  name: string,
+  slug?: string
+): Promise<Category> {
   const db = getDb();
-  const existing = await db.category.findFirst({ where: { name } });
-  if (existing) return existing;
-  return db.category.create({
-    data: { name, slug: name.toLowerCase().replace(/\s+/g, '-') },
+  const slugValue = slug || name.toLowerCase().replace(/\s+/g, '-');
+  const existing = await db.category.findFirst({
+    where: { OR: [{ name }, { slug: slugValue }] },
   });
+  if (existing) return existing;
+  return db.category.create({ data: { name, slug: slugValue } });
 }
 
 export async function renameCategory(

--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -3,6 +3,7 @@ import { AppContext } from '../../contexts/AppContext';
 import { Category, CategoryInput, ApiMessage } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
 import { TextInput } from '../../components/form-fields';
+import { slugify } from '../../lib/slugify';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
 
@@ -28,6 +29,7 @@ export default function Categories() {
     if (!newCat.trim()) return;
     const payload: CategoryInput = {
       name: newCat,
+      slug: slugify(newCat),
     };
     await fetchJson<ApiMessage>('/api/admin/categories', {
       method: 'POST',

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -22,16 +22,18 @@ async function handler(
       return;
     }
     if (req.method === 'POST') {
-      const { name } = req.body as CategoryInput;
+      const { name, slug } = req.body as CategoryInput;
       if (!name) return res.status(400).json({ message: 'name required' });
       const exists = (await getCategoriesFlat()).find(
-        (c: Category) => c.name.toLowerCase() === name.toLowerCase()
+        (c: Category) =>
+          c.name.toLowerCase() === name.toLowerCase() ||
+          (slug && c.slug?.toLowerCase() === slug.toLowerCase())
       );
       if (exists) {
         return res.status(409).json({ message: 'category exists' });
       }
-      await createCategory(name);
-      logAudit('create_category', { name });
+      await createCategory(name, slug);
+      logAudit('create_category', { name, slug });
       res.status(201).json({ message: 'category created' });
       return;
     }

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -17,14 +17,16 @@ export default async function handler(
     if (!session?.user || session.user.role !== 'BRAND') {
       return res.status(401).json({ message: 'Unauthorized' });
     }
-    const { name } = req.body || {};
+    const { name, slug } = req.body || {};
     if (!name) return res.status(400).json({ message: 'name required' });
     const exists = (await getCategoriesFlat()).find(
-      (c) => c.name.toLowerCase() === name.toLowerCase()
+      (c) =>
+        c.name.toLowerCase() === name.toLowerCase() ||
+        (slug && c.slug?.toLowerCase() === String(slug).toLowerCase())
     );
     let category: Category | null = exists ?? null;
     if (!category) {
-      category = await createCategory(name);
+      category = await createCategory(name, slug);
     }
     return res.status(201).json(category);
   } catch (error) {

--- a/types/category.ts
+++ b/types/category.ts
@@ -8,4 +8,7 @@ export interface Category {
   subcategories?: string[];
 }
 
-export type CategoryInput = Pick<Category, 'name'>;
+export type CategoryInput = {
+  name: string;
+  slug?: string;
+};


### PR DESCRIPTION
## Summary
- add `GenericInput` and `GenericModal` UI components
- extend `createCategory` to accept an optional slug
- allow brands and admins to send slug when creating categories
- update admin categories page to include slug
- overhaul product form category dropdown with async search and create-new modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cdcc8e7c0832fbc9713d361a3fc0e