### PR TITLE
Improve product creation error handling and brand listing

### DIFF
--- a/components/Product/ProductForm.tsx
+++ b/components/Product/ProductForm.tsx
@@ -62,6 +62,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
     control,
     formState: { errors },
     setValue,
+    setFocus,
     watch,
   } = useForm<ProductFormValues>({
     defaultValues: {
@@ -157,23 +158,29 @@ const ProductForm: React.FC<ProductFormProps> = ({
     }
   };
 
-  const onFormSubmit = handleSubmit(async (values) => {
-    const fd = new FormData();
-    fd.append('id', values.id);
-    fd.append('vendor', values.vendor);
-    fd.append('sku', values.sku);
-    fd.append('title', values.title);
-    fd.append('description', values.description);
-    fd.append('product_type', values.productType);
-    fd.append('tags', values.tags.join(','));
-    fd.append('category_id', values.categoryId);
-    fd.append('quantity', values.available ? String(values.quantity) : '0');
-    fd.append('min_price', String(values.minPrice));
-    fd.append('max_price', String(values.maxPrice));
-    fd.append('currency', values.currency);
-    images.forEach((img) => fd.append('photos', img));
-    await onSubmit(fd);
-  });
+  const onFormSubmit = handleSubmit(
+    async (values) => {
+      const fd = new FormData();
+      fd.append('id', values.id);
+      fd.append('vendor', values.vendor);
+      fd.append('sku', values.sku);
+      fd.append('title', values.title);
+      fd.append('description', values.description);
+      fd.append('product_type', values.productType);
+      fd.append('tags', values.tags.join(','));
+      fd.append('category_id', values.categoryId);
+      fd.append('quantity', values.available ? String(values.quantity) : '0');
+      fd.append('min_price', String(values.minPrice));
+      fd.append('max_price', String(values.maxPrice));
+      fd.append('currency', values.currency);
+      images.forEach((img) => fd.append('photos', img));
+      await onSubmit(fd);
+    },
+    (invalid) => {
+      const first = Object.keys(invalid)[0] as keyof ProductFormValues | undefined;
+      if (first) setFocus(first);
+    }
+  );
 
   const handleImagesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files ? Array.from(e.target.files) : [];

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -4,9 +4,10 @@ import type { Product, ProductInput } from '../types/product';
 import { parseImages } from './utils/parseImages';
 import type { Category } from '../types/category';
 import type { Vendor } from '../types/vendor';
-import type { Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import client from './typesenseClient';
 import { getBestSellingProducts } from './orders';
+import { slugify } from './slugify';
 
 type ProductWithRelations = Prisma.ProductGetPayload<{
   include: { category: true; vendor: true };
@@ -233,7 +234,7 @@ export async function addProduct(product: ProductInput): Promise<void> {
 
   const data: Prisma.ProductCreateInput = {
     uuid: product.uuid,
-    slug: product.slug ?? '',
+    slug: product.slug?.trim() || slugify(product.title || product.uuid),
     sku: product.sku,
     title: product.title,
     description: product.description ?? '',
@@ -248,7 +249,21 @@ export async function addProduct(product: ProductInput): Promise<void> {
     category: { connect: { id: category.id } },
   };
 
-  await db.product.create({ data });
+  try {
+    await db.product.create({ data });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      const err = new Error(
+        'Product with the same name or slug already exists.'
+      ) as Error & { code?: string };
+      (err as any).code = 'BAD_REQUEST';
+      throw err;
+    }
+    throw error;
+  }
 }
 
 export async function updateProduct(
@@ -397,6 +412,37 @@ export async function getApprovedProductsPaginated(
     include: { category: true, vendor: true },
     take: limit,
     skip: offset,
+    orderBy: { id: 'asc' },
+  });
+  return rows.map((row) =>
+    processProductRow({
+      id: row.id,
+      uuid: row.uuid,
+      slug: row.slug,
+      sku: row.sku,
+      title: row.title,
+      vendor: row.vendor ?? null,
+      description: row.description,
+      productType: row.productType,
+      tags: row.tags,
+      category: row.category ?? null,
+      images: parseImages(row.images),
+      totalInventory: row.quantity,
+      priceRange: {
+        minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
+        maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
+      },
+    })
+  );
+}
+
+export async function getProductsByVendorBrandName(
+  brandName: string
+): Promise<Product[]> {
+  const db = getDb();
+  const rows: ProductWithRelations[] = await db.product.findMany({
+    where: { status: 'approved', vendor: { brandName } },
+    include: { category: true, vendor: true },
     orderBy: { id: 'asc' },
   });
   return rows.map((row) =>

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -1,5 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { addProduct, loadAndIndexProducts } from '../../../../lib/products';
+import {
+  addProduct,
+  loadAndIndexProducts,
+  getProductsByVendorBrandName,
+} from '../../../../lib/products';
 import { handleApiError } from '../../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../../lib/utils/getQueryParam';
 import { slugify } from '../../../../lib/slugify';
@@ -41,9 +45,8 @@ export default async function handler(
     if (req.method === 'GET') {
       const vendor = getQueryParam(req.query.vendor);
       if (!vendor) return res.status(400).json({ message: 'vendor required' });
-      const { products } = await loadAndIndexProducts();
-      const filtered = products.filter((p) => p.vendor.brandName === vendor);
-      return res.status(200).json(filtered);
+      const products = await getProductsByVendorBrandName(vendor);
+      return res.status(200).json(products);
     }
 
     if (req.method === 'POST') {

--- a/pages/brand/products/new.tsx
+++ b/pages/brand/products/new.tsx
@@ -24,17 +24,22 @@ const NewProductPage: React.FC = () => {
   const submitProduct = async (values: FormData) => {
     setServerError('');
     setLoading(true);
-    const res = await fetch('/api/brand/products', {
-      method: 'POST',
-      body: values,
-    });
-    if (res.ok) {
-      addNotification('Product added', 'success');
-      setFormKey((k) => k + 1);
-    } else {
-      const data = await res.json().catch(() => ({ error: 'Error' }));
-      setServerError(data.error || data.message || 'Error');
-      addNotification(data.error || data.message || 'Error', 'error');
+    try {
+      const res = await fetch('/api/brand/products', {
+        method: 'POST',
+        body: values,
+      });
+      if (res.ok) {
+        addNotification('Product added', 'success');
+        setFormKey((k) => k + 1);
+      } else {
+        const data = await res.json().catch(() => ({ error: 'Error' }));
+        setServerError(data.error || data.message || 'Error');
+        addNotification(data.error || data.message || 'Error', 'error');
+      }
+    } catch (err) {
+      setServerError('Error');
+      addNotification('Error', 'error');
     }
     setLoading(false);
   };


### PR DESCRIPTION
## Summary
- handle unique constraint errors when creating products
- auto-generate slug if none supplied
- query products by vendor in API route
- focus first invalid field in brand product form
- show toast on network error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d46ecc080832fb4ffeb6acd5a5ada