### PR TITLE
Improve session typings

### DIFF
--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -67,13 +67,7 @@ export function AppProvider({ children }: AppProviderProps) {
 
   useEffect(() => {
     if (session?.user) {
-      const u = session.user as UserInfo & {
-        role?: string;
-        brandName?: string;
-        name?: string | null;
-        gender?: string;
-      };
-      const { email, name, role, brandName, gender } = u;
+      const { email, name, role, brandName, gender } = session.user;
       const [firstName = '', lastName = ''] = (name || '').split(' ');
       setUser({
         email: email ?? '',

--- a/lib/withRole.ts
+++ b/lib/withRole.ts
@@ -1,13 +1,10 @@
 import { getServerSession } from 'next-auth/next';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+import type { Session } from 'next-auth';
 import { authOptions } from '../pages/api/auth/[...nextauth]';
 
-interface AuthedNextApiRequest extends NextApiRequest {
-  user?: {
-    email?: string | null;
-    role?: string;
-    [key: string]: unknown;
-  };
+export interface AuthedNextApiRequest extends NextApiRequest {
+  user?: Session['user'];
 }
 
 export function withRole(roles: string[]) {

--- a/pages/api/admin/policies.ts
+++ b/pages/api/admin/policies.ts
@@ -1,9 +1,9 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-import { withRole } from '../../../lib/withRole';
+import type { NextApiResponse } from 'next';
+import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
 import { getDb } from '../../../lib/db';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 
-async function handler(req: NextApiRequest, res: NextApiResponse) {
+async function handler(req: AuthedNextApiRequest, res: NextApiResponse) {
   try {
     const db = getDb();
     if (req.method === 'GET') {
@@ -28,7 +28,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         res.status(400).json({ message: 'type and content required' });
         return;
       }
-      const adminEmail = (req as any).user?.email as string | undefined;
+      const adminEmail = req.user?.email as string | undefined;
       const admin = adminEmail
         ? await db.user.findUnique({ where: { email: adminEmail } })
         : null;

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -58,13 +58,13 @@ async function handler(
 
       const [rows, total] = await Promise.all([
         db.product.findMany({
-          where: { brandId: (session.user as any).brandId },
+          where: { brandId: session.user.brandId },
           include: { category: true, vendor: true },
           orderBy: { id: 'asc' },
           take: limit,
           skip,
         }),
-        db.product.count({ where: { brandId: (session.user as any).brandId } }),
+        db.product.count({ where: { brandId: session.user.brandId } }),
       ]);
 
       const products = rows.map((row) => mapDbRowToProduct(row));

--- a/pages/api/dashboard/best-sellers.ts
+++ b/pages/api/dashboard/best-sellers.ts
@@ -1,12 +1,12 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiResponse } from 'next';
 import { getDb } from '../../../lib/db';
-import { withRole } from '../../../lib/withRole';
+import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(
-  req: NextApiRequest,
+  req: AuthedNextApiRequest,
   res: NextApiResponse<
     { products: { id: string; title: string; quantity: number }[] } | ApiMessage
   >
@@ -16,10 +16,7 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as {
-      id?: string | number;
-      brandName?: string;
-    } | undefined;
+    const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const vendorId = Number(user?.id) || brandId || undefined;
     const where: any = {};

--- a/pages/api/dashboard/inventory-alerts.ts
+++ b/pages/api/dashboard/inventory-alerts.ts
@@ -1,12 +1,12 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiResponse } from 'next';
 import { getDb } from '../../../lib/db';
-import { withRole } from '../../../lib/withRole';
+import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(
-  req: NextApiRequest,
+  req: AuthedNextApiRequest,
   res: NextApiResponse<
     { products: { id: string; title: string; quantity: number }[] } | ApiMessage
   >
@@ -16,10 +16,7 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as {
-      id?: string | number;
-      brandName?: string;
-    } | undefined;
+    const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const vendorId = Number(user?.id) || brandId || undefined;
     const threshold = parseInt(getQueryParam(req.query.threshold) || '10', 10);

--- a/pages/api/dashboard/orders-this-month.ts
+++ b/pages/api/dashboard/orders-this-month.ts
@@ -1,13 +1,13 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiResponse } from 'next';
 import dayjs from 'dayjs';
 import { getDb } from '../../../lib/db';
-import { withRole } from '../../../lib/withRole';
+import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(
-  req: NextApiRequest,
+  req: AuthedNextApiRequest,
   res: NextApiResponse<{ count: number; revenue: number } | ApiMessage>
 ) {
   try {
@@ -15,10 +15,7 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as {
-      id?: string | number;
-      brandName?: string;
-    } | undefined;
+    const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const vendorId = Number(user?.id) || brandId || undefined;
     const monthOffset = parseInt(getQueryParam(req.query.monthOffset) || '0', 10);

--- a/pages/api/dashboard/total-products.ts
+++ b/pages/api/dashboard/total-products.ts
@@ -1,12 +1,12 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiResponse } from 'next';
 import { getDb } from '../../../lib/db';
-import { withRole } from '../../../lib/withRole';
+import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(
-  req: NextApiRequest,
+  req: AuthedNextApiRequest,
   res: NextApiResponse<{ count: number } | ApiMessage>
 ) {
   try {
@@ -14,10 +14,7 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as {
-      id?: string | number;
-      brandName?: string;
-    } | undefined;
+    const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const vendorId = Number(user?.id) || brandId || undefined;
     const where = vendorId ? { vendorId } : {};

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -1,12 +1,12 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiResponse } from 'next';
 import { getDb } from '../../../lib/db';
-import { withRole } from '../../../lib/withRole';
+import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(
-  req: NextApiRequest,
+  req: AuthedNextApiRequest,
   res: NextApiResponse<{ total: number } | ApiMessage>
 ) {
   try {
@@ -14,10 +14,7 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as {
-      id?: string | number;
-      brandName?: string;
-    } | undefined;
+    const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const vendorId = Number(user?.id) || brandId || undefined;
     const monthOffset = getQueryParam(req.query.monthOffset);

--- a/pages/api/dashboard/weekly-summary.ts
+++ b/pages/api/dashboard/weekly-summary.ts
@@ -1,13 +1,13 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiResponse } from 'next';
 import dayjs from 'dayjs';
 import { getDb } from '../../../lib/db';
-import { withRole } from '../../../lib/withRole';
+import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(
-  req: NextApiRequest,
+  req: AuthedNextApiRequest,
   res: NextApiResponse<{ count: number; revenue: number } | ApiMessage>
 ) {
   try {
@@ -15,10 +15,7 @@ async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const db = getDb();
-    const user = (req as any).user as {
-      id?: string | number;
-      brandName?: string;
-    } | undefined;
+    const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const vendorId = Number(user?.id) || brandId || undefined;
     const start = dayjs().subtract(7, 'day').startOf('day').toDate();

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -14,7 +14,7 @@ const BrandOrders: React.FC = () => {
 
   useEffect(() => {
     if (!user || status === 'loading') return;
-    const vendorId = user.brandName || (session?.user as any)?.brandName;
+    const vendorId = user.brandName || session?.user?.brandName;
     if (!vendorId) {
       setError('Unable to determine brand ID');
       setLoading(false);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    "typeRoots": ["./types", "./node_modules/@types"],
     "types": ["node", "jest"],
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,28 @@
+import 'next-auth';
+import 'next-auth/jwt';
+import type { Role } from '@prisma/client';
+import type { User as AppUser } from './user';
+
+declare module 'next-auth' {
+  interface Session {
+    user?: AppUser & {
+      name?: string | null;
+      role?: Role | string;
+      brandId?: number;
+    };
+  }
+
+  interface User extends AppUser {
+    name?: string | null;
+    role?: Role | string;
+    brandId?: number;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT extends AppUser {
+    name?: string | null;
+    role?: Role | string;
+    brandId?: number;
+  }
+}


### PR DESCRIPTION
## Summary
- extend NextAuth session and user types
- use the new types across APIs and components
- update TypeScript config so custom types are loaded
- remove casts to `any` when reading session or request users

## Testing
- `npm test`
- `npm run type-check` *(fails: Prisma types missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d941070dc832fa1749cc66526b301