### PR TITLE
Refactor mapping utilities to use entire objects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ npm run dev
 - Maintain consistency with existing code structure and formatting.
 - Run `npm run lint` and `npm run format` before pushing.
 - Add comments to complex logic, especially in `lib/products.js`.
+- Prefer using the provided `mapDbRowTo*` helpers with the full DB row object
+  instead of manually mapping each property.
 
 ---
 

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -27,7 +27,7 @@ interface AddOrderParams {
   paymentProof?: string;
 }
 
-function mapOrderRow(row: OrderWithRelations): Order {
+export function mapDbRowToOrder(row: OrderWithRelations): Order {
   return {
     id: row.id,
     uuid: row.uuid,
@@ -90,7 +90,7 @@ export async function addOrder({
     )
   );
 
-  return createdOrders.map((o) => mapOrderRow(o));
+  return createdOrders.map((o) => mapDbRowToOrder(o));
 }
 
 export async function getOrdersForUser(email: string): Promise<Order[]> {
@@ -103,7 +103,7 @@ export async function getOrdersForUser(email: string): Promise<Order[]> {
     },
     orderBy: { createdAt: 'desc' },
   });
-  return rows.map(mapOrderRow);
+  return rows.map(mapDbRowToOrder);
 }
 
 export async function getAllOrders(): Promise<Order[]> {
@@ -115,7 +115,7 @@ export async function getAllOrders(): Promise<Order[]> {
     },
     orderBy: { createdAt: 'desc' },
   });
-  return rows.map(mapOrderRow);
+  return rows.map(mapDbRowToOrder);
 }
 
 export async function getAllOrdersFiltered(params: {
@@ -148,7 +148,7 @@ export async function getAllOrdersFiltered(params: {
     },
     orderBy: { createdAt: 'desc' },
   });
-  return rows.map(mapOrderRow);
+  return rows.map(mapDbRowToOrder);
 }
 
 export async function getOrdersForVendor(vendor: string): Promise<Order[]> {
@@ -161,7 +161,7 @@ export async function getOrdersForVendor(vendor: string): Promise<Order[]> {
     },
     orderBy: { createdAt: 'desc' },
   });
-  return rows.map(mapOrderRow);
+  return rows.map(mapDbRowToOrder);
 }
 
 export async function hasOrdersForProduct(
@@ -186,7 +186,7 @@ export async function getOrderByUuid(
     },
   });
   if (!row) return null;
-  const order = mapOrderRow(row);
+  const order = mapDbRowToOrder(row);
   return { ...order, userEmail: row.user.email };
 }
 

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -112,49 +112,19 @@ async function loadProductsData(): Promise<Product[]> {
       include: { category: true, vendor: true },
     });
 
-    return rows.map((row) =>
-      processProductRow({
-        id: row.id,
-        uuid: row.uuid,
-        slug: row.slug,
-        sku: row.sku,
-        title: row.title,
-        vendor: row.vendor ?? null,
-        description: row.description,
-        productType: row.productType,
-        tags: row.tags,
-        category: row.category ?? null,
-        images: parseImages(row.images),
-        totalInventory: row.quantity,
-        priceRange: {
-          minVariantPrice: {
-            amount: row.minPrice,
-            currencyCode: row.currency,
-          },
-          maxVariantPrice: {
-            amount: row.maxPrice,
-            currencyCode: row.currency,
-          },
-        },
-      })
-    );
+    return rows.map((row) => mapDbRowToProduct(row));
   } catch (error) {
     throw error;
   }
 }
 
 export function mapDbRowToProduct(row: ProductRow): Product {
-  const {
-    images,
-    quantity,
-    minPrice,
-    maxPrice,
-    currency,
-    ...rest
-  } = row;
+  const { images, quantity, minPrice, maxPrice, currency, ...rest } = row;
 
   return processProductRow({
     ...rest,
+    vendor: row.vendor ?? null,
+    category: row.category ?? null,
     images: parseImages(images),
     totalInventory: quantity,
     priceRange: {
@@ -330,25 +300,7 @@ export async function getPendingProducts(): Promise<Product[]> {
     where: { status: 'pending' },
     include: { category: true, vendor: true },
   });
-  return rows.map((row) =>
-    processProductRow({
-      id: row.id,
-      slug: row.slug,
-      sku: row.sku,
-      title: row.title,
-      vendor: row.vendor ?? null,
-      description: row.description,
-      productType: row.productType,
-      tags: row.tags,
-      category: row.category ?? null,
-      images: parseImages(row.images),
-      totalInventory: row.quantity,
-      priceRange: {
-        minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
-        maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
-      },
-    })
-  );
+  return rows.map((row) => mapDbRowToProduct(row));
 }
 
 export async function getProductsByCategorySlug(
@@ -359,26 +311,7 @@ export async function getProductsByCategorySlug(
     where: { status: 'approved', category: { slug } },
     include: { category: true, vendor: true },
   });
-  return rows.map((row) =>
-    processProductRow({
-      id: row.id,
-      uuid: row.uuid,
-      slug: row.slug,
-      sku: row.sku,
-      title: row.title,
-      vendor: row.vendor ?? null,
-      description: row.description,
-      productType: row.productType,
-      tags: row.tags,
-      category: row.category ?? null,
-      images: parseImages(row.images),
-      totalInventory: row.quantity,
-      priceRange: {
-        minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
-        maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
-      },
-    })
-  );
+  return rows.map((row) => mapDbRowToProduct(row));
 }
 
 export async function getProductsByCategorySlugPaginated(
@@ -394,26 +327,7 @@ export async function getProductsByCategorySlugPaginated(
     skip: offset,
     orderBy: { id: 'asc' },
   });
-  return rows.map((row) =>
-    processProductRow({
-      id: row.id,
-      uuid: row.uuid,
-      slug: row.slug,
-      sku: row.sku,
-      title: row.title,
-      vendor: row.vendor ?? null,
-      description: row.description,
-      productType: row.productType,
-      tags: row.tags,
-      category: row.category ?? null,
-      images: parseImages(row.images),
-      totalInventory: row.quantity,
-      priceRange: {
-        minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
-        maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
-      },
-    })
-  );
+  return rows.map((row) => mapDbRowToProduct(row));
 }
 
 export async function getApprovedProductsPaginated(
@@ -428,26 +342,7 @@ export async function getApprovedProductsPaginated(
     skip: offset,
     orderBy: { id: 'asc' },
   });
-  return rows.map((row) =>
-    processProductRow({
-      id: row.id,
-      uuid: row.uuid,
-      slug: row.slug,
-      sku: row.sku,
-      title: row.title,
-      vendor: row.vendor ?? null,
-      description: row.description,
-      productType: row.productType,
-      tags: row.tags,
-      category: row.category ?? null,
-      images: parseImages(row.images),
-      totalInventory: row.quantity,
-      priceRange: {
-        minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
-        maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
-      },
-    })
-  );
+  return rows.map((row) => mapDbRowToProduct(row));
 }
 
 export async function getProductsByVendorBrandName(
@@ -459,26 +354,7 @@ export async function getProductsByVendorBrandName(
     include: { category: true, vendor: true },
     orderBy: { id: 'asc' },
   });
-  return rows.map((row) =>
-    processProductRow({
-      id: row.id,
-      uuid: row.uuid,
-      slug: row.slug,
-      sku: row.sku,
-      title: row.title,
-      vendor: row.vendor ?? null,
-      description: row.description,
-      productType: row.productType,
-      tags: row.tags,
-      category: row.category ?? null,
-      images: parseImages(row.images),
-      totalInventory: row.quantity,
-      priceRange: {
-        minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
-        maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
-      },
-    })
-  );
+  return rows.map((row) => mapDbRowToProduct(row));
 }
 
 export interface PaginatedOptions {
@@ -557,26 +433,7 @@ export async function getProductsPaginated(
   rows = rows.slice(options.offset, options.offset + options.limit);
   return {
     total,
-    products: rows.map((row) =>
-      processProductRow({
-        id: row.id,
-        uuid: row.uuid,
-        slug: row.slug,
-        sku: row.sku,
-        title: row.title,
-        vendor: row.vendor ?? null,
-        description: row.description,
-        productType: row.productType,
-        tags: row.tags,
-        category: row.category ?? null,
-        images: parseImages(row.images),
-        totalInventory: row.quantity,
-        priceRange: {
-          minVariantPrice: { amount: row.minPrice, currencyCode: row.currency },
-          maxVariantPrice: { amount: row.maxPrice, currencyCode: row.currency },
-        },
-      })
-    ),
+    products: rows.map((row) => mapDbRowToProduct(row)),
   };
 }
 
@@ -670,7 +527,11 @@ export async function getDistinctTags(search = ''): Promise<string[]> {
   const term = search.trim().toLowerCase();
   const set = new Set<string>();
   for (const row of rows) {
-    const tags = row.tags?.split(',').map((t) => t.trim()).filter(Boolean) || [];
+    const tags =
+      row.tags
+        ?.split(',')
+        .map((t) => t.trim())
+        .filter(Boolean) || [];
     for (const tag of tags) {
       if (!term || tag.toLowerCase().includes(term)) {
         set.add(tag);

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -9,7 +9,7 @@ import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import { slugify } from '../../../lib/slugify';
 import { Product, ApiMessage } from '../../../types';
-import { parseImages } from '../../../lib/utils/parseImages';
+import { mapDbRowToProduct } from '../../../lib/products';
 
 export const config = {
   api: {
@@ -170,36 +170,7 @@ async function handler(
         where,
         include: { category: true, vendor: true },
       });
-      const data: Product[] = rows.map(
-        (p: any): Product => ({
-          id: String(p.id),
-          slug: p.slug,
-          sku: p.sku,
-          title: p.title,
-          vendor: p.vendor?.brandName ?? String(p.vendorId),
-          description: p.description,
-          productType: p.productType,
-          tags: p.tags,
-          category: p.category?.name,
-          images: parseImages(p.images),
-          totalInventory: p.quantity,
-          priceRange: {
-            minVariantPrice: { amount: p.minPrice, currencyCode: p.currency },
-            maxVariantPrice: { amount: p.maxPrice, currencyCode: p.currency },
-          },
-          minPrice: p.minPrice,
-          maxPrice: p.maxPrice,
-          currency: p.currency,
-          soldCount: 0,
-          reviewCount: 0,
-          averageRating: 0,
-          quantity: p.quantity,
-          status: p.status,
-          uuid: p.uuid,
-          createdAt: p.createdAt,
-          updatedAt: p.updatedAt,
-        })
-      );
+      const data: Product[] = rows.map((p) => mapDbRowToProduct(p as any));
       res.status(200).json(data);
       return;
     }


### PR DESCRIPTION
## Summary
- refactor redundant mapping patterns across database utilities
- export a new `mapDbRowToOrder` helper
- use `mapDbRowToProduct` and `mapDbRowToOrder` directly
- document mapper usage guidelines

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run format`
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d88d72cdc832f939fbe92a89bfa43