### PR TITLE
Fix tag creation on dropdown

### DIFF
--- a/__tests__/TagInput.test.tsx
+++ b/__tests__/TagInput.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import TagInput from '../components/form-fields/TagInput';
+
+interface FormValues {
+  tags: string[];
+}
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve({ tags: [] }) })
+) as jest.Mock;
+
+const TestForm = ({ onSubmit }: { onSubmit: (data: FormValues) => void }) => {
+  const { control, handleSubmit } = useForm<FormValues>({
+    defaultValues: { tags: [] },
+  });
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <TagInput<FormValues> name="tags" control={control} />
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+test('allows creating a new tag', async () => {
+  const handleSubmit = jest.fn();
+  render(<TestForm onSubmit={handleSubmit} />);
+
+  const input = screen.getByRole('combobox');
+  fireEvent.change(input, { target: { value: 'NewTag' } });
+  fireEvent.keyDown(input, { key: 'ArrowDown' });
+  await waitFor(() => screen.getByText('Create "NewTag"'));
+  fireEvent.click(screen.getByText('Create "NewTag"'));
+
+  fireEvent.click(screen.getByText('Submit'));
+
+  await waitFor(() =>
+    expect(handleSubmit).toHaveBeenCalledWith(
+      { tags: ['NewTag'] },
+      expect.anything()
+    )
+  );
+});

--- a/components/form-fields/TagInput.tsx
+++ b/components/form-fields/TagInput.tsx
@@ -19,7 +19,15 @@ export interface TagInputProps<T extends FieldValues> {
 }
 
 const TagInput = <T extends FieldValues>(props: TagInputProps<T>) => {
-  const { name, control, label, placeholder = '', disabled, error, rules } = props;
+  const {
+    name,
+    control,
+    label,
+    placeholder = '',
+    disabled,
+    error,
+    rules,
+  } = props;
 
   const loadOptions = async (inputValue: string) => {
     const params = new URLSearchParams({ search: inputValue });
@@ -30,22 +38,31 @@ const TagInput = <T extends FieldValues>(props: TagInputProps<T>) => {
   };
 
   const customComponents = {
-    MultiValueContainer: (props: any) => (
-      <span className="badge badge-outline gap-1 mr-1">
-        {props.data.label}
-        <button
-          type="button"
-          className="ml-1"
-          onClick={props.removeProps.onClick}
-          onMouseDown={(e) => {
-            e.preventDefault();
-            props.removeProps.onMouseDown(e);
-          }}
-        >
-          ✕
-        </button>
-      </span>
-    ),
+    MultiValueContainer: (props: any) => {
+      if (!props.removeProps) {
+        // eslint-disable-next-line no-console
+        console.error('TagInput: removeProps not provided');
+      }
+      const handleClick = props.removeProps?.onClick;
+      const handleMouseDown = props.removeProps?.onMouseDown;
+      return (
+        <span className="badge badge-outline gap-1 mr-1">
+          {props.data.label}
+          <button
+            type="button"
+            className="ml-1"
+            onClick={handleClick}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              handleMouseDown?.(e);
+            }}
+            aria-label="Remove tag"
+          >
+            ✕
+          </button>
+        </span>
+      );
+    },
     MultiValueLabel: () => null,
     MultiValueRemove: () => null,
   };


### PR DESCRIPTION
## Summary
- safeguard TagInput custom remove button
- add regression test for creating tags via dropdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ceb351ffc832fbc7c57bdb13128d7