### PR TITLE
Fix brand order session fetching

### DIFF
--- a/pages/api/brand/orders.ts
+++ b/pages/api/brand/orders.ts
@@ -3,6 +3,8 @@ import { getOrdersForVendor } from '../../../lib/orders';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,9 +14,13 @@ export default async function handler(
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const vendor = getQueryParam(req.query.vendor);
+    const session = await getServerSession(req, res, authOptions);
+    const vendor =
+      getQueryParam(req.query.vendor) || session?.user?.brandName || '';
     if (!vendor) {
-      return res.status(400).json({ message: 'vendor required' });
+      return res
+        .status(401)
+        .json({ message: 'Unable to determine brand ID' });
     }
     const orders = await getOrdersForVendor(vendor);
     return res.status(200).json(orders);

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -7,21 +7,21 @@ import { getPageTitle } from '../../lib/pageTitle';
 
 const BrandOrders: React.FC = () => {
   const { user } = useContext(AppContext)!;
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!user) return;
-    const vendorId = session?.user?.id;
+    if (!user || status === 'loading') return;
+    const vendorId = user.brandName || (session?.user as any)?.brandName;
     if (!vendorId) {
       setError('Unable to determine brand ID');
       setLoading(false);
       return;
     }
     setLoading(true);
-    fetch(`/api/brand/orders?vendor=${encodeURIComponent(vendorId as string)}`)
+    fetch(`/api/brand/orders?vendor=${encodeURIComponent(vendorId)}`)
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data: Order[]) => {
         setOrders(data);
@@ -29,7 +29,7 @@ const BrandOrders: React.FC = () => {
       })
       .catch(() => setError('Failed to load orders'))
       .finally(() => setLoading(false));
-  }, [user, session]);
+  }, [user, session, status]);
 
   if (!user) {
     return <div className="p-4">Please log in to view orders.</div>;


### PR DESCRIPTION
## Summary
- handle brand session in orders API route
- fetch brand orders using brand name from session

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d851cb32c832f80d4017a77b49cc9