### PR TITLE
Fix brand analytics filtering

### DIFF
--- a/components/dashboard/ExistingProductsCard.tsx
+++ b/components/dashboard/ExistingProductsCard.tsx
@@ -17,12 +17,22 @@ const ExistingProductsCard: React.FC<Props> = ({ previewCount = 3 }) => {
   useEffect(() => {
     setProducts(null);
     setError('');
-    fetch('/api/brand/products')
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data: { products: Product[]; total: number }) =>
-        setProducts(data.products)
-      )
-      .catch(() => setError('Failed to load'));
+    async function load() {
+      try {
+        const res = await fetch('/api/brand/products');
+        if (res.ok) {
+          const data: { products: Product[]; total: number } = await res.json();
+          setProducts(data.products);
+        } else if (res.status === 404) {
+          setError('No data available');
+        } else {
+          throw new Error('err');
+        }
+      } catch {
+        setError('Failed to load');
+      }
+    }
+    load();
   }, []);
 
   const preview =

--- a/components/dashboard/InventoryAlertsCard.tsx
+++ b/components/dashboard/InventoryAlertsCard.tsx
@@ -27,10 +27,22 @@ const InventoryAlertsCard: React.FC<Props> = ({ brandId, threshold = 10 }) => {
     const url =
       '/api/dashboard/inventory-alerts' +
       (params.toString() ? `?${params.toString()}` : '');
-    fetch(url)
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data) => setProducts(data.products))
-      .catch(() => setError('Failed to load'));
+    async function load() {
+      try {
+        const res = await fetch(url);
+        if (res.ok) {
+          const data = await res.json();
+          setProducts(data.products);
+        } else if (res.status === 404) {
+          setError('No data available');
+        } else {
+          throw new Error('err');
+        }
+      } catch {
+        setError('Failed to load');
+      }
+    }
+    load();
   }, [brandId, threshold]);
 
   return (

--- a/components/dashboard/OrdersThisMonthCard.tsx
+++ b/components/dashboard/OrdersThisMonthCard.tsx
@@ -26,17 +26,22 @@ const OrdersThisMonthCard: React.FC<Props> = ({ brandId }) => {
       const base = '/api/dashboard/orders-this-month';
       try {
         const curRes = await fetch(`${base}?${params.toString()}`);
-        if (!curRes.ok) throw new Error('err');
-        const cur = await curRes.json();
-        setData(cur);
-        params.set('monthOffset', '1');
-        const prevRes = await fetch(`${base}?${params.toString()}`);
-        if (prevRes.ok) {
-          const prev = await prevRes.json();
-          const pct = prev.count
-            ? ((cur.count - prev.count) / prev.count) * 100
-            : 100;
-          setTrend(pct);
+        if (curRes.ok) {
+          const cur = await curRes.json();
+          setData(cur);
+          params.set('monthOffset', '1');
+          const prevRes = await fetch(`${base}?${params.toString()}`);
+          if (prevRes.ok) {
+            const prev = await prevRes.json();
+            const pct = prev.count
+              ? ((cur.count - prev.count) / prev.count) * 100
+              : 100;
+            setTrend(pct);
+          }
+        } else if (curRes.status === 404) {
+          setError('No data available');
+        } else {
+          throw new Error('err');
         }
       } catch {
         setError('Failed to load');

--- a/components/dashboard/TotalProductsCard.tsx
+++ b/components/dashboard/TotalProductsCard.tsx
@@ -22,9 +22,15 @@ const TotalProductsCard: React.FC<Props> = ({ brandId }) => {
         (brandId ? `?brandId=${brandId}` : '');
       try {
         const res = await fetch(url);
-        if (!res.ok) throw new Error('Failed to load');
-        const data = await res.json();
-        setCount(data.count);
+        if (res.ok) {
+          const data = await res.json();
+          setCount(data.count);
+        } else if (res.status === 404) {
+          setError('No data available');
+          setCount(0);
+        } else {
+          throw new Error('err');
+        }
       } catch {
         setError('Failed to load');
         setCount(0);

--- a/components/dashboard/TotalSalesCard.tsx
+++ b/components/dashboard/TotalSalesCard.tsx
@@ -20,17 +20,22 @@ const TotalSalesCard: React.FC<Props> = ({ brandId }) => {
       const base = '/api/dashboard/total-sales';
       try {
         const curRes = await fetch(`${base}?${params.toString()}`);
-        if (!curRes.ok) throw new Error('err');
-        const cur = await curRes.json();
-        setTotal(cur.total);
-        params.set('monthOffset', '1');
-        const prevRes = await fetch(`${base}?${params.toString()}`);
-        if (prevRes.ok) {
-          const prev = await prevRes.json();
-          const pct = prev.total
-            ? ((cur.total - prev.total) / prev.total) * 100
-            : 100;
-          setTrend(pct);
+        if (curRes.ok) {
+          const cur = await curRes.json();
+          setTotal(cur.total);
+          params.set('monthOffset', '1');
+          const prevRes = await fetch(`${base}?${params.toString()}`);
+          if (prevRes.ok) {
+            const prev = await prevRes.json();
+            const pct = prev.total
+              ? ((cur.total - prev.total) / prev.total) * 100
+              : 100;
+            setTrend(pct);
+          }
+        } else if (curRes.status === 404) {
+          setError('No data available');
+        } else {
+          throw new Error('err');
         }
       } catch {
         setError('Failed to load');

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -164,6 +164,19 @@ export async function getOrdersForVendor(vendor: string): Promise<Order[]> {
   return rows.map(mapDbRowToOrder);
 }
 
+export async function getOrdersForVendorId(vendorId: number): Promise<Order[]> {
+  const db = getDb();
+  const rows: OrderWithRelations[] = await db.order.findMany({
+    where: { product: { vendorId } },
+    include: {
+      user: true,
+      product: { include: { vendor: true, category: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+  return rows.map(mapDbRowToOrder);
+}
+
 export async function hasOrdersForProduct(
   productUuid: string
 ): Promise<boolean> {

--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -1,7 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrdersForVendor } from '../../../lib/orders';
+import { getOrdersForVendorId } from '../../../lib/orders';
 import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { AnalyticsData, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
@@ -15,11 +14,14 @@ export default async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const session = await getServerSession(req, res, authOptions);
-    const vendor = session?.user?.brandName || getQueryParam(req.query.vendor);
-    if (!session?.user || session.user.role !== 'BRAND' || !vendor) {
+    const brandId =
+      typeof session?.user?.brandId === 'number'
+        ? session.user.brandId
+        : undefined;
+    if (!session?.user || session.user.role !== 'BRAND' || !brandId) {
       return res.status(401).json({ message: 'Unauthorized' });
     }
-    const orders = await getOrdersForVendor(vendor);
+    const orders = await getOrdersForVendorId(brandId);
     const summary: AnalyticsData = {
       totalOrders: orders.length,
       totalRevenue: 0,
@@ -28,9 +30,7 @@ export default async function handler(
     const counts: Record<string, number> = {};
     orders.forEach((o) => {
       summary.totalRevenue += o.total || 0;
-      if (o.product.vendor.brandName === vendor) {
-        counts[o.product.id] = (counts[o.product.id] || 0) + o.quantity;
-      }
+      counts[o.product.id] = (counts[o.product.id] || 0) + o.quantity;
     });
     summary.topProducts = Object.entries(counts)
       .sort((a, b) => (b[1] as number) - (a[1] as number))

--- a/pages/api/brand/earnings.ts
+++ b/pages/api/brand/earnings.ts
@@ -1,7 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrdersForVendor } from '../../../lib/orders';
+import { getOrdersForVendorId } from '../../../lib/orders';
 import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { EarningsData, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
@@ -15,11 +14,14 @@ export default async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const session = await getServerSession(req, res, authOptions);
-    const vendor = session?.user?.brandName || getQueryParam(req.query.vendor);
-    if (!session?.user || session.user.role !== 'BRAND' || !vendor) {
+    const brandId =
+      typeof session?.user?.brandId === 'number'
+        ? session.user.brandId
+        : undefined;
+    if (!session?.user || session.user.role !== 'BRAND' || !brandId) {
       return res.status(401).json({ message: 'Unauthorized' });
     }
-    const orders = await getOrdersForVendor(vendor);
+    const orders = await getOrdersForVendorId(brandId);
     const totalEarned = orders.reduce((s, o) => s + (o.total || 0), 0);
     const pending = orders
       .filter((o) => o.status !== 'completed')

--- a/pages/api/brand/orders.ts
+++ b/pages/api/brand/orders.ts
@@ -1,7 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrdersForVendor } from '../../../lib/orders';
+import { getOrdersForVendorId } from '../../../lib/orders';
 import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
@@ -15,14 +14,16 @@ export default async function handler(
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
     const session = await getServerSession(req, res, authOptions);
-    const vendor =
-      getQueryParam(req.query.vendor) || session?.user?.brandName || '';
-    if (!vendor) {
+    const brandId =
+      typeof session?.user?.brandId === 'number'
+        ? session.user.brandId
+        : undefined;
+    if (!brandId) {
       return res
         .status(401)
         .json({ message: 'Unable to determine brand ID' });
     }
-    const orders = await getOrdersForVendor(vendor);
+    const orders = await getOrdersForVendorId(brandId);
     return res.status(200).json(orders);
   } catch (error) {
     return handleApiError(res, error, 'Failed to get orders');

--- a/pages/brand/analytics.tsx
+++ b/pages/brand/analytics.tsx
@@ -76,20 +76,26 @@ const BrandAnalytics: React.FC = () => {
 
   useEffect(() => {
     if (!user) return;
-    setLoading(true);
-    fetch(
-      `/api/brand/analytics?vendor=${encodeURIComponent(user.brandName || '')}`
-    )
-      .then((res) => (res.ok ? res.json() : null))
-      .then((d) =>
-        setData(d || { totalOrders: 0, totalRevenue: 0, topProducts: [] })
-      )
-      .finally(() => setLoading(false));
-    fetch(
-      `/api/brand/earnings?vendor=${encodeURIComponent(user.brandName || '')}`
-    )
-      .then((res) => (res.ok ? res.json() : null))
-      .then(setEarnings);
+    async function load() {
+      try {
+        setLoading(true);
+        const analyticsRes = await fetch('/api/brand/analytics');
+        const analyticsData = analyticsRes.ok
+          ? await analyticsRes.json()
+          : null;
+        setData(
+          analyticsData || { totalOrders: 0, totalRevenue: 0, topProducts: [] }
+        );
+        const earningsRes = await fetch('/api/brand/earnings');
+        setEarnings(earningsRes.ok ? await earningsRes.json() : null);
+      } catch {
+        setData({ totalOrders: 0, totalRevenue: 0, topProducts: [] });
+        setEarnings(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
   }, [user]);
 
   if (!user) return <div className="p-4">Please log in.</div>;

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -14,14 +14,8 @@ const BrandOrders: React.FC = () => {
 
   useEffect(() => {
     if (!user || status === 'loading') return;
-    const vendorId = user.brandName || session?.user?.brandName;
-    if (!vendorId) {
-      setError('Unable to determine brand ID');
-      setLoading(false);
-      return;
-    }
     setLoading(true);
-    fetch(`/api/brand/orders?vendor=${encodeURIComponent(vendorId)}`)
+    fetch('/api/brand/orders')
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data: Order[]) => {
         setOrders(data);


### PR DESCRIPTION
## Summary
- filter brand analytics by logged-in brand instead of query params
- update earnings and orders API handlers for brand-scoped queries
- add helper to get orders by brand id
- improve dashboard card error handling
- remove brand name query from brand pages

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: prisma client download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685e275e9e8c832f98c2b8ee45586d8b