### PR TITLE
Add zip code error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ create a persistent volume and deploy the container.
 
 Returns matching products in enriched format.
 
+Common error responses include:
+
+```json
+{ "error": "shipping zip code required" }
+```
+
 ---
 
 ## 📂 Project Structure

--- a/lib/utils/handleApiError.ts
+++ b/lib/utils/handleApiError.ts
@@ -1,5 +1,9 @@
 import type { NextApiResponse } from 'next';
 
+export const ERROR_MESSAGES = {
+  MISSING_ZIP_CODE: 'shipping zip code required',
+} as const;
+
 export function handleApiError(
   res: NextApiResponse,
   error: unknown,


### PR DESCRIPTION
## Summary
- add `MISSING_ZIP_CODE` to API error handler
- document new message in README

## Testing
- `npx prettier --write README.md lib/utils/handleApiError.ts`
- `npx --no-install jest` *(fails: jest missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e2a28541c832f8582a2f63ee50e6d