### PR TITLE
Refactor create category modal

### DIFF
--- a/components/CreateCategoryModal.tsx
+++ b/components/CreateCategoryModal.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from 'react';
+import { GenericInput, GenericModal } from './ui';
+import { slugify } from '../lib/slugify';
+
+interface CreateCategoryModalProps {
+  isOpen: boolean;
+  initialName?: string;
+  onClose: () => void;
+  onCreated: (cat: { id: number | string; name: string }) => void;
+}
+
+const CreateCategoryModal: React.FC<CreateCategoryModalProps> = ({
+  isOpen,
+  initialName = '',
+  onClose,
+  onCreated,
+}) => {
+  const [name, setName] = useState(initialName);
+  const [slug, setSlug] = useState(slugify(initialName));
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setName(initialName);
+    setSlug(slugify(initialName));
+    setError('');
+    setSaving(false);
+  }, [initialName, isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const nameTrim = name.trim();
+    const slugTrim = slug.trim();
+    if (!nameTrim) {
+      setError('Name required');
+      return;
+    }
+    if (!slugTrim) {
+      setError('Slug required');
+      return;
+    }
+    setSaving(true);
+    try {
+      const checkRes = await fetch(
+        `/api/categories/check?name=${encodeURIComponent(nameTrim)}`
+      );
+      if (checkRes.ok) {
+        const checkData = await checkRes.json();
+        if (checkData.exists) {
+          setError(`Category already exists: ${checkData.category.name}`);
+          setSaving(false);
+          return;
+        }
+      }
+      const createRes = await fetch('/api/categories', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: nameTrim, slug: slugTrim }),
+      });
+      if (createRes.status === 409) {
+        const data = await createRes.json().catch(() => ({}));
+        const existingName = data.category?.name || nameTrim;
+        setError(`Category already exists: ${existingName}`);
+        setSaving(false);
+        return;
+      }
+      if (!createRes.ok) {
+        const data = await createRes.json().catch(() => ({ message: 'Error' }));
+        setError(data.message || 'Error');
+        setSaving(false);
+        return;
+      }
+      const data = await createRes.json();
+      const cat = (data.category || data) as {
+        id: number | string;
+        name: string;
+      };
+      onCreated(cat);
+      setName('');
+      setSlug('');
+      setSaving(false);
+      onClose();
+    } catch (err) {
+      setError('Error');
+      setSaving(false);
+    }
+  };
+
+  return (
+    <GenericModal isOpen={isOpen} onClose={onClose} title="Create Category">
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <GenericInput
+          label="Category Name"
+          name="category-name"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            setSlug(slugify(e.target.value));
+          }}
+          required
+        />
+        <GenericInput
+          label="Slug"
+          name="category-slug"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          required
+        />
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <button type="button" className="btn" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="submit" className="btn btn-primary" disabled={saving}>
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </form>
+    </GenericModal>
+  );
+};
+
+export default CreateCategoryModal;

--- a/components/ProductForm.tsx
+++ b/components/ProductForm.tsx
@@ -9,8 +9,7 @@ import {
   Checkbox,
   TagInput,
 } from './form-fields';
-import { GenericInput, GenericModal } from './ui';
-import { slugify } from '../lib/slugify';
+
 import { AppContext } from '../contexts/AppContext';
 
 export interface ProductFormValues {
@@ -34,6 +33,9 @@ interface ProductFormProps {
   onSubmit: (data: FormData) => Promise<void> | void;
   onCancel?: () => void;
   submitLabel?: string;
+  requestNewCategory?: (
+    name: string
+  ) => Promise<{ id: number | string; name: string } | undefined>;
 }
 
 const ProductForm: React.FC<ProductFormProps> = ({
@@ -41,6 +43,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
   onSubmit,
   onCancel,
   submitLabel = 'Save',
+  requestNewCategory,
 }) => {
   const { user } = useContext(AppContext) as {
     user: { brandName?: string } | null;
@@ -89,11 +92,6 @@ const ProductForm: React.FC<ProductFormProps> = ({
       ? { label: '', value: String(initial.categoryId) }
       : null
   );
-  const [showCatModal, setShowCatModal] = useState(false);
-  const [newCatName, setNewCatName] = useState('');
-  const [newCatSlug, setNewCatSlug] = useState('');
-  const [catError, setCatError] = useState('');
-  const [creatingCat, setCreatingCat] = useState(false);
   const loadCategoryOptions = async (
     inputValue: string
   ): Promise<SelectOption[]> => {
@@ -107,72 +105,14 @@ const ProductForm: React.FC<ProductFormProps> = ({
     }));
   };
 
-  const openCreateCategory = (input: string) => {
+  const openCreateCategory = async (input: string) => {
     const name = input.trim();
-    setNewCatName(name);
-    setNewCatSlug(slugify(name));
-    setCatError('');
-    setCreatingCat(false);
-    setShowCatModal(true);
-  };
-
-  const handleCreateCategory = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const name = newCatName.trim();
-    const slug = newCatSlug.trim();
-    if (!name) {
-      setCatError('Name required');
-      return;
-    }
-    if (!slug) {
-      setCatError('Slug required');
-      return;
-    }
-    setCreatingCat(true);
-    try {
-      const checkRes = await fetch(
-        `/api/categories/check?name=${encodeURIComponent(name)}`
-      );
-      if (checkRes.ok) {
-        const checkData = await checkRes.json();
-        if (checkData.exists) {
-          setCatError(`Category already exists: ${checkData.category.name}`);
-          setCreatingCat(false);
-          return;
-        }
-      }
-      const createRes = await fetch('/api/categories', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name,
-          slug,
-        }),
-      });
-      if (createRes.status === 409) {
-        const data = await createRes.json().catch(() => ({}));
-        const existingName = data.category?.name || name;
-        setCatError(`Category already exists: ${existingName}`);
-        setCreatingCat(false);
-        return;
-      }
-      if (!createRes.ok) {
-        const data = await createRes.json().catch(() => ({ message: 'Error' }));
-        setCatError(data.message || 'Error');
-        setCreatingCat(false);
-        return;
-      }
-      const data = await createRes.json();
-      const cat = (data.category || data) as { id: number | string; name: string };
+    if (!requestNewCategory) return;
+    const cat = await requestNewCategory(name);
+    if (cat) {
       const opt = { label: cat.name, value: String(cat.id) } as SelectOption;
       setCategoryOption(opt);
       setValue('categoryId', opt.value);
-      setShowCatModal(false);
-      setNewCatName('');
-      setNewCatSlug('');
-      setCreatingCat(false);
-    } catch (err) {
-      setCatError('Error');
     }
   };
 
@@ -255,76 +195,30 @@ const ProductForm: React.FC<ProductFormProps> = ({
           control={control}
           rules={{ required: 'Required' }}
           render={({ field }) => (
-            <>
-              <AsyncCreatableSelect
-                inputId="category-select"
-                ref={field.ref}
-                value={categoryOption}
-                defaultOptions
-                loadOptions={loadCategoryOptions}
-                onBlur={field.onBlur}
-                onChange={(val) => {
-                  if (!val) {
-                    setCategoryOption(null);
-                    field.onChange('');
-                  } else if (!Array.isArray(val)) {
-                    setCategoryOption(val as SelectOption);
-                    field.onChange(val.value);
-                  }
-                }}
-                onCreateOption={openCreateCategory}
-                formatCreateLabel={() => 'Create New Category'}
-                isValidNewOption={(input, _value, options) =>
-                  input.trim().length > 0 && options.length === 0
+            <AsyncCreatableSelect
+              inputId="category-select"
+              ref={field.ref}
+              value={categoryOption}
+              defaultOptions
+              loadOptions={loadCategoryOptions}
+              onBlur={field.onBlur}
+              onChange={(val) => {
+                if (!val) {
+                  setCategoryOption(null);
+                  field.onChange('');
+                } else if (!Array.isArray(val)) {
+                  setCategoryOption(val as SelectOption);
+                  field.onChange(val.value);
                 }
-                placeholder="Category"
-                classNamePrefix="react-select"
-              />
-              <GenericModal
-                isOpen={showCatModal}
-                onClose={() => setShowCatModal(false)}
-                title="Create Category"
-              >
-                <form onSubmit={handleCreateCategory} className="space-y-2">
-                  <GenericInput
-                    label="Category Name"
-                    name="category-name"
-                    value={newCatName}
-                    onChange={(e) => {
-                      setNewCatName(e.target.value);
-                      setNewCatSlug(slugify(e.target.value));
-                    }}
-                    required
-                  />
-                  <GenericInput
-                    label="Slug"
-                    name="category-slug"
-                    value={newCatSlug}
-                    onChange={(e) => setNewCatSlug(e.target.value)}
-                    required
-                  />
-                  {catError && (
-                    <p className="text-sm text-red-600">{catError}</p>
-                  )}
-                  <div className="flex justify-end gap-2">
-                    <button
-                      type="button"
-                      className="btn"
-                      onClick={() => setShowCatModal(false)}
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      className="btn btn-primary"
-                      disabled={creatingCat}
-                    >
-                      {creatingCat ? 'Saving...' : 'Save'}
-                    </button>
-                  </div>
-                </form>
-              </GenericModal>
-            </>
+              }}
+              onCreateOption={openCreateCategory}
+              formatCreateLabel={() => 'Create New Category'}
+              isValidNewOption={(input, _value, options) =>
+                input.trim().length > 0 && options.length === 0
+              }
+              placeholder="Category"
+              classNamePrefix="react-select"
+            />
           )}
         />
       </div>

--- a/pages/brand/products/new.tsx
+++ b/pages/brand/products/new.tsx
@@ -1,7 +1,8 @@
-import React, { useContext } from 'react';
+import React, { useContext, useRef, useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import ProductForm from '../../../components/ProductForm';
+import CreateCategoryModal from '../../../components/CreateCategoryModal';
 import { AppContext } from '../../../contexts/AppContext';
 import { NotificationContext } from '../../../contexts/NotificationContext';
 import type { User } from '../../../types/user';
@@ -10,6 +11,12 @@ import { getPageTitle } from '../../../lib/pageTitle';
 const NewProductPage: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
   const { addNotification } = useContext(NotificationContext);
+
+  const [catModalOpen, setCatModalOpen] = useState(false);
+  const [catInitialName, setCatInitialName] = useState('');
+  const catResolver = useRef<
+    ((cat?: { id: number | string; name: string }) => void) | undefined
+  >();
 
   const submitProduct = async (values: FormData) => {
     const res = await fetch('/api/brand/products', {
@@ -21,6 +28,32 @@ const NewProductPage: React.FC = () => {
     } else {
       const data = await res.json().catch(() => ({ message: 'Error' }));
       addNotification(data.message || 'Error', 'error');
+    }
+  };
+
+  const requestNewCategory = (name: string) => {
+    setCatInitialName(name);
+    setCatModalOpen(true);
+    return new Promise<{ id: number | string; name: string } | undefined>(
+      (resolve) => {
+        catResolver.current = resolve;
+      }
+    );
+  };
+
+  const handleCatClose = () => {
+    setCatModalOpen(false);
+    if (catResolver.current) {
+      catResolver.current(undefined);
+      catResolver.current = undefined;
+    }
+  };
+
+  const handleCatCreated = (cat: { id: number | string; name: string }) => {
+    setCatModalOpen(false);
+    if (catResolver.current) {
+      catResolver.current(cat);
+      catResolver.current = undefined;
     }
   };
 
@@ -38,7 +71,17 @@ const NewProductPage: React.FC = () => {
       </Head>
       <div className="max-w-lg mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
         <h1 className="text-2xl font-bold mb-4 text-center">Add New Product</h1>
-        <ProductForm onSubmit={submitProduct} submitLabel="Add Product" />
+        <ProductForm
+          onSubmit={submitProduct}
+          submitLabel="Add Product"
+          requestNewCategory={requestNewCategory}
+        />
+        <CreateCategoryModal
+          isOpen={catModalOpen}
+          initialName={catInitialName}
+          onClose={handleCatClose}
+          onCreated={handleCatCreated}
+        />
         <p className="text-center mt-4">
           <Link href="/brand/dashboard" className="link">
             Back to Dashboard


### PR DESCRIPTION
## Summary
- extract `CreateCategoryModal` component for standalone category creation
- let `ProductForm` request category creation via a callback
- update new product page to host the modal

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685d14071d80832f87dd22db46df9950