### PR TITLE
Fix brand-specific product counts

### DIFF
--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -53,9 +53,10 @@ export function AppProvider({ children }: AppProviderProps) {
 
   useEffect(() => {
     if (session?.user) {
-      const { email, name, role, brandName, gender } = session.user;
+      const { email, name, role, brandName, gender, brandId } = session.user;
       const [firstName = '', lastName = ''] = (name || '').split(' ');
       setUser({
+        id: brandId,
         email: email ?? '',
         firstName,
         lastName,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 
 export type UserInfo = Pick<
   Prisma.User,
+  | 'id'
   | 'email'
   | 'firstName'
   | 'lastName'

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -52,7 +52,7 @@ export const authOptions: AuthOptions = {
           !user.disabled &&
           (await bcrypt.compare(credentials.password, user.password))
         ) {
-          const { firstName, lastName, brandName, gender, role } = user;
+          const { id, firstName, lastName, brandName, gender, role } = user;
           return {
             id: user.email,
             email: user.email,
@@ -60,6 +60,7 @@ export const authOptions: AuthOptions = {
             brandName,
             gender,
             role,
+            brandId: id,
           };
         }
         return null;
@@ -100,10 +101,19 @@ export const authOptions: AuthOptions = {
     async jwt({ token, user }) {
       if (user) {
         token.role = user.role;
-      } else if (!token.role) {
-        if (typeof token.email === 'string') {
+        if ('brandId' in user && typeof (user as any).brandId === 'number') {
+          token.brandId = (user as any).brandId;
+        } else if (typeof user.email === 'string') {
+          const dbUser = await findUser(user.email);
+          if (dbUser) token.brandId = dbUser.id;
+        }
+      } else {
+        if (token.brandId === undefined && typeof token.email === 'string') {
           const dbUser = await findUser(token.email);
-          if (dbUser) token.role = dbUser.role;
+          if (dbUser) {
+            token.brandId = dbUser.id;
+            if (!token.role) token.role = dbUser.role;
+          }
         }
       }
       return token;
@@ -111,6 +121,9 @@ export const authOptions: AuthOptions = {
     session({ session, token }) {
       if (token && session.user) {
         session.user.role = token.role;
+        if (typeof token.brandId === 'number') {
+          (session.user as { brandId?: number }).brandId = token.brandId;
+        }
       }
       return session;
     },

--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -3,6 +3,8 @@ import { getOrdersForVendor } from '../../../lib/orders';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { AnalyticsData, ApiMessage } from '../../../types';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,9 +14,10 @@ export default async function handler(
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const vendor = getQueryParam(req.query.vendor);
-    if (!vendor) {
-      return res.status(400).json({ message: 'vendor required' });
+    const session = await getServerSession(req, res, authOptions);
+    const vendor = session?.user?.brandName || getQueryParam(req.query.vendor);
+    if (!session?.user || session.user.role !== 'BRAND' || !vendor) {
+      return res.status(401).json({ message: 'Unauthorized' });
     }
     const orders = await getOrdersForVendor(vendor);
     const summary: AnalyticsData = {

--- a/pages/api/brand/earnings.ts
+++ b/pages/api/brand/earnings.ts
@@ -3,6 +3,8 @@ import { getOrdersForVendor } from '../../../lib/orders';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { EarningsData, ApiMessage } from '../../../types';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,9 +14,10 @@ export default async function handler(
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const vendor = getQueryParam(req.query.vendor);
-    if (!vendor) {
-      return res.status(400).json({ message: 'vendor required' });
+    const session = await getServerSession(req, res, authOptions);
+    const vendor = session?.user?.brandName || getQueryParam(req.query.vendor);
+    if (!session?.user || session.user.role !== 'BRAND' || !vendor) {
+      return res.status(401).json({ message: 'Unauthorized' });
     }
     const orders = await getOrdersForVendor(vendor);
     const totalEarned = orders.reduce((s, o) => s + (o.total || 0), 0);

--- a/pages/api/dashboard/best-sellers.ts
+++ b/pages/api/dashboard/best-sellers.ts
@@ -18,7 +18,7 @@ async function handler(
     const db = getDb();
     const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = Number(user?.id) || brandId || undefined;
+    const vendorId = user?.brandId ?? brandId || undefined;
     const where: any = {};
     if (vendorId) where.product = { vendorId };
     const grouped = await db.order.groupBy({

--- a/pages/api/dashboard/inventory-alerts.ts
+++ b/pages/api/dashboard/inventory-alerts.ts
@@ -18,7 +18,7 @@ async function handler(
     const db = getDb();
     const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = Number(user?.id) || brandId || undefined;
+    const vendorId = user?.brandId ?? brandId || undefined;
     const threshold = parseInt(getQueryParam(req.query.threshold) || '10', 10);
     const where: any = { quantity: { lt: threshold } };
     if (vendorId) where.vendorId = vendorId;

--- a/pages/api/dashboard/orders-this-month.ts
+++ b/pages/api/dashboard/orders-this-month.ts
@@ -17,8 +17,11 @@ async function handler(
     const db = getDb();
     const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = Number(user?.id) || brandId || undefined;
-    const monthOffset = parseInt(getQueryParam(req.query.monthOffset) || '0', 10);
+    const vendorId = user?.brandId ?? brandId || undefined;
+    const monthOffset = parseInt(
+      getQueryParam(req.query.monthOffset) || '0',
+      10
+    );
     const start = dayjs()
       .startOf('month')
       .subtract(monthOffset, 'month')

--- a/pages/api/dashboard/total-products.ts
+++ b/pages/api/dashboard/total-products.ts
@@ -16,7 +16,7 @@ async function handler(
     const db = getDb();
     const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = Number(user?.id) || brandId || undefined;
+    const vendorId = user?.brandId ?? brandId || undefined;
     const where = vendorId ? { vendorId } : {};
     const count = await db.product.count({ where });
     return res.status(200).json({ count });

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -16,10 +16,14 @@ async function handler(
     const db = getDb();
     const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = Number(user?.id) || brandId || undefined;
+    const vendorId = user?.brandId ?? brandId || undefined;
     const monthOffset = getQueryParam(req.query.monthOffset);
     const where: any = { status: 'completed' };
-    if (monthOffset !== null && monthOffset !== undefined && monthOffset !== '') {
+    if (
+      monthOffset !== null &&
+      monthOffset !== undefined &&
+      monthOffset !== ''
+    ) {
       const m = parseInt(monthOffset, 10);
       const start = require('dayjs')()
         .startOf('month')

--- a/pages/api/dashboard/weekly-summary.ts
+++ b/pages/api/dashboard/weekly-summary.ts
@@ -17,7 +17,7 @@ async function handler(
     const db = getDb();
     const user = req.user;
     const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = Number(user?.id) || brandId || undefined;
+    const vendorId = user?.brandId ?? brandId || undefined;
     const start = dayjs().subtract(7, 'day').startOf('day').toDate();
     const where: any = { createdAt: { gte: start }, status: 'completed' };
     if (vendorId) where.product = { vendorId };


### PR DESCRIPTION
## Summary
- include brandId in session context and AppContext
- update dashboard API endpoints to filter by brandId
- secure brand analytics and earnings endpoints
- fetch brand analytics without vendor query parameter

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685e216194d4832f8f8f1ddbc4b290bd