### PR TITLE
Add product discount support

### DIFF
--- a/components/Product/ProductCard.tsx
+++ b/components/Product/ProductCard.tsx
@@ -29,7 +29,16 @@ const ProductCard: React.FC<ProductCardProps> = ({
       ? product.totalInventory
       : (product as any).quantity;
   const isOut = typeof inventory === 'number' && inventory <= 0;
-  const onSale = product.maxPrice > product.minPrice;
+  const finalPrice =
+    product.discountType === 'percentage'
+      ? product.minPrice -
+        ((product.minPrice * (product.discountValue || 0)) / 100)
+      : product.discountType === 'fixed'
+        ? product.minPrice - (product.discountValue || 0)
+        : product.minPrice;
+  const onSale =
+    (product.discountType !== null && product.discountType !== undefined) ||
+    product.maxPrice > product.minPrice;
   const isNew = product.tags?.toLowerCase().includes('new');
   const rating = Math.round(product.averageRating || 0);
 
@@ -55,7 +64,15 @@ const ProductCard: React.FC<ProductCardProps> = ({
       {(isNew || onSale || isOut) && (
         <div className="absolute top-2 left-2 flex flex-col gap-1">
           {isNew && <span className="badge badge-primary">New</span>}
-          {onSale && <span className="badge badge-secondary">Sale</span>}
+          {onSale && (
+            <span className="badge badge-secondary">
+              {product.discountType === 'percentage'
+                ? `${product.discountValue}% OFF`
+                : product.discountType === 'fixed'
+                ? `${formatCurrency(product.discountValue || 0, product.currency)} OFF`
+                : 'Sale'}
+            </span>
+          )}
           {isOut && <span className="badge">Out of stock</span>}
         </div>
       )}
@@ -87,8 +104,13 @@ const ProductCard: React.FC<ProductCardProps> = ({
           className={`flex justify-between items-center mt-auto ${compact ? 'text-xs' : 'text-sm'}`}
         >
           <span className={`font-bold ${compact ? 'text-sm' : 'text-base'}`}>
-            {formatCurrency(product.minPrice ?? 0, product.currency)}
+            {formatCurrency(finalPrice ?? 0, product.currency)}
           </span>
+          {onSale && (
+            <span className="ml-1 line-through text-sm text-gray-500">
+              {formatCurrency(product.minPrice ?? 0, product.currency)}
+            </span>
+          )}
           {product.reviewCount > 0 && (
             <span className="text-xs">
               {'★'.repeat(rating)}

--- a/components/Product/ProductForm.tsx
+++ b/components/Product/ProductForm.tsx
@@ -25,6 +25,8 @@ export interface ProductFormValues {
   minPrice: number;
   maxPrice: number;
   currency: string;
+  discountType: 'percentage' | 'fixed' | 'none';
+  discountValue?: number;
   available: boolean;
 }
 
@@ -87,6 +89,11 @@ const ProductForm: React.FC<ProductFormProps> = ({
       minPrice: initial?.minPrice ?? 0,
       maxPrice: initial?.maxPrice ?? 0,
       currency: initial?.currency || 'USD',
+      discountType: (initial?.discountType as any) || 'none',
+      discountValue:
+        typeof initial?.discountValue === 'number'
+          ? initial.discountValue
+          : undefined,
       available: initial?.available ?? true,
     },
   });
@@ -173,6 +180,11 @@ const ProductForm: React.FC<ProductFormProps> = ({
       fd.append('min_price', String(values.minPrice));
       fd.append('max_price', String(values.maxPrice));
       fd.append('currency', values.currency);
+      if (values.discountType !== 'none') {
+        fd.append('discount_type', values.discountType);
+        if (values.discountValue !== undefined)
+          fd.append('discount_value', String(values.discountValue));
+      }
       images.forEach((img) => fd.append('photos', img));
       await onSubmit(fd);
     },
@@ -332,19 +344,50 @@ const ProductForm: React.FC<ProductFormProps> = ({
           }}
           error={errors.minPrice?.message}
         />
-        <TextInput<ProductFormValues>
-          label="Max Price"
-          name="maxPrice"
-          type="number"
-          min={0}
-          step="0.01"
-          register={register}
-          rules={{
-            required: 'Required',
-            min: { value: 0, message: 'Must be >= 0' },
-          }}
-          error={errors.maxPrice?.message}
-        />
+      <TextInput<ProductFormValues>
+        label="Max Price"
+        name="maxPrice"
+        type="number"
+        min={0}
+        step="0.01"
+        register={register}
+        rules={{
+          required: 'Required',
+          min: { value: 0, message: 'Must be >= 0' },
+        }}
+        error={errors.maxPrice?.message}
+      />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="discountType">Discount Type</label>
+          <select
+            id="discountType"
+            className="select select-bordered w-full"
+            {...register('discountType')}
+          >
+            <option value="none">None</option>
+            <option value="percentage">Percentage</option>
+            <option value="fixed">Fixed</option>
+          </select>
+        </div>
+        {watch('discountType') !== 'none' && (
+          <TextInput<ProductFormValues>
+            label="Discount Value"
+            name="discountValue"
+            type="number"
+            step="0.01"
+            register={register}
+            rules={{
+              required: 'Required',
+              validate: (v) =>
+                watch('discountType') === 'percentage'
+                  ? v > 0 && v < 100 || '1-99'
+                  : v < watch('minPrice') || 'Must be < price',
+            }}
+            error={errors.discountValue?.message}
+          />
+        )}
       </div>
       <TextInput<ProductFormValues>
         label="Currency"

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -29,6 +29,8 @@ interface ProductRow {
   minPrice: number;
   maxPrice: number;
   currency: string;
+  discountType?: string | null;
+  discountValue?: number | null;
 }
 
 /**
@@ -119,7 +121,16 @@ async function loadProductsData(): Promise<Product[]> {
 }
 
 export function mapDbRowToProduct(row: ProductRow): Product {
-  const { images, quantity, minPrice, maxPrice, currency, ...rest } = row;
+  const {
+    images,
+    quantity,
+    minPrice,
+    maxPrice,
+    currency,
+    discountType,
+    discountValue,
+    ...rest
+  } = row;
 
   return processProductRow({
     ...rest,
@@ -131,6 +142,8 @@ export function mapDbRowToProduct(row: ProductRow): Product {
       minVariantPrice: { amount: minPrice, currencyCode: currency },
       maxVariantPrice: { amount: maxPrice, currencyCode: currency },
     },
+    discountType,
+    discountValue,
   });
 }
 
@@ -218,6 +231,8 @@ export async function addProduct(product: ProductInput): Promise<void> {
     minPrice: product.minPrice ?? 0,
     maxPrice: product.maxPrice ?? 0,
     currency: product.currency ?? 'USD',
+    discountType: product.discountType ?? null,
+    discountValue: product.discountValue ?? null,
     status: product.status ?? 'approved',
     vendor: { connect: { id: vendor.id } },
     category: { connect: { id: category.id } },
@@ -288,6 +303,8 @@ export async function updateProduct(
       minPrice: product.minPrice,
       maxPrice: product.maxPrice,
       currency: product.currency,
+      discountType: product.discountType,
+      discountValue: product.discountValue,
       vendor: { connect: { id: vendor.id } },
       category: { connect: { id: category.id } },
     } as Prisma.ProductUpdateInput,

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -62,7 +62,40 @@ export default async function handler(
         min_price,
         max_price,
         currency,
+        discount_type,
+        discount_value,
       } = fields as Record<string, unknown>;
+
+      const parsedDiscountType =
+        discount_type && String(discount_type) !== 'none'
+          ? (String(discount_type) as 'percentage' | 'fixed')
+          : null;
+      const parsedDiscountValue =
+        discount_value && String(discount_value) !== ''
+          ? parseFloat(String(discount_value))
+          : null;
+      if (parsedDiscountType === 'percentage') {
+        if (
+          parsedDiscountValue === null ||
+          parsedDiscountValue < 1 ||
+          parsedDiscountValue > 99
+        ) {
+          return res
+            .status(400)
+            .json({ message: 'Percentage discount must be between 1 and 99' });
+        }
+      }
+      if (parsedDiscountType === 'fixed') {
+        const basePrice =
+          typeof min_price !== 'undefined'
+            ? parseFloat(String(min_price))
+            : existing.min_price;
+        if (parsedDiscountValue === null || parsedDiscountValue >= basePrice) {
+          return res.status(400).json({
+            message: 'Fixed discount must be less than product price',
+          });
+        }
+      }
       const photos: File[] = files.photos
         ? Array.isArray(files.photos)
           ? (files.photos as File[])
@@ -104,6 +137,11 @@ export default async function handler(
             ? parseFloat(String(max_price))
             : existing.max_price,
         currency: String(currency ?? existing.currency),
+        discountType: parsedDiscountType ?? (existing as any).discount_type ?? null,
+        discountValue:
+          parsedDiscountValue !== null
+            ? parsedDiscountValue
+            : (existing as any).discount_value ?? null,
         status: existing.status,
         images: imagePaths.length > 0
           ? imagePaths.map((p) => ({ url: p }))

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -81,6 +81,8 @@ async function handler(
         min_price,
         max_price,
         currency,
+        discount_type,
+        discount_value,
       } = fields as Record<string, unknown>;
       if (!id || !sku || !title || !vendor) {
         return res
@@ -92,6 +94,34 @@ async function handler(
           ? (files.photos as File[])
           : [files.photos as File]
         : [];
+      const parsedDiscountType =
+        discount_type && String(discount_type) !== 'none'
+          ? (String(discount_type) as 'percentage' | 'fixed')
+          : null;
+      const parsedDiscountValue =
+        discount_value && String(discount_value) !== ''
+          ? parseFloat(String(discount_value))
+          : null;
+      if (parsedDiscountType === 'percentage') {
+        if (
+          parsedDiscountValue === null ||
+          parsedDiscountValue < 1 ||
+          parsedDiscountValue > 99
+        ) {
+          return res
+            .status(400)
+            .json({ message: 'Percentage discount must be between 1 and 99' });
+        }
+      }
+      if (parsedDiscountType === 'fixed') {
+        const basePrice = parseFloat(String(min_price || '0'));
+        if (parsedDiscountValue === null || parsedDiscountValue >= basePrice) {
+          return res.status(400).json({
+            message: 'Fixed discount must be less than product price',
+          });
+        }
+      }
+
       const destDir = path.join(process.cwd(), 'public', 'uploads', String(id));
       fs.mkdirSync(destDir, { recursive: true });
       const imagePaths: string[] = [];
@@ -115,6 +145,8 @@ async function handler(
         minPrice: parseFloat(String(min_price || '0')),
         maxPrice: parseFloat(String(max_price || '0')),
         currency: String(currency || 'USD'),
+        discountType: parsedDiscountType,
+        discountValue: parsedDiscountValue,
         status: 'approved',
         images: imagePaths.map((p) => ({ url: p })),
       };

--- a/prisma/migrations/20250626183000_add-discount-fields/migration.sql
+++ b/prisma/migrations/20250626183000_add-discount-fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Product" ADD COLUMN "discountType" TEXT;
+ALTER TABLE "Product" ADD COLUMN "discountValue" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,8 @@ model Product {
   minPrice    Float    @default(0)
   maxPrice    Float    @default(0)
   currency    String   @default("USD")
+  discountType String?
+  discountValue Float?
   status      String   @default("approved")
   images      String?
   vendorId    Int

--- a/types/product.ts
+++ b/types/product.ts
@@ -19,6 +19,8 @@ type ProductBase = Pick<
   | 'minPrice'
   | 'maxPrice'
   | 'currency'
+  | 'discountType'
+  | 'discountValue'
   | 'status'
   | 'createdAt'
   | 'updatedAt'
@@ -53,6 +55,8 @@ export type ProductInput = Pick<
   | 'minPrice'
   | 'maxPrice'
   | 'currency'
+  | 'discountType'
+  | 'discountValue'
   | 'status'
 > &
   Partial<Pick<PrismaProduct, 'slug' | 'uuid'>> & {


### PR DESCRIPTION
## Summary
- allow products to have percentage or fixed discounts in Prisma
- expose discount fields in add/update product endpoints
- validate discount values on the server
- support discount values in admin product form
- display discounts on product cards
- create prisma migration for new columns

## Testing
- `npm test`
- `npm run type-check` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685d8ee596c8832fbdf35e74571af730