### PR TITLE
Restrict brand products API & add pagination

### DIFF
--- a/components/dashboard/ExistingProductsCard.tsx
+++ b/components/dashboard/ExistingProductsCard.tsx
@@ -19,7 +19,9 @@ const ExistingProductsCard: React.FC<Props> = ({ previewCount = 3 }) => {
     setError('');
     fetch('/api/brand/products')
       .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data: Product[]) => setProducts(data))
+      .then((data: { products: Product[]; total: number }) =>
+        setProducts(data.products)
+      )
       .catch(() => setError('Failed to load'));
   }, []);
 

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -42,7 +42,7 @@ async function parseBody(
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Product[] | ApiMessage>
+  res: NextApiResponse<{ products: Product[]; total: number } | ApiMessage>
 ): Promise<void> {
   try {
     if (req.method === 'GET') {
@@ -52,18 +52,24 @@ async function handler(
       }
 
       const db = getDb();
-      const rows = await db.product.findMany({
-        where: { vendor: { brandName: session.user.brandName } },
-        include: { category: true, vendor: true },
-        orderBy: { id: 'asc' },
-      });
+      const page = parseInt(String((req.query.page as string) || '1'), 10);
+      const limit = parseInt(String((req.query.limit as string) || '20'), 10);
+      const skip = (page - 1) * limit;
+
+      const [rows, total] = await Promise.all([
+        db.product.findMany({
+          where: { brandId: (session.user as any).brandId },
+          include: { category: true, vendor: true },
+          orderBy: { id: 'asc' },
+          take: limit,
+          skip,
+        }),
+        db.product.count({ where: { brandId: (session.user as any).brandId } }),
+      ]);
+
       const products = rows.map((row) => mapDbRowToProduct(row));
 
-      if (products.length === 0) {
-        return res.status(200).json([]);
-      }
-
-      return res.status(200).json(products);
+      return res.status(200).json({ products, total });
     }
 
     if (req.method === 'POST') {

--- a/pages/brand/products/index.tsx
+++ b/pages/brand/products/index.tsx
@@ -17,7 +17,9 @@ const BrandProductsPage: React.FC = () => {
     setLoading(true);
     fetch('/api/brand/products')
       .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data: Product[]) => setProducts(data))
+      .then((data: { products: Product[]; total: number }) =>
+        setProducts(data.products)
+      )
       .finally(() => setLoading(false));
   }, [user]);
 
@@ -62,7 +64,10 @@ const BrandProductsPage: React.FC = () => {
         <ul className="space-y-1">
           {filtered.map((p) => (
             <li key={p.id} className="border p-2">
-              {p.title} ({p.sku}) - {typeof p.category === 'string' ? p.category : p.category?.name || p.productType}
+              {p.title} ({p.sku}) -{' '}
+              {typeof p.category === 'string'
+                ? p.category
+                : p.category?.name || p.productType}
             </li>
           ))}
           {filtered.length === 0 && <li>No products found.</li>}


### PR DESCRIPTION
## Summary
- filter brand products by logged in brand
- paginate brand product listing API
- adjust brand products page and dashboard card for new API response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d92331ae4832fa5632d4ad6bb0d36