### PR TITLE
Enhance analytics visuals

### DIFF
--- a/components/dashboard/InventoryAlertsCard.tsx
+++ b/components/dashboard/InventoryAlertsCard.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import DashboardCard from './DashboardCard';
+import BellIcon from '../icons/BellIcon';
+import CheckCircleIcon from '../icons/CheckCircleIcon';
 
 interface Props {
   brand?: string;
@@ -35,9 +37,16 @@ const InventoryAlertsCard: React.FC<Props> = ({ brand, threshold = 10 }) => {
       title="Inventory Alerts"
       loading={!products && !error}
       error={error}
+      className="bg-rose-50"
     >
       {products && products.length > 0 ? (
         <div className="max-h-40 overflow-y-auto">
+          <div className="flex items-center gap-2 mb-2">
+            <BellIcon className="w-5 h-5 text-rose-600" />
+            <span className="badge badge-error badge-sm">
+              {products.length}
+            </span>
+          </div>
           <ul className="list-disc pl-4 space-y-1">
             {products.map((p) => (
               <li key={p.id}>
@@ -47,7 +56,12 @@ const InventoryAlertsCard: React.FC<Props> = ({ brand, threshold = 10 }) => {
           </ul>
         </div>
       ) : (
-        !error && <p>All good!</p>
+        !error && (
+          <div className="flex items-center gap-2">
+            <CheckCircleIcon className="w-5 h-5 text-green-600" />
+            <span className="badge badge-success badge-sm">OK</span>
+          </div>
+        )
       )}
     </DashboardCard>
   );

--- a/components/dashboard/OrdersThisMonthCard.tsx
+++ b/components/dashboard/OrdersThisMonthCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import DashboardCard from './DashboardCard';
+import ArrowTrendingUpIcon from '../icons/ArrowTrendingUpIcon';
 
 interface Props {
   brand?: string;
@@ -31,11 +32,15 @@ const OrdersThisMonthCard: React.FC<Props> = ({ brand }) => {
       title="Orders This Month"
       loading={!data && !error}
       error={error}
+      className="bg-yellow-50"
     >
       {data && (
-        <div>
-          <p className="text-3xl font-bold">{data.count}</p>
-          <p className="text-sm">£{data.revenue.toFixed(2)}</p>
+        <div className="flex items-center gap-2">
+          <ArrowTrendingUpIcon className="w-5 h-5 text-yellow-600" />
+          <div>
+            <p className="text-3xl font-bold">{data.count}</p>
+            <p className="text-sm">£{data.revenue.toFixed(2)}</p>
+          </div>
         </div>
       )}
     </DashboardCard>

--- a/components/dashboard/TotalProductsCard.tsx
+++ b/components/dashboard/TotalProductsCard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import DashboardCard from './DashboardCard';
+import CartIcon from '../icons/CartIcon';
 
 interface Props {
   brand?: string;
@@ -41,8 +42,14 @@ const TotalProductsCard: React.FC<Props> = ({ brand }) => {
       loading={count === null && !error}
       error={error}
       onClick={handleClick}
+      className="bg-indigo-50"
     >
-      {count !== null && <p className="text-3xl font-bold">{count}</p>}
+      {count !== null && (
+        <div className="flex items-center gap-2">
+          <CartIcon className="w-5 h-5 text-indigo-600" />
+          <p className="text-3xl font-bold">{count}</p>
+        </div>
+      )}
     </DashboardCard>
   );
 };

--- a/components/dashboard/TotalSalesCard.tsx
+++ b/components/dashboard/TotalSalesCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import DashboardCard from './DashboardCard';
+import ArrowTrendingUpIcon from '../icons/ArrowTrendingUpIcon';
 
 interface Props {
   brand?: string;
@@ -25,9 +26,13 @@ const TotalSalesCard: React.FC<Props> = ({ brand }) => {
       title="Total Sales"
       loading={total === null && !error}
       error={error}
+      className="bg-green-50"
     >
       {total !== null && (
-        <p className="text-3xl font-bold">£{total.toFixed(2)}</p>
+        <div className="flex items-center gap-2">
+          <ArrowTrendingUpIcon className="w-5 h-5 text-green-600" />
+          <p className="text-3xl font-bold">£{total.toFixed(2)}</p>
+        </div>
       )}
     </DashboardCard>
   );

--- a/components/icons/ArrowTrendingUpIcon.tsx
+++ b/components/icons/ArrowTrendingUpIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const ArrowTrendingUpIcon: React.FC<IconProps> = ({
+  size = 24,
+  color = 'currentColor',
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941"
+    />
+  </svg>
+);
+
+export default ArrowTrendingUpIcon;

--- a/components/icons/CheckCircleIcon.tsx
+++ b/components/icons/CheckCircleIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const CheckCircleIcon: React.FC<IconProps> = ({
+  size = 24,
+  color = 'currentColor',
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+    />
+  </svg>
+);
+
+export default CheckCircleIcon;

--- a/components/icons/XCircleIcon.tsx
+++ b/components/icons/XCircleIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const XCircleIcon: React.FC<IconProps> = ({
+  size = 24,
+  color = 'currentColor',
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+    />
+  </svg>
+);
+
+export default XCircleIcon;

--- a/pages/brand/analytics.tsx
+++ b/pages/brand/analytics.tsx
@@ -20,6 +20,7 @@ import {
   CartesianGrid,
   BarChart as ReBarChart,
   Bar,
+  Cell,
 } from 'recharts';
 
 const useDummyData = process.env.NEXT_PUBLIC_USE_DUMMY_DATA === 'true';
@@ -44,6 +45,8 @@ const dummyInventoryStatus = [
   { name: 'Low Stock', value: 40 },
   { name: 'Out of Stock', value: 10 },
 ];
+
+const BAR_COLORS = ['#ef4444', '#f59e0b', '#10b981', '#3b82f6'];
 
 type TopProduct = {
   id: string;
@@ -112,11 +115,23 @@ const BrandAnalytics: React.FC = () => {
           <ChartContainer dataLength={salesData.length} height="16rem">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={salesData}>
+                <defs>
+                  <linearGradient id="salesGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#4F46E5" />
+                    <stop offset="100%" stopColor="#6366F1" />
+                  </linearGradient>
+                </defs>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="name" />
                 <YAxis />
                 <Tooltip />
-                <Line type="monotone" dataKey="value" stroke="#8884d8" />
+                <Line
+                  type="monotone"
+                  dataKey="value"
+                  stroke="url(#salesGradient)"
+                  strokeWidth={3}
+                  dot
+                />
               </LineChart>
             </ResponsiveContainer>
           </ChartContainer>
@@ -129,7 +144,11 @@ const BrandAnalytics: React.FC = () => {
                 <XAxis dataKey="name" />
                 <YAxis />
                 <Tooltip />
-                <Bar dataKey="value" fill="#8884d8" />
+                <Bar dataKey="value">
+                  {ordersData.map((_, i) => (
+                    <Cell key={i} fill={BAR_COLORS[i % BAR_COLORS.length]} />
+                  ))}
+                </Bar>
               </ReBarChart>
             </ResponsiveContainer>
           </ChartContainer>
@@ -142,7 +161,11 @@ const BrandAnalytics: React.FC = () => {
                 <XAxis dataKey="name" />
                 <YAxis />
                 <Tooltip />
-                <Bar dataKey="value" fill="#8884d8" />
+                <Bar dataKey="value">
+                  {inventoryData.map((_, i) => (
+                    <Cell key={i} fill={BAR_COLORS[i % BAR_COLORS.length]} />
+                  ))}
+                </Bar>
               </ReBarChart>
             </ResponsiveContainer>
           </ChartContainer>


### PR DESCRIPTION
## Summary
- add trendy icon components
- colorize dashboard cards with icons
- upgrade analytics charts with gradient line and colored bars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d8b016a48832f94a5617679297998