### PR TITLE
Secure brand resolution in dashboard APIs

### DIFF
--- a/pages/api/dashboard/best-sellers.ts
+++ b/pages/api/dashboard/best-sellers.ts
@@ -17,8 +17,13 @@ async function handler(
     }
     const db = getDb();
     const user = req.user;
-    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = user?.brandId ?? brandId || undefined;
+    const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const queryBrandId = Number.isNaN(param) ? undefined : param;
+    const vendorId =
+      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+    if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
     const where: any = {};
     if (vendorId) where.product = { vendorId };
     const grouped = await db.order.groupBy({

--- a/pages/api/dashboard/inventory-alerts.ts
+++ b/pages/api/dashboard/inventory-alerts.ts
@@ -17,8 +17,13 @@ async function handler(
     }
     const db = getDb();
     const user = req.user;
-    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = user?.brandId ?? brandId || undefined;
+    const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const queryBrandId = Number.isNaN(param) ? undefined : param;
+    const vendorId =
+      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+    if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
     const threshold = parseInt(getQueryParam(req.query.threshold) || '10', 10);
     const where: any = { quantity: { lt: threshold } };
     if (vendorId) where.vendorId = vendorId;

--- a/pages/api/dashboard/orders-this-month.ts
+++ b/pages/api/dashboard/orders-this-month.ts
@@ -16,8 +16,13 @@ async function handler(
     }
     const db = getDb();
     const user = req.user;
-    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = user?.brandId ?? brandId || undefined;
+    const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const queryBrandId = Number.isNaN(param) ? undefined : param;
+    const vendorId =
+      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+    if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
     const monthOffset = parseInt(
       getQueryParam(req.query.monthOffset) || '0',
       10

--- a/pages/api/dashboard/total-products.ts
+++ b/pages/api/dashboard/total-products.ts
@@ -15,8 +15,13 @@ async function handler(
     }
     const db = getDb();
     const user = req.user;
-    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = user?.brandId ?? brandId || undefined;
+    const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const queryBrandId = Number.isNaN(param) ? undefined : param;
+    const vendorId =
+      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+    if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
     const where = vendorId ? { vendorId } : {};
     const count = await db.product.count({ where });
     return res.status(200).json({ count });

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -15,8 +15,13 @@ async function handler(
     }
     const db = getDb();
     const user = req.user;
-    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = user?.brandId ?? brandId || undefined;
+    const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const queryBrandId = Number.isNaN(param) ? undefined : param;
+    const vendorId =
+      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+    if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
     const monthOffset = getQueryParam(req.query.monthOffset);
     const where: any = { status: 'completed' };
     if (

--- a/pages/api/dashboard/weekly-summary.ts
+++ b/pages/api/dashboard/weekly-summary.ts
@@ -16,8 +16,13 @@ async function handler(
     }
     const db = getDb();
     const user = req.user;
-    const brandId = parseInt(getQueryParam(req.query.brandId) || '', 10);
-    const vendorId = user?.brandId ?? brandId || undefined;
+    const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
+    const queryBrandId = Number.isNaN(param) ? undefined : param;
+    const vendorId =
+      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+    if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
     const start = dayjs().subtract(7, 'day').startOf('day').toDate();
     const where: any = { createdAt: { gte: start }, status: 'completed' };
     if (vendorId) where.product = { vendorId };


### PR DESCRIPTION
## Summary
- use `req.user.brandId` as the main brand context
- allow admin to optionally filter by `brandId`
- reject brand users without a brandId

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e27c1f950832f96f5be47e1d38fa1