### PR TITLE
Improve brand dashboard design

### DIFF
--- a/components/dashboard/BestSellersCard.tsx
+++ b/components/dashboard/BestSellersCard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import DashboardCard from './DashboardCard';
+import CartIcon from '../icons/CartIcon';
 
 interface Props {
   brandId?: number;
@@ -37,6 +38,7 @@ const BestSellersCard: React.FC<Props> = ({ brandId }) => {
       title="Best-Selling Products"
       loading={!products && !error}
       error={error}
+      icon={<CartIcon className="w-5 h-5" />}
       onClick={handleClick}
     >
       {products && products.length > 0 ? (

--- a/components/dashboard/DashboardCard.tsx
+++ b/components/dashboard/DashboardCard.tsx
@@ -7,6 +7,8 @@ interface Props {
   children?: React.ReactNode;
   className?: string;
   onClick?: () => void;
+  icon?: React.ReactNode;
+  trend?: string;
 }
 
 const DashboardCard: React.FC<Props> = ({
@@ -16,13 +18,23 @@ const DashboardCard: React.FC<Props> = ({
   children,
   className = '',
   onClick,
+  icon,
+  trend,
 }) => {
   return (
     <div
       className={`border rounded-lg shadow p-4 bg-base-100 transition-shadow duration-200 hover:shadow-lg ${onClick ? 'cursor-pointer hover:bg-base-200' : ''} ${className}`}
       onClick={onClick}
     >
-      <h3 className="font-semibold mb-2">{title}</h3>
+      <h3 className="font-semibold mb-2 flex items-center justify-between">
+        <span className="flex items-center gap-2">
+          {icon}
+          {title}
+        </span>
+        {trend && (
+          <span className="text-xs font-normal text-gray-500">{trend}</span>
+        )}
+      </h3>
       {loading ? (
         <div className="space-y-2 animate-pulse">
           <div className="h-4 bg-base-300 rounded w-3/4" />

--- a/components/dashboard/ExistingProductsCard.tsx
+++ b/components/dashboard/ExistingProductsCard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import DashboardCard from './DashboardCard';
+import BoxIcon from '../icons/BoxIcon';
 import type { Product } from '../../types/product';
 
 interface Props {
@@ -37,6 +38,7 @@ const ExistingProductsCard: React.FC<Props> = ({ previewCount = 3 }) => {
       loading={!products && !error}
       error={error}
       className="space-y-2"
+      icon={<BoxIcon className="w-5 h-5" />}
       onClick={() => router.push('/brand/products')}
     >
       {products && (

--- a/components/dashboard/InventoryAlertsCard.tsx
+++ b/components/dashboard/InventoryAlertsCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import DashboardCard from './DashboardCard';
+import WarningIcon from '../icons/WarningIcon';
 
 interface Props {
   brandId?: number;
@@ -35,6 +36,7 @@ const InventoryAlertsCard: React.FC<Props> = ({ brandId, threshold = 10 }) => {
       title="Inventory Alerts"
       loading={!products && !error}
       error={error}
+      icon={<WarningIcon className="w-5 h-5" />}
     >
       {products && products.length > 0 ? (
         <div className="max-h-40 overflow-y-auto">

--- a/components/dashboard/OrdersThisMonthCard.tsx
+++ b/components/dashboard/OrdersThisMonthCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import DashboardCard from './DashboardCard';
+import CartIcon from '../icons/CartIcon';
 
 interface Props {
   brandId?: number;
@@ -12,18 +13,35 @@ interface Data {
 
 const OrdersThisMonthCard: React.FC<Props> = ({ brandId }) => {
   const [data, setData] = useState<Data | null>(null);
+  const [trend, setTrend] = useState<number | null>(null);
   const [error, setError] = useState<string>('');
 
   useEffect(() => {
     setData(null);
     setError('');
-    const url =
-      '/api/dashboard/orders-this-month' +
-      (brandId ? `?brandId=${brandId}` : '');
-    fetch(url)
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then(setData)
-      .catch(() => setError('Failed to load'));
+    async function load() {
+      const params = new URLSearchParams();
+      if (brandId) params.set('brandId', String(brandId));
+      const base = '/api/dashboard/orders-this-month';
+      try {
+        const curRes = await fetch(`${base}?${params.toString()}`);
+        if (!curRes.ok) throw new Error('err');
+        const cur = await curRes.json();
+        setData(cur);
+        params.set('monthOffset', '1');
+        const prevRes = await fetch(`${base}?${params.toString()}`);
+        if (prevRes.ok) {
+          const prev = await prevRes.json();
+          const pct = prev.count
+            ? ((cur.count - prev.count) / prev.count) * 100
+            : 100;
+          setTrend(pct);
+        }
+      } catch {
+        setError('Failed to load');
+      }
+    }
+    load();
   }, [brandId]);
 
   return (
@@ -31,6 +49,8 @@ const OrdersThisMonthCard: React.FC<Props> = ({ brandId }) => {
       title="Orders This Month"
       loading={!data && !error}
       error={error}
+      icon={<CartIcon className="w-5 h-5" />}
+      trend={trend !== null ? `${trend > 0 ? '+' : ''}${trend.toFixed(1)}%` : undefined}
     >
       {data && (
         <div>

--- a/components/dashboard/TotalProductsCard.tsx
+++ b/components/dashboard/TotalProductsCard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import DashboardCard from './DashboardCard';
+import BoxIcon from '../icons/BoxIcon';
 
 interface Props {
   brandId?: number;
@@ -40,6 +41,7 @@ const TotalProductsCard: React.FC<Props> = ({ brandId }) => {
       title="Total Products"
       loading={count === null && !error}
       error={error}
+      icon={<BoxIcon className="w-5 h-5" />}
       onClick={handleClick}
     >
       {count !== null && <p className="text-3xl font-bold">{count}</p>}

--- a/components/dashboard/TotalSalesCard.tsx
+++ b/components/dashboard/TotalSalesCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import DashboardCard from './DashboardCard';
+import MoneyIcon from '../icons/MoneyIcon';
 
 interface Props {
   brandId?: number;
@@ -7,17 +8,34 @@ interface Props {
 
 const TotalSalesCard: React.FC<Props> = ({ brandId }) => {
   const [total, setTotal] = useState<number | null>(null);
+  const [trend, setTrend] = useState<number | null>(null);
   const [error, setError] = useState<string>('');
   useEffect(() => {
     setTotal(null);
     setError('');
-    const url =
-      '/api/dashboard/total-sales' +
-      (brandId ? `?brandId=${brandId}` : '');
-    fetch(url)
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data) => setTotal(data.total))
-      .catch(() => setError('Failed to load'));
+    async function load() {
+      const params = new URLSearchParams();
+      if (brandId) params.set('brandId', String(brandId));
+      const base = '/api/dashboard/total-sales';
+      try {
+        const curRes = await fetch(`${base}?${params.toString()}`);
+        if (!curRes.ok) throw new Error('err');
+        const cur = await curRes.json();
+        setTotal(cur.total);
+        params.set('monthOffset', '1');
+        const prevRes = await fetch(`${base}?${params.toString()}`);
+        if (prevRes.ok) {
+          const prev = await prevRes.json();
+          const pct = prev.total
+            ? ((cur.total - prev.total) / prev.total) * 100
+            : 100;
+          setTrend(pct);
+        }
+      } catch {
+        setError('Failed to load');
+      }
+    }
+    load();
   }, [brandId]);
 
   return (
@@ -25,6 +43,8 @@ const TotalSalesCard: React.FC<Props> = ({ brandId }) => {
       title="Total Sales"
       loading={total === null && !error}
       error={error}
+      icon={<MoneyIcon className="w-5 h-5" />}
+      trend={trend !== null ? `${trend > 0 ? '+' : ''}${trend.toFixed(1)}%` : undefined}
     >
       {total !== null && (
         <p className="text-3xl font-bold">£{total.toFixed(2)}</p>

--- a/components/dashboard/WeeklySummaryCard.tsx
+++ b/components/dashboard/WeeklySummaryCard.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import DashboardCard from './DashboardCard';
+import CartIcon from '../icons/CartIcon';
+
+interface Props {
+  brandId?: number;
+}
+
+interface Data {
+  count: number;
+  revenue: number;
+}
+
+const WeeklySummaryCard: React.FC<Props> = ({ brandId }) => {
+  const [data, setData] = useState<Data | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      setData(null);
+      setError('');
+      const params = new URLSearchParams();
+      if (brandId) params.set('brandId', String(brandId));
+      const res = await fetch(`/api/dashboard/weekly-summary?${params.toString()}`);
+      if (!res.ok) {
+        setError('Failed to load');
+        return;
+      }
+      const json = await res.json();
+      setData(json);
+    }
+    load();
+  }, [brandId]);
+
+  return (
+    <DashboardCard
+      title="Weekly Summary"
+      loading={!data && !error}
+      error={error}
+      icon={<CartIcon className="w-5 h-5" />}
+    >
+      {data && (
+        <div>
+          <p className="text-3xl font-bold">{data.count} orders</p>
+          <p className="text-sm">£{data.revenue.toFixed(2)}</p>
+        </div>
+      )}
+    </DashboardCard>
+  );
+};
+
+export default WeeklySummaryCard;

--- a/components/icons/BoxIcon.tsx
+++ b/components/icons/BoxIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const BoxIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      d="M21 7.5L12 2.25L3 7.5M21 7.5L12 12.75M21 7.5V16.5L12 21.75M3 7.5L12 12.75M3 7.5V16.5L12 21.75M12 12.75V21.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default BoxIcon;

--- a/components/icons/MoneyIcon.tsx
+++ b/components/icons/MoneyIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const MoneyIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      d="M12 6V18M9 15.1818L9.8789 15.841C11.0504 16.7197 12.9498 16.7197 14.1213 15.841C15.2929 14.9623 15.2929 13.5377 14.1213 12.659C13.5354 12.2196 12.7677 12 11.9999 12C11.275 12 10.5502 11.7804 9.9971 11.341C8.89097 10.4623 8.89097 9.03772 9.9971 8.15904C11.1032 7.28036 12.8965 7.28036 14.0026 8.15904L14.4175 8.48863"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <circle cx="12" cy="12" r="9" />
+  </svg>
+);
+
+export default MoneyIcon;

--- a/components/icons/WarningIcon.tsx
+++ b/components/icons/WarningIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const WarningIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      d="M11.9998 9.00006V12.7501M2.69653 16.1257C1.83114 17.6257 2.91371 19.5001 4.64544 19.5001H19.3541C21.0858 19.5001 22.1684 17.6257 21.303 16.1257L13.9487 3.37819C13.0828 1.87736 10.9167 1.87736 10.0509 3.37819L2.69653 16.1257ZM11.9998 15.7501H12.0073V15.7576H11.9998V15.7501Z"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default WarningIcon;

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -20,7 +20,17 @@ async function handler(
     } | undefined;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const vendorId = Number(user?.id) || brandId || undefined;
+    const monthOffset = getQueryParam(req.query.monthOffset);
     const where: any = { status: 'completed' };
+    if (monthOffset !== null && monthOffset !== undefined && monthOffset !== '') {
+      const m = parseInt(monthOffset, 10);
+      const start = require('dayjs')()
+        .startOf('month')
+        .subtract(m, 'month')
+        .toDate();
+      const end = require('dayjs')(start).endOf('month').toDate();
+      where.createdAt = { gte: start, lte: end };
+    }
     if (vendorId) where.product = { vendorId };
     const result = await db.order.aggregate({ where, _sum: { total: true } });
     return res.status(200).json({ total: result._sum.total ?? 0 });

--- a/pages/api/dashboard/weekly-summary.ts
+++ b/pages/api/dashboard/weekly-summary.ts
@@ -21,22 +21,14 @@ async function handler(
     } | undefined;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const vendorId = Number(user?.id) || brandId || undefined;
-    const monthOffset = parseInt(getQueryParam(req.query.monthOffset) || '0', 10);
-    const start = dayjs()
-      .startOf('month')
-      .subtract(monthOffset, 'month')
-      .toDate();
-    const end = dayjs(start).endOf('month').toDate();
-    const where: any = {
-      createdAt: { gte: start, lte: end },
-      status: 'completed',
-    };
+    const start = dayjs().subtract(7, 'day').startOf('day').toDate();
+    const where: any = { createdAt: { gte: start }, status: 'completed' };
     if (vendorId) where.product = { vendorId };
     const count = await db.order.count({ where });
     const result = await db.order.aggregate({ where, _sum: { total: true } });
     return res.status(200).json({ count, revenue: result._sum.total ?? 0 });
   } catch (error) {
-    return handleApiError(res, error, 'Failed to load orders');
+    return handleApiError(res, error, 'Failed to load weekly summary');
   }
 }
 

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import type { User } from '../../types/user';
 import ExistingProductsCard from '../../components/dashboard/ExistingProductsCard';
@@ -7,11 +7,31 @@ import TotalSalesCard from '../../components/dashboard/TotalSalesCard';
 import OrdersThisMonthCard from '../../components/dashboard/OrdersThisMonthCard';
 import BestSellersCard from '../../components/dashboard/BestSellersCard';
 import InventoryAlertsCard from '../../components/dashboard/InventoryAlertsCard';
+import WeeklySummaryCard from '../../components/dashboard/WeeklySummaryCard';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
+import Link from 'next/link';
 
 const BrandDashboard: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };
+  const [summary, setSummary] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      const [prodRes, alertRes] = await Promise.all([
+        fetch('/api/dashboard/total-products'),
+        fetch('/api/dashboard/inventory-alerts'),
+      ]);
+      if (prodRes.ok && alertRes.ok) {
+        const prod = await prodRes.json();
+        const alert = await alertRes.json();
+        setSummary(
+          `${prod.count} active products, ${alert.products.length} low inventory`
+        );
+      }
+    }
+    load();
+  }, []);
 
   if (!user) {
     return <div className="p-4">Please log in to manage products.</div>;
@@ -25,18 +45,34 @@ const BrandDashboard: React.FC = () => {
       <Head>
         <title>{getPageTitle('Brand Dashboard')}</title>
       </Head>
-      <h1 className="text-2xl font-bold text-center sm:text-left">
-        Brand Dashboard
-      </h1>
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-4">
+          {user.logo && (
+            <img src={user.logo} alt="logo" className="w-12 h-12 rounded-full object-cover" />
+          )}
+          <div>
+            <h1 className="text-2xl font-bold">Welcome, {user.brandName || user.firstName}!</h1>
+            {summary && <p className="text-sm text-gray-600">{summary}</p>}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link href="/brand/products/new" className="btn btn-primary btn-sm">
+            + Add Product
+          </Link>
+          <Link href="/brand/orders" className="btn btn-sm">🧾 View Orders</Link>
+          <Link href="/brand/analytics" className="btn btn-sm">📈 Open Analytics</Link>
+        </div>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <TotalProductsCard />
         <TotalSalesCard />
         <OrdersThisMonthCard />
+        <InventoryAlertsCard />
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <BestSellersCard />
-        <InventoryAlertsCard />
         <ExistingProductsCard />
+        <WeeklySummaryCard />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- polish DashboardCard with icon and trend props
- add icons for products, sales and alerts
- add weekly summary card and metrics
- redesign Brand Dashboard layout with quick actions
- provide API for weekly summaries and month-over-month comparisons

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Property 'read' does not exist on type 'Notification', etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d8c5be774832f9cd151048d25109c