### PR TITLE
Add existing products card to dashboard layout

### DIFF
--- a/components/dashboard/DashboardCard.tsx
+++ b/components/dashboard/DashboardCard.tsx
@@ -6,6 +6,7 @@ interface Props {
   error?: string;
   children?: React.ReactNode;
   className?: string;
+  onClick?: () => void;
 }
 
 const DashboardCard: React.FC<Props> = ({
@@ -14,10 +15,12 @@ const DashboardCard: React.FC<Props> = ({
   error,
   children,
   className = '',
+  onClick,
 }) => {
   return (
     <div
-      className={`border rounded-lg shadow p-4 bg-base-100 transition-shadow duration-200 hover:shadow-md ${className}`}
+      className={`border rounded-lg shadow p-4 bg-base-100 transition-shadow duration-200 hover:shadow-md ${onClick ? 'cursor-pointer hover:bg-base-200' : ''} ${className}`}
+      onClick={onClick}
     >
       <h3 className="font-semibold mb-2">{title}</h3>
       {loading ? (

--- a/components/dashboard/ExistingProductsCard.tsx
+++ b/components/dashboard/ExistingProductsCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import DashboardCard from './DashboardCard';
 import type { Product } from '../../types/product';
 
@@ -11,6 +12,7 @@ interface Props {
 const ExistingProductsCard: React.FC<Props> = ({ brand, previewCount = 3 }) => {
   const [products, setProducts] = useState<Product[] | null>(null);
   const [error, setError] = useState('');
+  const router = useRouter();
 
   useEffect(() => {
     if (!brand) return;
@@ -38,6 +40,7 @@ const ExistingProductsCard: React.FC<Props> = ({ brand, previewCount = 3 }) => {
       loading={!products && !error}
       error={error}
       className="space-y-2"
+      onClick={() => router.push('/brand/products')}
     >
       {products && (
         <p>

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -32,10 +32,12 @@ const BrandDashboard: React.FC = () => {
         <TotalProductsCard brand={user.brandName || undefined} />
         <TotalSalesCard brand={user.brandName || undefined} />
         <OrdersThisMonthCard brand={user.brandName || undefined} />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <BestSellersCard brand={user.brandName || undefined} />
         <InventoryAlertsCard brand={user.brandName || undefined} />
+        <ExistingProductsCard brand={user.brandName || undefined} />
       </div>
-      <ExistingProductsCard brand={user.brandName || undefined} />
     </div>
   );
 };

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -7,6 +7,7 @@ import TotalSalesCard from '../components/dashboard/TotalSalesCard';
 import OrdersThisMonthCard from '../components/dashboard/OrdersThisMonthCard';
 import BestSellersCard from '../components/dashboard/BestSellersCard';
 import InventoryAlertsCard from '../components/dashboard/InventoryAlertsCard';
+import ExistingProductsCard from '../components/dashboard/ExistingProductsCard';
 
 const DashboardPage: React.FC = () => {
   const { user } = useContext(AppContext) as { user: any };
@@ -28,8 +29,11 @@ const DashboardPage: React.FC = () => {
         <TotalProductsCard brand={brand} />
         <TotalSalesCard brand={brand} />
         <OrdersThisMonthCard brand={brand} />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <BestSellersCard brand={brand} />
         <InventoryAlertsCard brand={brand} />
+        {brand && <ExistingProductsCard brand={brand} />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make `DashboardCard` accept onClick
- allow navigating to Products from `ExistingProductsCard`
- show existing products card in dashboard and brand dashboard grids

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm ci` *(fails: could not fetch prisma binaries)*

------
https://chatgpt.com/codex/tasks/task_e_685cea08a9b4832fbf109d40244ae5c9