### PR TITLE
Add validation to category modal

### DIFF
--- a/components/ProductForm.tsx
+++ b/components/ProductForm.tsx
@@ -76,6 +76,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
   const [newCatName, setNewCatName] = useState('');
   const [newCatSlug, setNewCatSlug] = useState('');
   const [catError, setCatError] = useState('');
+  const [creatingCat, setCreatingCat] = useState(false);
   const loadCategoryOptions = async (
     inputValue: string
   ): Promise<SelectOption[]> => {
@@ -94,6 +95,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
     setNewCatName(name);
     setNewCatSlug(slugify(name));
     setCatError('');
+    setCreatingCat(false);
     setShowCatModal(true);
   };
 
@@ -103,7 +105,8 @@ const ProductForm: React.FC<ProductFormProps> = ({
       setCatError('Name required');
       return;
     }
-    const res = await fetch('/api/brand/categories', {
+    setCreatingCat(true);
+    const res = await fetch('/api/categories/check-or-create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -111,15 +114,23 @@ const ProductForm: React.FC<ProductFormProps> = ({
         slug: newCatSlug.trim(),
       }),
     });
-    if (res.ok) {
-      const cat = await res.json();
+    setCreatingCat(false);
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({ message: 'Error' }));
+      setCatError(data.message || 'Error');
+      return;
+    }
+    const data = await res.json();
+    if (data.exists) {
+      setCatError(`Category "${data.name}" already exists`);
+      return;
+    }
+    if (data.success && data.category) {
+      const cat = data.category as { id: number | string; name: string };
       const opt = { label: cat.name, value: String(cat.id) } as SelectOption;
       setCategoryOption(opt);
       setValue('categoryId', opt.value);
       setShowCatModal(false);
-    } else {
-      const data = await res.json().catch(() => ({ message: 'Error' }));
-      setCatError(data.message || 'Error');
     }
   };
 
@@ -254,8 +265,12 @@ const ProductForm: React.FC<ProductFormProps> = ({
                   >
                     Cancel
                   </button>
-                  <button type="submit" className="btn btn-primary">
-                    Save
+                  <button
+                    type="submit"
+                    className="btn btn-primary"
+                    disabled={creatingCat}
+                  >
+                    {creatingCat ? 'Saving...' : 'Save'}
                   </button>
                 </div>
               </form>

--- a/pages/api/categories/check-or-create.ts
+++ b/pages/api/categories/check-or-create.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getCategoriesFlat, createCategory } from '../../../lib/products';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { ApiMessage, Category } from '../../../types';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+
+interface CheckOrCreateResponse {
+  exists?: boolean;
+  success?: boolean;
+  name?: string;
+  category?: Category;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CheckOrCreateResponse | ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'POST') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user || session.user.role !== 'BRAND') {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const { name, slug } = req.body || {};
+    if (!name) return res.status(400).json({ message: 'name required' });
+    const exists = (await getCategoriesFlat()).find(
+      (c) =>
+        c.name.toLowerCase() === name.toLowerCase() ||
+        (slug && c.slug?.toLowerCase() === String(slug).toLowerCase())
+    );
+    if (exists) {
+      return res.status(200).json({ exists: true, name: exists.name });
+    }
+    const category = await createCategory(name, slug);
+    return res.status(201).json({ success: true, category });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to create category');
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/categories/check-or-create` endpoint
- keep category creation modal open while saving
- prevent duplicate categories client-side

## Testing
- `npx tsc --noEmit` *(fails: cannot find Prisma generated types)*
- `npm install` *(fails: network access to binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ce35f72c0832f8723e2bbddb30a09