### PR TITLE
Add async category validation and creation

### DIFF
--- a/__tests__/categories-check.api.test.ts
+++ b/__tests__/categories-check.api.test.ts
@@ -1,0 +1,30 @@
+import handler from '../pages/api/categories/check';
+import { getCategoriesFlat } from '../lib/products';
+
+jest.mock('../lib/products', () => ({
+  getCategoriesFlat: jest.fn(),
+}));
+
+test('reports category exists', async () => {
+  (getCategoriesFlat as jest.Mock).mockResolvedValue([
+    { id: 1, name: 'Books', slug: 'books', createdAt: new Date(), updatedAt: new Date() },
+  ]);
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const req = { method: 'GET', query: { name: 'Books' } } as any;
+  const res = { status } as any;
+  await handler(req, res);
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({ exists: true, category: expect.any(Object) });
+});
+
+test('reports category not found', async () => {
+  (getCategoriesFlat as jest.Mock).mockResolvedValue([]);
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const req = { method: 'GET', query: { name: 'New' } } as any;
+  const res = { status } as any;
+  await handler(req, res);
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({ exists: false });
+});

--- a/__tests__/categories.api.test.ts
+++ b/__tests__/categories.api.test.ts
@@ -1,3 +1,6 @@
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('../pages/api/auth/[...nextauth]', () => ({ authOptions: {} }));
+
 import handler from '../pages/api/categories';
 import { getCategoryTree } from '../lib/products';
 

--- a/components/ProductForm.tsx
+++ b/components/ProductForm.tsx
@@ -106,31 +106,47 @@ const ProductForm: React.FC<ProductFormProps> = ({
       return;
     }
     setCreatingCat(true);
-    const res = await fetch('/api/categories/check-or-create', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: newCatName.trim(),
-        slug: newCatSlug.trim(),
-      }),
-    });
-    setCreatingCat(false);
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({ message: 'Error' }));
-      setCatError(data.message || 'Error');
-      return;
-    }
-    const data = await res.json();
-    if (data.exists) {
-      setCatError(`Category "${data.name}" already exists`);
-      return;
-    }
-    if (data.success && data.category) {
-      const cat = data.category as { id: number | string; name: string };
+    try {
+      const checkRes = await fetch(
+        `/api/categories/check?name=${encodeURIComponent(newCatName.trim())}`
+      );
+      if (!checkRes.ok) {
+        const data = await checkRes.json().catch(() => ({ message: 'Error' }));
+        setCatError(data.message || 'Error');
+        setCreatingCat(false);
+        return;
+      }
+      const checkData = await checkRes.json();
+      if (checkData.exists) {
+        const name = checkData.category?.name || newCatName.trim();
+        setCatError(`Category already exists: ${name}`);
+        setCreatingCat(false);
+        return;
+      }
+
+      const createRes = await fetch('/api/categories', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: newCatName.trim(),
+          slug: newCatSlug.trim(),
+        }),
+      });
+      setCreatingCat(false);
+      if (!createRes.ok) {
+        const data = await createRes.json().catch(() => ({ message: 'Error' }));
+        setCatError(data.message || 'Error');
+        return;
+      }
+      const data = await createRes.json();
+      const cat = (data.category || data) as { id: number | string; name: string };
       const opt = { label: cat.name, value: String(cat.id) } as SelectOption;
       setCategoryOption(opt);
       setValue('categoryId', opt.value);
       setShowCatModal(false);
+    } catch (err) {
+      setCatError('Error');
+      setCreatingCat(false);
     }
   };
 

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -1,7 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getCategoryTree, getCategoriesPaginated } from '../../lib/products';
+import {
+  getCategoryTree,
+  getCategoriesPaginated,
+  createCategory,
+  getCategoriesFlat,
+} from '../../lib/products';
 import { handleApiError } from '../../lib/utils/handleApiError';
-import type { CategoriesResponse, ApiMessage } from '../../types';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
+import type { CategoriesResponse, ApiMessage, Category } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
@@ -23,6 +30,24 @@ export default async function handler(
       }
       const categories = await getCategoryTree();
       return res.status(200).json({ categories });
+    }
+    if (req.method === 'POST') {
+      const session = await getServerSession(req, res, authOptions);
+      if (!session?.user) {
+        return res.status(401).json({ message: 'Unauthorized' });
+      }
+      const { name, slug } = req.body as Partial<Category>;
+      if (!name) return res.status(400).json({ message: 'name required' });
+      const exists = (await getCategoriesFlat()).find(
+        (c) =>
+          c.name.toLowerCase() === name.toLowerCase() ||
+          (slug && c.slug?.toLowerCase() === String(slug).toLowerCase())
+      );
+      if (exists) {
+        return res.status(409).json({ message: 'category exists' });
+      }
+      const category = await createCategory(name, slug);
+      return res.status(201).json({ category } as any);
     }
     return res.status(405).json({ message: 'Method Not Allowed' });
   } catch (error) {

--- a/pages/api/categories/check.ts
+++ b/pages/api/categories/check.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getCategoriesFlat } from '../../../lib/products';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { ApiMessage, Category } from '../../../types';
+
+interface CheckResponse {
+  exists: boolean;
+  category?: Category;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CheckResponse | ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const name = String(req.query.name || '').trim();
+    if (!name) return res.status(400).json({ message: 'name required' });
+    const categories = await getCategoriesFlat();
+    const match = categories.find(
+      (c) => c.name.toLowerCase() === name.toLowerCase()
+    );
+    if (match) {
+      return res.status(200).json({ exists: true, category: match });
+    }
+    return res.status(200).json({ exists: false });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to check category');
+  }
+}


### PR DESCRIPTION
## Summary
- add GET `/api/categories/check` endpoint
- extend `POST /api/categories` to create new categories
- check with `/api/categories/check` and create via `/api/categories` from the product form
- test new API behavior

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_685ce9317af4832fae2cc5cb694a68f7