### PR TITLE
Improve product form tag UI

### DIFF
--- a/components/ProductForm.tsx
+++ b/components/ProductForm.tsx
@@ -147,7 +147,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
   };
 
   return (
-    <form onSubmit={onFormSubmit} className="space-y-2">
+    <form onSubmit={onFormSubmit} className="grid grid-cols-1 md:grid-cols-2 gap-4">
       <input type="hidden" {...register('id')} />
       <TextInput<ProductFormValues>
         label="SKU"
@@ -171,13 +171,15 @@ const ProductForm: React.FC<ProductFormProps> = ({
         rules={{ required: 'Required' }}
         error={errors.title?.message}
       />
-      <Textarea<ProductFormValues>
-        label="Description"
-        name="description"
-        register={register}
-        rules={{ required: 'Required' }}
-        error={errors.description?.message}
-      />
+      <div className="md:col-span-2">
+        <Textarea<ProductFormValues>
+          label="Description"
+          name="description"
+          register={register}
+          rules={{ required: 'Required' }}
+          error={errors.description?.message}
+        />
+      </div>
       <TextInput<ProductFormValues>
         label="Product Type"
         name="productType"
@@ -185,14 +187,17 @@ const ProductForm: React.FC<ProductFormProps> = ({
         rules={{ required: 'Required' }}
         error={errors.productType?.message}
       />
-      <TagInput<ProductFormValues>
-        label="Tags"
-        name="tags"
-        control={control}
-        placeholder="Press Enter to add"
-        error={errors.tags?.message as string}
-      />
-      <Controller
+      <div className="md:col-span-2">
+        <TagInput<ProductFormValues>
+          label="Tags"
+          name="tags"
+          control={control}
+          placeholder="Search or create tags"
+          error={errors.tags?.message as string}
+        />
+      </div>
+      <div className="md:col-span-2">
+        <Controller
         name="categoryId"
         control={control}
         rules={{ required: 'Required' }}
@@ -263,6 +268,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
           </>
         )}
       />
+      </div>
       {errors.categoryId && (
         <p className="text-sm text-red-600">{errors.categoryId.message}</p>
       )}
@@ -313,15 +319,17 @@ const ProductForm: React.FC<ProductFormProps> = ({
         rules={{ required: 'Required' }}
         error={errors.currency?.message}
       />
-      <FileUpload<ProductFormValues>
-        label="Images"
-        name="images"
-        multiple
-        accept="image/*"
-        onChange={handleImagesChange}
-      />
+      <div className="md:col-span-2">
+        <FileUpload<ProductFormValues>
+          label="Images"
+          name="images"
+          multiple
+          accept="image/*"
+          onChange={handleImagesChange}
+        />
+      </div>
       {images.length > 0 && (
-        <div className="flex gap-2 flex-wrap">
+        <div className="md:col-span-2 flex gap-2 flex-wrap">
           {images.map((img, idx) => (
             <img
               key={idx}
@@ -332,7 +340,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
           ))}
         </div>
       )}
-      <div className="flex gap-2 mt-2">
+      <div className="md:col-span-2 flex gap-2 mt-2">
         {onCancel && (
           <button type="button" className="btn" onClick={onCancel}>
             Cancel

--- a/components/form-fields/TagInput.tsx
+++ b/components/form-fields/TagInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Controller,
   Control,
@@ -6,6 +6,7 @@ import {
   Path,
   RegisterOptions,
 } from 'react-hook-form';
+import AsyncCreatableSelect from 'react-select/async-creatable';
 
 export interface TagInputProps<T extends FieldValues> {
   name: Path<T>;
@@ -19,7 +20,36 @@ export interface TagInputProps<T extends FieldValues> {
 
 const TagInput = <T extends FieldValues>(props: TagInputProps<T>) => {
   const { name, control, label, placeholder = '', disabled, error, rules } = props;
-  const [input, setInput] = useState('');
+
+  const loadOptions = async (inputValue: string) => {
+    const params = new URLSearchParams({ search: inputValue });
+    const res = await fetch(`/api/tags?${params.toString()}`);
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (data.tags || []).map((t: string) => ({ label: t, value: t }));
+  };
+
+  const customComponents = {
+    MultiValueContainer: (props: any) => (
+      <span className="badge badge-outline gap-1 mr-1">
+        {props.data.label}
+        <button
+          type="button"
+          className="ml-1"
+          onClick={props.removeProps.onClick}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            props.removeProps.onMouseDown(e);
+          }}
+        >
+          ✕
+        </button>
+      </span>
+    ),
+    MultiValueLabel: () => null,
+    MultiValueRemove: () => null,
+  };
+
   return (
     <Controller
       name={name}
@@ -27,12 +57,6 @@ const TagInput = <T extends FieldValues>(props: TagInputProps<T>) => {
       rules={rules}
       render={({ field }) => {
         const tags: string[] = field.value || [];
-        const addTag = () => {
-          const val = input.trim();
-          if (!val) return;
-          if (!tags.includes(val)) field.onChange([...tags, val]);
-          setInput('');
-        };
         return (
           <div className="mb-4 w-full">
             {label && (
@@ -40,33 +64,28 @@ const TagInput = <T extends FieldValues>(props: TagInputProps<T>) => {
                 {label}
               </label>
             )}
-            <div className="flex flex-wrap gap-1 mb-1">
-              {tags.map((tag, idx) => (
-                <span key={idx} className="badge badge-outline gap-1">
-                  {tag}
-                  <button
-                    type="button"
-                    className="ml-1"
-                    onClick={() => field.onChange(tags.filter((_, i) => i !== idx))}
-                  >
-                    ✕
-                  </button>
-                </span>
-              ))}
-            </div>
-            <input
-              type="text"
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  addTag();
+            <AsyncCreatableSelect
+              isMulti
+              inputId={`tag-input-${String(name)}`}
+              value={tags.map((t) => ({ label: t, value: t }))}
+              defaultOptions
+              loadOptions={loadOptions}
+              onChange={(val) => {
+                const arr = Array.isArray(val) ? val.map((v) => v.value) : [];
+                field.onChange(arr);
+              }}
+              onCreateOption={(val) => {
+                const newTag = val.trim();
+                if (newTag && !tags.includes(newTag)) {
+                  field.onChange([...tags, newTag]);
                 }
               }}
+              onBlur={field.onBlur}
               placeholder={placeholder}
-              disabled={disabled}
-              className={`px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${error ? 'border-red-500' : 'border-gray-300'}`}
+              isDisabled={disabled}
+              className="w-full"
+              classNamePrefix="react-select"
+              components={customComponents}
             />
             {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
           </div>

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -586,3 +586,22 @@ export async function deleteProduct(uuid: string): Promise<void> {
   const db = getDb();
   await db.product.delete({ where: { uuid } });
 }
+
+export async function getDistinctTags(search = ''): Promise<string[]> {
+  const db = getDb();
+  const rows = await db.product.findMany({
+    where: { tags: { not: null } },
+    select: { tags: true },
+  });
+  const term = search.trim().toLowerCase();
+  const set = new Set<string>();
+  for (const row of rows) {
+    const tags = row.tags?.split(',').map((t) => t.trim()).filter(Boolean) || [];
+    for (const tag of tags) {
+      if (!term || tag.toLowerCase().includes(term)) {
+        set.add(tag);
+      }
+    }
+  }
+  return Array.from(set).sort();
+}

--- a/pages/api/tags.ts
+++ b/pages/api/tags.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDistinctTags } from '../../lib/products';
+import { handleApiError } from '../../lib/utils/handleApiError';
+import type { ApiMessage } from '../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ tags: string[] } | ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const search = typeof req.query.search === 'string' ? req.query.search : '';
+    const tags = await getDistinctTags(search);
+    return res.status(200).json({ tags });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load tags');
+  }
+}

--- a/types/api.ts
+++ b/types/api.ts
@@ -60,6 +60,10 @@ export interface CategoriesResponse {
   categories: import('./category').Category[];
 }
 
+export interface TagsResponse {
+  tags: string[];
+}
+
 interface UsersResponse {
   users: (import('./user').User & { disabled?: boolean })[];
 }


### PR DESCRIPTION
## Summary
- make the product form use a two‑column grid layout
- add searchable tag input built with react-select
- fetch tags from new `/api/tags` endpoint
- expose `TagsResponse` type and helper to load unique tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ce506738c832f91bae6e435c4db5d