### PR TITLE
Fix loading state for dashboard product count card

### DIFF
--- a/components/dashboard/TotalProductsCard.tsx
+++ b/components/dashboard/TotalProductsCard.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import DashboardCard from './DashboardCard';
 
 interface Props {
@@ -8,23 +9,38 @@ interface Props {
 const TotalProductsCard: React.FC<Props> = ({ brand }) => {
   const [count, setCount] = useState<number | null>(null);
   const [error, setError] = useState<string>('');
+  const router = useRouter();
+
   useEffect(() => {
-    setCount(null);
-    setError('');
-    const url =
-      '/api/dashboard/total-products' +
-      (brand ? `?brand=${encodeURIComponent(brand)}` : '');
-    fetch(url)
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data) => setCount(data.count))
-      .catch(() => setError('Failed to load'));
+    async function load() {
+      setCount(null);
+      setError('');
+      const url =
+        '/api/dashboard/total-products' +
+        (brand ? `?brand=${encodeURIComponent(brand)}` : '');
+      try {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error('Failed to load');
+        const data = await res.json();
+        setCount(data.count);
+      } catch {
+        setError('Failed to load');
+        setCount(0);
+      }
+    }
+    load();
   }, [brand]);
+
+  const handleClick = () => {
+    router.push(brand ? '/brand/products' : '/products');
+  };
 
   return (
     <DashboardCard
       title="Total Products"
       loading={count === null && !error}
       error={error}
+      onClick={handleClick}
     >
       {count !== null && <p className="text-3xl font-bold">{count}</p>}
     </DashboardCard>


### PR DESCRIPTION
## Summary
- fix product count loading state
- navigate to product list when clicking the card

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d39511e84832f8039a822aa27543d