### PR TITLE
Add BOGO coupon support with min order value

### DIFF
--- a/__tests__/coupon.api.test.ts
+++ b/__tests__/coupon.api.test.ts
@@ -11,6 +11,7 @@ test('returns coupon data', async () => {
     code: 'SAVE',
     discountType: 'percent',
     amount: 10,
+    minOrderValue: 50,
     isActive: true,
     usedCount: 0,
   });
@@ -25,6 +26,7 @@ test('returns coupon data', async () => {
     code: 'SAVE',
     discountType: 'percent',
     amount: 10,
+    minOrderValue: 50,
     isActive: true,
     usedCount: 0,
   });

--- a/pages/admin/coupons.tsx
+++ b/pages/admin/coupons.tsx
@@ -12,6 +12,7 @@ export default function AdminCoupons() {
     code: '',
     discountType: 'percent',
     amount: 0,
+    minOrderValue: undefined,
   });
   const [editingId, setEditingId] = useState<number | null>(null);
   const [message, setMessage] = useState('');
@@ -38,7 +39,7 @@ export default function AdminCoupons() {
     });
     if (res.ok) {
       setMessage(editingId ? 'Coupon updated' : 'Coupon created');
-      setForm({ code: '', discountType: 'percent', amount: 0 });
+      setForm({ code: '', discountType: 'percent', amount: 0, minOrderValue: undefined });
       setEditingId(null);
       fetchCoupons();
     } else {
@@ -71,13 +72,14 @@ export default function AdminCoupons() {
           value={form.discountType}
           onChange={(e) =>
             setForm((f) => ({
-              ...f,
-              discountType: e.target.value as 'percent' | 'amount',
-            }))
+                ...f,
+                discountType: e.target.value as 'percent' | 'amount' | 'bogo',
+              }))
           }
         >
-          <option value="percent">Percent</option>
-          <option value="amount">Amount</option>
+            <option value="percent">Percent</option>
+            <option value="amount">Amount</option>
+            <option value="bogo">BOGO</option>
         </select>
         <TextInput
           name="amount"
@@ -87,6 +89,15 @@ export default function AdminCoupons() {
             setForm((f) => ({ ...f, amount: parseFloat(e.target.value) }))
           }
           placeholder="Amount"
+        />
+        <TextInput
+          name="minOrderValue"
+          type="number"
+          value={form.minOrderValue ? String(form.minOrderValue) : ''}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setForm((f) => ({ ...f, minOrderValue: parseFloat(e.target.value) }))
+          }
+          placeholder="Min Order Value"
         />
         <TextInput
           name="expirationDate"
@@ -112,7 +123,7 @@ export default function AdminCoupons() {
               className="btn"
               onClick={() => {
                 setEditingId(null);
-                setForm({ code: '', discountType: 'percent', amount: 0 });
+                setForm({ code: '', discountType: 'percent', amount: 0, minOrderValue: undefined });
               }}
             >
               Cancel
@@ -130,6 +141,7 @@ export default function AdminCoupons() {
             <th>Code</th>
             <th>Type</th>
             <th>Amount</th>
+            <th>Min Order</th>
             <th>Used</th>
             <th>Actions</th>
           </tr>
@@ -140,6 +152,7 @@ export default function AdminCoupons() {
               <td>{c.code}</td>
               <td>{c.discountType}</td>
               <td>{c.amount}</td>
+              <td>{c.minOrderValue ?? '-'}</td>
               <td>{c.usedCount}</td>
               <td>
                 <button
@@ -150,6 +163,7 @@ export default function AdminCoupons() {
                       code: c.code,
                       discountType: c.discountType,
                       amount: c.amount,
+                      minOrderValue: c.minOrderValue,
                       expirationDate: c.expirationDate,
                       usageLimit: c.usageLimit,
                     });

--- a/pages/api/admin/coupons.ts
+++ b/pages/api/admin/coupons.ts
@@ -16,7 +16,7 @@ async function handler(
     }
 
     if (req.method === 'POST') {
-      const { code, discountType, amount, expirationDate, usageLimit } =
+      const { code, discountType, amount, minOrderValue, expirationDate, usageLimit } =
         req.body as Partial<Coupon>;
       if (!code || !discountType || amount === undefined) {
         res
@@ -28,6 +28,7 @@ async function handler(
         code: code.toUpperCase(),
         discountType,
         amount,
+        minOrderValue: minOrderValue ?? null,
         expirationDate: expirationDate ? new Date(expirationDate) : undefined,
         usageLimit: usageLimit ?? null,
       });
@@ -44,6 +45,7 @@ async function handler(
       await updateCoupon(Number(id), {
         ...rest,
         code: rest.code?.toUpperCase(),
+        minOrderValue: rest.minOrderValue ?? null,
         expirationDate: rest.expirationDate
           ? new Date(rest.expirationDate)
           : undefined,

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -160,9 +160,24 @@ const Checkout: React.FC = () => {
                 if (res.ok) {
                   const data: Coupon = await res.json();
                   if (data.discountType === 'percent') {
-                    setDiscount(data.value);
+                    setDiscount(data.amount);
+                  } else if (data.discountType === 'bogo') {
+                    if (cart.length >= 2) {
+                      const cheapest = Math.min(
+                        ...cart.map((item) =>
+                          parseFloat(
+                            typeof item.minPrice === 'number'
+                              ? item.minPrice.toString()
+                              : item.minPrice || '0'
+                          )
+                        )
+                      );
+                      setDiscount((cheapest / totalPrice) * 100);
+                    } else {
+                      setDiscount(0);
+                    }
                   } else {
-                    setDiscount(totalPrice > 0 ? (data.value / totalPrice) * 100 : 0);
+                    setDiscount(totalPrice > 0 ? (data.amount / totalPrice) * 100 : 0);
                   }
                 } else {
                   setDiscount(0);

--- a/prisma/migrations/20250627100000_add-minorder-column/migration.sql
+++ b/prisma/migrations/20250627100000_add-minorder-column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Coupon" ADD COLUMN "minOrderValue" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -144,6 +144,7 @@ model Coupon {
   code           String        @unique
   discountType   String
   amount         Float
+  minOrderValue  Float?
   expirationDate DateTime?
   usageLimit     Int?
   usedCount      Int           @default(0)

--- a/types/coupon.ts
+++ b/types/coupon.ts
@@ -1,8 +1,9 @@
 export interface Coupon {
   id?: string | number;
   code: string;
-  discountType: 'percent' | 'amount';
+  discountType: 'percent' | 'amount' | 'bogo';
   amount: number;
+  minOrderValue?: number;
   expirationDate?: string;
   usageLimit?: number;
   usedCount?: number;


### PR DESCRIPTION
## Summary
- extend coupon type with `bogo` and optional `minOrderValue`
- expose min order value in admin UI and API
- implement BOGO discount logic in checkout
- add Prisma migration for the new field

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e29ff4698832fab681172016bbf40