### PR TITLE
Fix reset page overflow

### DIFF
--- a/pages/reset.tsx
+++ b/pages/reset.tsx
@@ -21,7 +21,7 @@ const RequestReset: React.FC = () => {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8 overflow-hidden">
+    <div className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
       <Head>
         <title>{getPageTitle('Reset Password')}</title>
       </Head>


### PR DESCRIPTION
## Summary
- allow reset page container to grow with content

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d10b92ab8832fa7634b56332c5ec8