### PR TITLE
Refactor mapDbRowToProduct usage

### DIFF
--- a/lib/products.ts
+++ b/lib/products.ts
@@ -144,28 +144,22 @@ async function loadProductsData(): Promise<Product[]> {
 }
 
 export function mapDbRowToProduct(row: ProductRow): Product {
+  const {
+    images,
+    quantity,
+    minPrice,
+    maxPrice,
+    currency,
+    ...rest
+  } = row;
+
   return processProductRow({
-    id: row.id,
-    uuid: row.uuid,
-    slug: row.slug,
-    sku: row.sku,
-    title: row.title,
-    vendor: row.vendor ?? null,
-    description: row.description,
-    productType: row.productType,
-    tags: row.tags,
-    category: row.category,
-    images: parseImages(row.images),
-    totalInventory: row.quantity,
+    ...rest,
+    images: parseImages(images),
+    totalInventory: quantity,
     priceRange: {
-      minVariantPrice: {
-        amount: row.minPrice,
-        currencyCode: row.currency,
-      },
-      maxVariantPrice: {
-        amount: row.maxPrice,
-        currencyCode: row.currency,
-      },
+      minVariantPrice: { amount: minPrice, currencyCode: currency },
+      maxVariantPrice: { amount: maxPrice, currencyCode: currency },
     },
   });
 }

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -62,28 +62,7 @@ async function handler(
         include: { category: true, vendor: true },
         orderBy: { id: 'asc' },
       });
-      const products = rows.map((row) =>
-        mapDbRowToProduct({
-          id: row.id,
-          uuid: row.uuid,
-          slug: row.slug,
-          sku: row.sku,
-          title: row.title,
-          vendor: row.vendor ?? null,
-          description: row.description,
-          productType: row.productType,
-          tags: row.tags,
-          category: row.category ?? null,
-          images: row.images,
-          quantity: row.quantity,
-          minPrice: row.minPrice,
-          maxPrice: row.maxPrice,
-          currency: row.currency,
-          status: row.status,
-          createdAt: row.createdAt,
-          updatedAt: row.updatedAt,
-        })
-      );
+      const products = rows.map((row) => mapDbRowToProduct(row));
       return res.status(200).json(products);
     }
 


### PR DESCRIPTION
## Summary
- simplify mapDbRowToProduct implementation
- pass full product row object in brand products API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d873d4230832fbdb431a430e34450