### PR TITLE
Add brand products page and simplify dashboard

### DIFF
--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useEffect, useContext, useCallback } from 'react';
 import { AppContext } from '../../contexts/AppContext';
-import { NotificationContext } from '../../contexts/NotificationContext';
 import type { User } from '../../types/user';
 import type { Product } from '../../types/product';
-import ProductForm from '../../components/ProductForm';
 import Link from 'next/link';
 import TotalProductsCard from '../../components/dashboard/TotalProductsCard';
 import TotalSalesCard from '../../components/dashboard/TotalSalesCard';
@@ -17,10 +15,8 @@ type ProductApi = Product;
 
 const BrandDashboard: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
-  const [editing, setEditing] = useState<ProductApi | null>(null);
   const [products, setProducts] = useState<ProductApi[]>([]);
   const [lowStock, setLowStock] = useState<ProductApi[]>([]);
-  const { addNotification } = useContext(NotificationContext);
 
   const fetchProducts = useCallback(async () => {
     if (!user) return;
@@ -42,43 +38,6 @@ const BrandDashboard: React.FC = () => {
     fetchProducts();
   }, [fetchProducts]);
 
-  const submitProduct = async (
-    values: FormData,
-    id?: string
-  ): Promise<void> => {
-    const url = id ? `/api/brand/products/${id}` : '/api/brand/products';
-    const method = id ? 'PUT' : 'POST';
-    const res = await fetch(url, { method, body: values });
-    if (res.ok) {
-      addNotification(id ? 'Product updated' : 'Product added', 'success');
-      setEditing(null);
-      fetchProducts();
-    } else {
-      const data = await res.json().catch(() => ({ message: 'Error' }));
-      addNotification(data.message || 'Error', 'error');
-    }
-  };
-
-  const handleEdit = (p: ProductApi) => {
-    setEditing(p);
-  };
-
-  const cancelEdit = () => {
-    setEditing(null);
-  };
-
-  const handleDelete = async (id: string) => {
-    if (!window.confirm('Delete this product?')) return;
-    const res = await fetch(`/api/brand/products/${encodeURIComponent(id)}`, {
-      method: 'DELETE',
-    });
-    if (res.ok) {
-      addNotification('Product deleted', 'success');
-      fetchProducts();
-    } else {
-      addNotification('Delete failed', 'error');
-    }
-  };
 
   if (!user) {
     return <div className="p-4">Please log in to manage products.</div>;
@@ -110,65 +69,13 @@ const BrandDashboard: React.FC = () => {
           </div>
         )}
 
-        {!editing && (
-          <div className="flex justify-end">
-            <Link href="/brand/products/new" className="btn btn-primary">
-              Add Product
-            </Link>
-          </div>
-        )}
-        {editing && (
-          <ProductForm
-            key={editing.id}
-            initial={{
-              id: editing.uuid || editing.id,
-              vendor: editing.vendor?.brandName || user.brandName || '',
-              sku: editing.sku,
-              title: editing.title,
-              description: editing.description,
-              productType: editing.productType,
-              tags: editing.tags,
-              categoryId:
-                typeof editing.category === 'string'
-                  ? undefined
-                  : String(editing.category?.id ?? ''),
-              quantity: editing.totalInventory || 0,
-              minPrice: editing.minPrice,
-              maxPrice: editing.maxPrice,
-              currency: editing.currency,
-              available: (editing.totalInventory ?? editing.quantity ?? 0) > 0,
-            }}
-            onSubmit={(fd) => submitProduct(fd, editing.id)}
-            onCancel={() => setEditing(null)}
-            submitLabel="Update Product"
-          />
-        )}
-        <h2 className="text-xl font-semibold">Existing Products</h2>
-        <ul className="space-y-1">
-          {products.map((p) => (
-            <li key={p.id} className="flex justify-between items-center gap-2">
-              <span>
-                {p.title} ({p.sku}) - {p.category || p.productType}
-              </span>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  className="btn btn-sm"
-                  onClick={() => handleEdit(p)}
-                >
-                  Edit
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-sm btn-error"
-                  onClick={() => handleDelete(p.id)}
-                >
-                  Delete
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
+        <div className="flex justify-between items-center">
+          <h2 className="text-xl font-semibold">Existing Products</h2>
+          <Link href="/brand/products" className="btn btn-primary">
+            Go to Products
+          </Link>
+        </div>
+        <p>You currently have {products.length} product{products.length !== 1 ? 's' : ''}.</p>
       </div>
     </div>
   );

--- a/pages/brand/products/index.tsx
+++ b/pages/brand/products/index.tsx
@@ -1,0 +1,75 @@
+import React, { useContext, useEffect, useState } from 'react';
+import Link from 'next/link';
+import Head from 'next/head';
+import { AppContext } from '../../../contexts/AppContext';
+import type { User } from '../../../types/user';
+import type { Product } from '../../../types/product';
+import { getPageTitle } from '../../../lib/pageTitle';
+
+const BrandProductsPage: React.FC = () => {
+  const { user } = useContext(AppContext) as { user: User | null };
+  const [products, setProducts] = useState<Product[]>([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    setLoading(true);
+    fetch(`/api/brand/products?vendor=${encodeURIComponent(user.brandName || '')}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data: Product[]) => setProducts(data))
+      .finally(() => setLoading(false));
+  }, [user]);
+
+  if (!user) {
+    return <div className="p-4">Please log in to manage products.</div>;
+  }
+  if (user.role !== 'brand') {
+    return <div className="p-4">Brand access required.</div>;
+  }
+
+  const filtered = products.filter((p) => {
+    const term = search.toLowerCase();
+    return (
+      p.title?.toLowerCase().includes(term) ||
+      p.sku?.toLowerCase().includes(term)
+    );
+  });
+
+  return (
+    <div className="min-h-screen px-4 py-6 space-y-4">
+      <Head>
+        <title>{getPageTitle('Products')}</title>
+      </Head>
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Products</h1>
+        <Link href="/brand/products/new" className="btn btn-primary">
+          Add New Product
+        </Link>
+      </div>
+      <input
+        type="text"
+        className="input input-bordered w-full sm:w-80"
+        placeholder="Search products"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      {loading ? (
+        <div className="flex justify-center my-4">
+          <span className="loading loading-spinner"></span>
+        </div>
+      ) : (
+        <ul className="space-y-1">
+          {filtered.map((p) => (
+            <li key={p.id} className="border p-2">
+              {p.title} ({p.sku}) - {typeof p.category === 'string' ? p.category : p.category?.name || p.productType}
+            </li>
+          ))}
+          {filtered.length === 0 && <li>No products found.</li>}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default BrandProductsPage;


### PR DESCRIPTION
## Summary
- clean up brand dashboard, show link to products page
- add products page for brand management

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing type definitions)*
- `npm install` *(blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_685ce16cf2d0832f8874ecd3e868c70a