### PR TITLE
Fix brand dashboard scope & improve card links

### DIFF
--- a/components/dashboard/BestSellersCard.tsx
+++ b/components/dashboard/BestSellersCard.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import DashboardCard from './DashboardCard';
 
 interface Props {
-  brand?: string;
+  brandId?: number;
 }
 
 interface Product {
@@ -11,26 +12,32 @@ interface Product {
   quantity: number;
 }
 
-const BestSellersCard: React.FC<Props> = ({ brand }) => {
+const BestSellersCard: React.FC<Props> = ({ brandId }) => {
   const [products, setProducts] = useState<Product[] | null>(null);
   const [error, setError] = useState<string>('');
+  const router = useRouter();
   useEffect(() => {
     setProducts(null);
     setError('');
     const url =
       '/api/dashboard/best-sellers' +
-      (brand ? `?brand=${encodeURIComponent(brand)}` : '');
+      (brandId ? `?brandId=${brandId}` : '');
     fetch(url)
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data) => setProducts(data.products))
       .catch(() => setError('Failed to load'));
-  }, [brand]);
+  }, [brandId]);
+
+  const handleClick = () => {
+    router.push('/brand/orders');
+  };
 
   return (
     <DashboardCard
       title="Best-Selling Products"
       loading={!products && !error}
       error={error}
+      onClick={handleClick}
     >
       {products && products.length > 0 ? (
         <ul className="list-disc pl-4 space-y-1">
@@ -43,6 +50,9 @@ const BestSellersCard: React.FC<Props> = ({ brand }) => {
       ) : (
         !error && <p>No sales yet.</p>
       )}
+      <div className="mt-2 text-right text-sm">
+        <span className="link">View ↗</span>
+      </div>
     </DashboardCard>
   );
 };

--- a/components/dashboard/DashboardCard.tsx
+++ b/components/dashboard/DashboardCard.tsx
@@ -19,7 +19,7 @@ const DashboardCard: React.FC<Props> = ({
 }) => {
   return (
     <div
-      className={`border rounded-lg shadow p-4 bg-base-100 transition-shadow duration-200 hover:shadow-md ${onClick ? 'cursor-pointer hover:bg-base-200' : ''} ${className}`}
+      className={`border rounded-lg shadow p-4 bg-base-100 transition-shadow duration-200 hover:shadow-lg ${onClick ? 'cursor-pointer hover:bg-base-200' : ''} ${className}`}
       onClick={onClick}
     >
       <h3 className="font-semibold mb-2">{title}</h3>

--- a/components/dashboard/ExistingProductsCard.tsx
+++ b/components/dashboard/ExistingProductsCard.tsx
@@ -53,8 +53,8 @@ const ExistingProductsCard: React.FC<Props> = ({ previewCount = 3 }) => {
         </ul>
       )}
       <div>
-        <Link href="/brand/products" className="btn btn-primary btn-sm">
-          Go to Products
+        <Link href="/brand/products" className="btn btn-primary btn-sm gap-1">
+          View <span aria-hidden>↗</span>
         </Link>
       </div>
     </DashboardCard>

--- a/components/dashboard/InventoryAlertsCard.tsx
+++ b/components/dashboard/InventoryAlertsCard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import DashboardCard from './DashboardCard';
 
 interface Props {
-  brand?: string;
+  brandId?: number;
   threshold?: number;
 }
 
@@ -12,14 +12,14 @@ interface Product {
   quantity: number;
 }
 
-const InventoryAlertsCard: React.FC<Props> = ({ brand, threshold = 10 }) => {
+const InventoryAlertsCard: React.FC<Props> = ({ brandId, threshold = 10 }) => {
   const [products, setProducts] = useState<Product[] | null>(null);
   const [error, setError] = useState<string>('');
   useEffect(() => {
     setProducts(null);
     setError('');
     const params = new URLSearchParams();
-    if (brand) params.set('brand', brand);
+    if (brandId) params.set('brandId', String(brandId));
     if (threshold) params.set('threshold', String(threshold));
     const url =
       '/api/dashboard/inventory-alerts' +
@@ -28,7 +28,7 @@ const InventoryAlertsCard: React.FC<Props> = ({ brand, threshold = 10 }) => {
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data) => setProducts(data.products))
       .catch(() => setError('Failed to load'));
-  }, [brand, threshold]);
+  }, [brandId, threshold]);
 
   return (
     <DashboardCard

--- a/components/dashboard/OrdersThisMonthCard.tsx
+++ b/components/dashboard/OrdersThisMonthCard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import DashboardCard from './DashboardCard';
 
 interface Props {
-  brand?: string;
+  brandId?: number;
 }
 
 interface Data {
@@ -10,7 +10,7 @@ interface Data {
   revenue: number;
 }
 
-const OrdersThisMonthCard: React.FC<Props> = ({ brand }) => {
+const OrdersThisMonthCard: React.FC<Props> = ({ brandId }) => {
   const [data, setData] = useState<Data | null>(null);
   const [error, setError] = useState<string>('');
 
@@ -19,12 +19,12 @@ const OrdersThisMonthCard: React.FC<Props> = ({ brand }) => {
     setError('');
     const url =
       '/api/dashboard/orders-this-month' +
-      (brand ? `?brand=${encodeURIComponent(brand)}` : '');
+      (brandId ? `?brandId=${brandId}` : '');
     fetch(url)
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then(setData)
       .catch(() => setError('Failed to load'));
-  }, [brand]);
+  }, [brandId]);
 
   return (
     <DashboardCard

--- a/components/dashboard/TotalProductsCard.tsx
+++ b/components/dashboard/TotalProductsCard.tsx
@@ -3,10 +3,10 @@ import { useRouter } from 'next/router';
 import DashboardCard from './DashboardCard';
 
 interface Props {
-  brand?: string;
+  brandId?: number;
 }
 
-const TotalProductsCard: React.FC<Props> = ({ brand }) => {
+const TotalProductsCard: React.FC<Props> = ({ brandId }) => {
   const [count, setCount] = useState<number | null>(null);
   const [error, setError] = useState<string>('');
   const router = useRouter();
@@ -17,7 +17,7 @@ const TotalProductsCard: React.FC<Props> = ({ brand }) => {
       setError('');
       const url =
         '/api/dashboard/total-products' +
-        (brand ? `?brand=${encodeURIComponent(brand)}` : '');
+        (brandId ? `?brandId=${brandId}` : '');
       try {
         const res = await fetch(url);
         if (!res.ok) throw new Error('Failed to load');
@@ -29,10 +29,10 @@ const TotalProductsCard: React.FC<Props> = ({ brand }) => {
       }
     }
     load();
-  }, [brand]);
+  }, [brandId]);
 
   const handleClick = () => {
-    router.push(brand ? '/brand/products' : '/products');
+    router.push(brandId ? '/brand/products' : '/products');
   };
 
   return (

--- a/components/dashboard/TotalSalesCard.tsx
+++ b/components/dashboard/TotalSalesCard.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react';
 import DashboardCard from './DashboardCard';
 
 interface Props {
-  brand?: string;
+  brandId?: number;
 }
 
-const TotalSalesCard: React.FC<Props> = ({ brand }) => {
+const TotalSalesCard: React.FC<Props> = ({ brandId }) => {
   const [total, setTotal] = useState<number | null>(null);
   const [error, setError] = useState<string>('');
   useEffect(() => {
@@ -13,12 +13,12 @@ const TotalSalesCard: React.FC<Props> = ({ brand }) => {
     setError('');
     const url =
       '/api/dashboard/total-sales' +
-      (brand ? `?brand=${encodeURIComponent(brand)}` : '');
+      (brandId ? `?brandId=${brandId}` : '');
     fetch(url)
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data) => setTotal(data.total))
       .catch(() => setError('Failed to load'));
-  }, [brand]);
+  }, [brandId]);
 
   return (
     <DashboardCard

--- a/pages/api/dashboard/best-sellers.ts
+++ b/pages/api/dashboard/best-sellers.ts
@@ -16,10 +16,14 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as { brandName?: string } | undefined;
-    const brand = user?.brandName || getQueryParam(req.query.brand);
+    const user = (req as any).user as {
+      id?: string | number;
+      brandName?: string;
+    } | undefined;
+    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const vendorId = Number(user?.id) || brandId || undefined;
     const where: any = {};
-    if (brand) where.product = { vendor: { brandName: brand } };
+    if (vendorId) where.product = { vendorId };
     const grouped = await db.order.groupBy({
       by: ['productId'],
       where,

--- a/pages/api/dashboard/inventory-alerts.ts
+++ b/pages/api/dashboard/inventory-alerts.ts
@@ -16,11 +16,15 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as { brandName?: string } | undefined;
-    const brand = user?.brandName || getQueryParam(req.query.brand);
+    const user = (req as any).user as {
+      id?: string | number;
+      brandName?: string;
+    } | undefined;
+    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const vendorId = Number(user?.id) || brandId || undefined;
     const threshold = parseInt(getQueryParam(req.query.threshold) || '10', 10);
     const where: any = { quantity: { lt: threshold } };
-    if (brand) where.vendor = { brandName: brand };
+    if (vendorId) where.vendorId = vendorId;
     const products = await db.product.findMany({
       where,
       select: { id: true, title: true, quantity: true },

--- a/pages/api/dashboard/orders-this-month.ts
+++ b/pages/api/dashboard/orders-this-month.ts
@@ -15,14 +15,18 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as { brandName?: string } | undefined;
-    const brand = user?.brandName || getQueryParam(req.query.brand);
+    const user = (req as any).user as {
+      id?: string | number;
+      brandName?: string;
+    } | undefined;
+    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const vendorId = Number(user?.id) || brandId || undefined;
     const start = dayjs().startOf('month').toDate();
     const where: any = {
       createdAt: { gte: start },
       status: 'completed',
     };
-    if (brand) where.product = { vendor: { brandName: brand } };
+    if (vendorId) where.product = { vendorId };
     const count = await db.order.count({ where });
     const result = await db.order.aggregate({ where, _sum: { total: true } });
     return res.status(200).json({ count, revenue: result._sum.total ?? 0 });

--- a/pages/api/dashboard/total-products.ts
+++ b/pages/api/dashboard/total-products.ts
@@ -14,9 +14,13 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as { brandName?: string } | undefined;
-    const brand = user?.brandName || getQueryParam(req.query.brand);
-    const where = brand ? { vendor: { brandName: brand } } : {};
+    const user = (req as any).user as {
+      id?: string | number;
+      brandName?: string;
+    } | undefined;
+    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const vendorId = Number(user?.id) || brandId || undefined;
+    const where = vendorId ? { vendorId } : {};
     const count = await db.product.count({ where });
     return res.status(200).json({ count });
   } catch (error) {

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -14,10 +14,14 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as { brandName?: string } | undefined;
-    const brand = user?.brandName || getQueryParam(req.query.brand);
+    const user = (req as any).user as {
+      id?: string | number;
+      brandName?: string;
+    } | undefined;
+    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const vendorId = Number(user?.id) || brandId || undefined;
     const where: any = { status: 'completed' };
-    if (brand) where.product = { vendor: { brandName: brand } };
+    if (vendorId) where.product = { vendorId };
     const result = await db.order.aggregate({ where, _sum: { total: true } });
     return res.status(200).json({ total: result._sum.total ?? 0 });
   } catch (error) {

--- a/pages/brand/analytics.tsx
+++ b/pages/brand/analytics.tsx
@@ -75,10 +75,10 @@ const BrandAnalytics: React.FC = () => {
       </Head>
       <h1 className="text-2xl font-bold text-center sm:text-left">Analytics</h1>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <TotalProductsCard brand={user.brandName || undefined} />
-        <TotalSalesCard brand={user.brandName || undefined} />
-        <OrdersThisMonthCard brand={user.brandName || undefined} />
-        <InventoryAlertsCard brand={user.brandName || undefined} />
+        <TotalProductsCard />
+        <TotalSalesCard />
+        <OrdersThisMonthCard />
+        <InventoryAlertsCard />
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <DashboardCard title="Sales Over Time">

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -29,13 +29,13 @@ const BrandDashboard: React.FC = () => {
         Brand Dashboard
       </h1>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <TotalProductsCard brand={user.brandName || undefined} />
-        <TotalSalesCard brand={user.brandName || undefined} />
-        <OrdersThisMonthCard brand={user.brandName || undefined} />
+        <TotalProductsCard />
+        <TotalSalesCard />
+        <OrdersThisMonthCard />
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <BestSellersCard brand={user.brandName || undefined} />
-        <InventoryAlertsCard brand={user.brandName || undefined} />
+        <BestSellersCard />
+        <InventoryAlertsCard />
         <ExistingProductsCard />
       </div>
     </div>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -17,8 +17,6 @@ const DashboardPage: React.FC = () => {
   if (role !== 'brand' && role !== 'super_admin') {
     return <div className="p-4">Access denied.</div>;
   }
-  const brand = user.brandName || undefined;
-
   return (
     <div className="space-y-4">
       <Head>
@@ -26,14 +24,14 @@ const DashboardPage: React.FC = () => {
       </Head>
       <h1 className="text-2xl font-bold">Dashboard Overview</h1>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <TotalProductsCard brand={brand} />
-        <TotalSalesCard brand={brand} />
-        <OrdersThisMonthCard brand={brand} />
+        <TotalProductsCard />
+        <TotalSalesCard />
+        <OrdersThisMonthCard />
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <BestSellersCard brand={brand} />
-        <InventoryAlertsCard brand={brand} />
-        {brand && <ExistingProductsCard />}
+        <BestSellersCard />
+        <InventoryAlertsCard />
+        {user.brandName && <ExistingProductsCard />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- scope dashboard stats by logged-in brand ID
- make dashboard cards clickable with better hover shadow
- show arrow button for viewing products and best sellers
- update dashboard pages to rely on session brand

## Testing
- `npm test`
- `npm run lint` *(fails: next not found due to blocked install)*

------
https://chatgpt.com/codex/tasks/task_e_685d89dca784832fbf98ea1f93907f1b