### PR TITLE
Fix brand products session role check

### DIFF
--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -47,7 +47,7 @@ async function handler(
   try {
     if (req.method === 'GET') {
       const session = await getServerSession(req, res, authOptions);
-      if (!session?.user || session.user.role !== 'brand') {
+      if (!session?.user || session.user.role !== 'BRAND') {
         return res.status(401).json({ message: 'Unauthorized' });
       }
 


### PR DESCRIPTION
## Summary
- fix session role check in brand products API to use 'BRAND'

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check` *(fails: Module '@prisma/client' has no exported member)*

------
https://chatgpt.com/codex/tasks/task_e_685d901d0304832f841a440400c067b2