### PR TITLE
Fix product count card

### DIFF
--- a/components/dashboard/DashboardCard.tsx
+++ b/components/dashboard/DashboardCard.tsx
@@ -24,7 +24,10 @@ const DashboardCard: React.FC<Props> = ({
     >
       <h3 className="font-semibold mb-2">{title}</h3>
       {loading ? (
-        <p>Loading...</p>
+        <div className="space-y-2 animate-pulse">
+          <div className="h-4 bg-base-300 rounded w-3/4" />
+          <div className="h-3 bg-base-300 rounded w-1/2" />
+        </div>
       ) : error ? (
         <p className="text-red-600">{error}</p>
       ) : (

--- a/components/dashboard/ExistingProductsCard.tsx
+++ b/components/dashboard/ExistingProductsCard.tsx
@@ -5,25 +5,22 @@ import DashboardCard from './DashboardCard';
 import type { Product } from '../../types/product';
 
 interface Props {
-  brand?: string;
   previewCount?: number;
 }
 
-const ExistingProductsCard: React.FC<Props> = ({ brand, previewCount = 3 }) => {
+const ExistingProductsCard: React.FC<Props> = ({ previewCount = 3 }) => {
   const [products, setProducts] = useState<Product[] | null>(null);
   const [error, setError] = useState('');
   const router = useRouter();
 
   useEffect(() => {
-    if (!brand) return;
     setProducts(null);
     setError('');
-    const url = `/api/brand/products?vendor=${encodeURIComponent(brand)}`;
-    fetch(url)
+    fetch('/api/brand/products')
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data: Product[]) => setProducts(data))
       .catch(() => setError('Failed to load'));
-  }, [brand]);
+  }, []);
 
   const preview =
     products

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -11,6 +11,7 @@ import type { Product, ProductInput, ApiMessage } from '../../../../types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import fs from 'fs';
 import path from 'path';
+import { withRole } from '../../../../lib/withRole';
 
 export const config = {
   api: {
@@ -37,13 +38,14 @@ async function parseBody(
   });
 }
 
-export default async function handler(
+async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Product[] | ApiMessage>
 ): Promise<void> {
   try {
     if (req.method === 'GET') {
-      const vendor = getQueryParam(req.query.vendor);
+      const user = (req as any).user as { brandName?: string } | undefined;
+      const vendor = getQueryParam(req.query.vendor) || user?.brandName;
       if (!vendor) return res.status(400).json({ message: 'vendor required' });
       const products = await getProductsByVendorBrandName(vendor);
       return res.status(200).json(products);
@@ -111,3 +113,5 @@ export default async function handler(
     return handleApiError(res, error, 'Failed to manage products');
   }
 }
+
+export default withRole(['BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -36,7 +36,7 @@ const BrandDashboard: React.FC = () => {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <BestSellersCard brand={user.brandName || undefined} />
         <InventoryAlertsCard brand={user.brandName || undefined} />
-        <ExistingProductsCard brand={user.brandName || undefined} />
+        <ExistingProductsCard />
       </div>
     </div>
   );

--- a/pages/brand/products/index.tsx
+++ b/pages/brand/products/index.tsx
@@ -15,7 +15,7 @@ const BrandProductsPage: React.FC = () => {
   useEffect(() => {
     if (!user) return;
     setLoading(true);
-    fetch(`/api/brand/products?vendor=${encodeURIComponent(user.brandName || '')}`)
+    fetch('/api/brand/products')
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data: Product[]) => setProducts(data))
       .finally(() => setLoading(false));

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -33,7 +33,7 @@ const DashboardPage: React.FC = () => {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <BestSellersCard brand={brand} />
         <InventoryAlertsCard brand={brand} />
-        {brand && <ExistingProductsCard brand={brand} />}
+        {brand && <ExistingProductsCard />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- use session-based brand in `brand/products` API
- show skeleton in dashboard cards
- fetch products without query in `ExistingProductsCard`
- update brand dashboard and pages to new card API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4d1d9af4832f8333ca22fcff1681