### PR TITLE
Move brand product form to new route

### DIFF
--- a/components/dashboard/InventoryAlertsCard.tsx
+++ b/components/dashboard/InventoryAlertsCard.tsx
@@ -37,7 +37,7 @@ const InventoryAlertsCard: React.FC<Props> = ({ brand, threshold = 10 }) => {
       error={error}
     >
       {products && products.length > 0 ? (
-        <ul className="list-disc pl-4 space-y-1">
+        <ul className="list-disc pl-4 space-y-1 max-h-40 overflow-y-auto">
           {products.map((p) => (
             <li key={p.id}>
               {p.title} - {p.quantity} left

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext, useCallback } from 'react';
+import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
 import { NotificationContext } from '../../contexts/NotificationContext';
 import type { User } from '../../types/user';
@@ -107,28 +108,36 @@ const BrandDashboard: React.FC = () => {
           </div>
         )}
 
-        <ProductForm
-          key={editing?.id || 'new'}
-          initial={editing ? {
-            sku: editing.sku,
-            title: editing.title,
-            description: editing.description,
-            productType: editing.productType,
-            tags: editing.tags,
-            categoryId:
-              typeof editing.category === 'string'
-                ? undefined
-                : String(editing.category?.id ?? ''),
-            quantity: editing.totalInventory || 0,
-            minPrice: editing.minPrice,
-            maxPrice: editing.maxPrice,
-            currency: editing.currency,
-            available: (editing.totalInventory ?? editing.quantity ?? 0) > 0,
-          } : undefined}
-          onSubmit={(fd) => submitProduct(fd, editing?.id)}
-          onCancel={editing ? () => setEditing(null) : undefined}
-          submitLabel={editing ? 'Update Product' : 'Add Product'}
-        />
+        {editing ? (
+          <ProductForm
+            key={editing.id}
+            initial={{
+              sku: editing.sku,
+              title: editing.title,
+              description: editing.description,
+              productType: editing.productType,
+              tags: editing.tags,
+              categoryId:
+                typeof editing.category === 'string'
+                  ? undefined
+                  : String(editing.category?.id ?? ''),
+              quantity: editing.totalInventory || 0,
+              minPrice: editing.minPrice,
+              maxPrice: editing.maxPrice,
+              currency: editing.currency,
+              available: (editing.totalInventory ?? editing.quantity ?? 0) > 0,
+            }}
+            onSubmit={(fd) => submitProduct(fd, editing.id)}
+            onCancel={() => setEditing(null)}
+            submitLabel="Update Product"
+          />
+        ) : (
+          <div className="text-right">
+            <Link href="/brand/products/new" className="btn btn-primary">
+              Add Product
+            </Link>
+          </div>
+        )}
         <h2 className="text-xl font-semibold">Existing Products</h2>
         <ul className="space-y-1">
           {products.map((p) => (

--- a/pages/brand/products/new.tsx
+++ b/pages/brand/products/new.tsx
@@ -1,0 +1,37 @@
+import React, { useContext } from 'react';
+import Head from 'next/head';
+import { AppContext } from '../../../contexts/AppContext';
+import { NotificationContext } from '../../../contexts/NotificationContext';
+import type { User } from '../../../types/user';
+import ProductForm from '../../../components/ProductForm';
+import { getPageTitle } from '../../../lib/pageTitle';
+
+const NewProductPage: React.FC = () => {
+  const { user } = useContext(AppContext) as { user: User | null };
+  const { addNotification } = useContext(NotificationContext);
+
+  const submitProduct = async (values: FormData): Promise<void> => {
+    const res = await fetch('/api/brand/products', { method: 'POST', body: values });
+    if (res.ok) {
+      addNotification('Product added', 'success');
+    } else {
+      const data = await res.json().catch(() => ({ message: 'Error' }));
+      addNotification(data.message || 'Error', 'error');
+    }
+  };
+
+  if (!user) return <div className="p-4">Please log in to manage products.</div>;
+  if (user.role !== 'brand') return <div className="p-4">Brand access required.</div>;
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <Head>
+        <title>{getPageTitle('Add Product')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Add Product</h1>
+      <ProductForm onSubmit={submitProduct} submitLabel="Add Product" />
+    </div>
+  );
+};
+
+export default NewProductPage;


### PR DESCRIPTION
## Summary
- move product form from dashboard to `/brand/products/new`
- hide the creation form on dashboard, show Add Product link
- restrict Inventory Alerts card height to keep dashboard tidy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cde8b9700832f9ac01cba68cb2496