### PR TITLE
Improve vendor and category validation

### DIFF
--- a/components/ProductForm.tsx
+++ b/components/ProductForm.tsx
@@ -36,6 +36,11 @@ interface ProductFormProps {
   requestNewCategory?: (
     name: string
   ) => Promise<{ id: number | string; name: string } | undefined>;
+  requestNewVendor?: (
+    name: string
+  ) => Promise<{ brandName: string } | undefined>;
+  loading?: boolean;
+  serverError?: string;
 }
 
 const ProductForm: React.FC<ProductFormProps> = ({
@@ -44,6 +49,9 @@ const ProductForm: React.FC<ProductFormProps> = ({
   onCancel,
   submitLabel = 'Save',
   requestNewCategory,
+  requestNewVendor,
+  loading = false,
+  serverError,
 }) => {
   const { user } = useContext(AppContext) as {
     user: { brandName?: string } | null;
@@ -84,9 +92,13 @@ const ProductForm: React.FC<ProductFormProps> = ({
   useEffect(() => {
     if (user?.brandName) {
       setValue('vendor', user.brandName);
+      setVendorOption({ label: user.brandName, value: user.brandName });
     }
   }, [user, setValue]);
   const [images, setImages] = useState<File[]>([]);
+  const [vendorOption, setVendorOption] = useState<SelectOption | null>(
+    initial?.vendor ? { label: initial.vendor, value: initial.vendor } : null
+  );
   const [categoryOption, setCategoryOption] = useState<SelectOption | null>(
     initial?.categoryId
       ? { label: '', value: String(initial.categoryId) }
@@ -103,6 +115,35 @@ const ProductForm: React.FC<ProductFormProps> = ({
       label: c.name,
       value: String(c.id),
     }));
+  };
+
+  const loadVendorOptions = async (
+    inputValue: string
+  ): Promise<SelectOption[]> => {
+    const params = new URLSearchParams({ search: inputValue, limit: '20' });
+    const res = await fetch(`/api/vendors?${params.toString()}`);
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (data.vendors || []).map((v: any) => ({
+      label: v.brandName,
+      value: v.brandName,
+    }));
+  };
+
+  const openCreateVendor = async (input: string) => {
+    const name = input.trim();
+    if (requestNewVendor) {
+      const v = await requestNewVendor(name);
+      if (v) {
+        const opt = { label: v.brandName, value: v.brandName } as SelectOption;
+        setVendorOption(opt);
+        setValue('vendor', opt.value);
+        return;
+      }
+    }
+    const opt = { label: name, value: name } as SelectOption;
+    setVendorOption(opt);
+    setValue('vendor', name);
   };
 
   const openCreateCategory = async (input: string) => {
@@ -149,14 +190,41 @@ const ProductForm: React.FC<ProductFormProps> = ({
         rules={{ required: 'Required' }}
         error={errors.sku?.message}
       />
-      <TextInput<ProductFormValues>
-        label="Vendor"
+      <Controller
         name="vendor"
-        register={register}
+        control={control}
         rules={{ required: 'Required' }}
-        disabled={!!user?.brandName}
-        error={errors.vendor?.message}
+        render={({ field }) => (
+          <AsyncCreatableSelect
+            inputId="vendor-select"
+            ref={field.ref}
+            value={vendorOption}
+            defaultOptions
+            loadOptions={loadVendorOptions}
+            onBlur={field.onBlur}
+            onChange={(val) => {
+              if (!val) {
+                setVendorOption(null);
+                field.onChange('');
+              } else if (!Array.isArray(val)) {
+                setVendorOption(val as SelectOption);
+                field.onChange(val.value);
+              }
+            }}
+            onCreateOption={openCreateVendor}
+            formatCreateLabel={() => 'Create New Vendor'}
+            isValidNewOption={(input, _value, options) =>
+              input.trim().length > 0 && options.length === 0
+            }
+            placeholder="Vendor"
+            classNamePrefix="react-select"
+            isDisabled={!!user?.brandName}
+          />
+        )}
       />
+      {errors.vendor && (
+        <p className="text-sm text-red-600">{errors.vendor.message}</p>
+      )}
       <TextInput<ProductFormValues>
         label="Title"
         name="title"
@@ -305,10 +373,11 @@ const ProductForm: React.FC<ProductFormProps> = ({
             Cancel
           </button>
         )}
-        <button type="submit" className="btn btn-primary">
-          {submitLabel}
+        <button type="submit" className="btn btn-primary" disabled={loading}>
+          {loading ? 'Saving...' : submitLabel}
         </button>
       </div>
+      {serverError && <p className="text-sm text-red-600">{serverError}</p>}
     </form>
   );
 };

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -220,8 +220,15 @@ export async function addProduct(product: ProductInput): Promise<void> {
       ? await db.category.findFirst({ where: { name: product.category.name } })
       : null;
 
-  if (!vendor || !category) {
-    throw new Error('Invalid vendor or category');
+  if (!vendor) {
+    const err = new Error('Vendor not found') as Error & { code?: string };
+    (err as any).code = 'BAD_REQUEST';
+    throw err;
+  }
+  if (!category) {
+    const err = new Error('Category not found') as Error & { code?: string };
+    (err as any).code = 'BAD_REQUEST';
+    throw err;
   }
 
   const data: Prisma.ProductCreateInput = {
@@ -260,8 +267,15 @@ export async function updateProduct(
     : product.category?.name
       ? await db.category.findFirst({ where: { name: product.category.name } })
       : null;
-  if (!vendor || !category) {
-    throw new Error('Invalid vendor or category');
+  if (!vendor) {
+    const err = new Error('Vendor not found') as Error & { code?: string };
+    (err as any).code = 'BAD_REQUEST';
+    throw err;
+  }
+  if (!category) {
+    const err = new Error('Category not found') as Error & { code?: string };
+    (err as any).code = 'BAD_REQUEST';
+    throw err;
   }
   await db.product.update({
     where: { uuid: product.uuid || String(product.id) },

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,6 +1,8 @@
 import { getDb } from './db';
 import type { Prisma, Role } from '@prisma/client';
 import type { UserInput } from '../types/user';
+import bcrypt from 'bcryptjs';
+import { slugify } from './slugify';
 
 const prisma = getDb();
 
@@ -131,4 +133,45 @@ export async function changeEmail(
 
 export function updateUserProfile(email: string, data: Prisma.UserUpdateInput) {
   return prisma.user.update({ where: { email }, data });
+}
+
+export function findVendorByName(brandName: string) {
+  return prisma.user.findFirst({
+    where: { role: 'BRAND', brandName },
+    select: { id: true, brandName: true, email: true },
+  });
+}
+
+export function getVendors(
+  search = '',
+  limit = 20,
+  offset = 0
+) {
+  return prisma.user.findMany({
+    where: {
+      role: 'BRAND',
+      brandName: { contains: search, mode: 'insensitive' },
+    },
+    select: { id: true, brandName: true, email: true },
+    orderBy: { brandName: 'asc' },
+    take: limit,
+    skip: offset,
+  });
+}
+
+export async function createVendor(name: string) {
+  const slug = slugify(name);
+  const email = `${slug}-${Date.now()}@example.com`;
+  const password = await bcrypt.hash('password', 10);
+  return prisma.user.create({
+    data: {
+      email,
+      password,
+      firstName: name,
+      lastName: '',
+      brandName: name,
+      gender: 'OTHER',
+      role: 'BRAND',
+    },
+  });
 }

--- a/pages/api/vendors.ts
+++ b/pages/api/vendors.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getVendors } from '../../lib/users';
+import { handleApiError } from '../../lib/utils/handleApiError';
+import type { Vendor, ApiMessage } from '../../types';
+
+export interface VendorsResponse {
+  vendors: Vendor[];
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<VendorsResponse | ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const { search = '', page, limit } = req.query;
+    const pageNum = parseInt(String(page || '1'), 10);
+    const limitNum = parseInt(String(limit || '20'), 10);
+    const offset = (pageNum - 1) * limitNum;
+    const vendors = await getVendors(String(search), limitNum, offset);
+    return res.status(200).json({ vendors });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load vendors');
+  }
+}

--- a/pages/api/vendors/check-or-create.ts
+++ b/pages/api/vendors/check-or-create.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { findVendorByName, createVendor } from '../../../lib/users';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { Vendor, ApiMessage } from '../../../types';
+
+interface CheckCreateResponse {
+  exists?: boolean;
+  success?: boolean;
+  vendor?: Vendor;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CheckCreateResponse | ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'POST') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const { name } = req.body || {};
+    if (!name) return res.status(400).json({ message: 'name required' });
+    const existing = await findVendorByName(String(name));
+    if (existing) {
+      return res
+        .status(200)
+        .json({ exists: true, vendor: existing as Vendor });
+    }
+    const vendor = await createVendor(String(name));
+    return res.status(201).json({ success: true, vendor });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to create vendor');
+  }
+}

--- a/pages/brand/products/new.tsx
+++ b/pages/brand/products/new.tsx
@@ -17,18 +17,26 @@ const NewProductPage: React.FC = () => {
   const catResolver = useRef<
     ((cat?: { id: number | string; name: string }) => void) | undefined
   >();
+  const [formKey, setFormKey] = useState(0);
+  const [serverError, setServerError] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const submitProduct = async (values: FormData) => {
+    setServerError('');
+    setLoading(true);
     const res = await fetch('/api/brand/products', {
       method: 'POST',
       body: values,
     });
     if (res.ok) {
       addNotification('Product added', 'success');
+      setFormKey((k) => k + 1);
     } else {
-      const data = await res.json().catch(() => ({ message: 'Error' }));
-      addNotification(data.message || 'Error', 'error');
+      const data = await res.json().catch(() => ({ error: 'Error' }));
+      setServerError(data.error || data.message || 'Error');
+      addNotification(data.error || data.message || 'Error', 'error');
     }
+    setLoading(false);
   };
 
   const requestNewCategory = (name: string) => {
@@ -39,6 +47,17 @@ const NewProductPage: React.FC = () => {
         catResolver.current = resolve;
       }
     );
+  };
+
+  const requestNewVendor = async (name: string) => {
+    const res = await fetch('/api/vendors/check-or-create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    if (!res.ok) return undefined;
+    const data = await res.json();
+    return data.vendor as { brandName: string };
   };
 
   const handleCatClose = () => {
@@ -72,9 +91,13 @@ const NewProductPage: React.FC = () => {
       <div className="max-w-lg mx-auto mt-10 border border-gray-200 rounded-lg shadow-sm p-6 bg-white w-full">
         <h1 className="text-2xl font-bold mb-4 text-center">Add New Product</h1>
         <ProductForm
+          key={formKey}
           onSubmit={submitProduct}
           submitLabel="Add Product"
           requestNewCategory={requestNewCategory}
+          requestNewVendor={requestNewVendor}
+          loading={loading}
+          serverError={serverError}
         />
         <CreateCategoryModal
           isOpen={catModalOpen}


### PR DESCRIPTION
## Summary
- validate vendor and category in product helpers
- expose vendor listing and creation API routes
- extend user utilities with vendor helpers
- use createable vendor dropdown in `ProductForm`
- show submission errors and loading state in product page

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3a8d5f48832fae766d99dfdef610