### PR TITLE
Add product variants with stock tracking

### DIFF
--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -9,6 +9,7 @@ import { NotificationContext } from './NotificationContext';
 import type { UserInfo } from '../lib/types';
 import type { AppContextValue } from '../types';
 import { Product } from '../types/product';
+import { Variant } from '../types/variant';
 import type { ShippingInfo } from '../types/shipping';
 
 export const AppContext = createContext<AppContextValue | undefined>(undefined);
@@ -20,7 +21,7 @@ interface AppProviderProps {
 export function AppProvider({ children }: AppProviderProps) {
   const { data: session } = useSession();
   const [user, setUser] = useState<UserInfo | null>(null);
-  const [cart, setCart] = useState<(Product & { qty: number })[]>([]);
+  const [cart, setCart] = useState<(Product & { qty: number; variant?: Variant })[]>([]);
   const [wishlist, setWishlist] = useState<Product[]>([]);
   const { addNotification } = useContext(NotificationContext);
 
@@ -151,15 +152,21 @@ export function AppProvider({ children }: AppProviderProps) {
     return true;
   };
 
-  const addToCart = (product: Product) => {
+  const addToCart = (product: Product, variant?: Variant) => {
     let qty = 1;
     setCart((prev) => {
-      const existing = prev.find((p) => p.id === product.id);
+      const existing = prev.find(
+        (p) => p.id === product.id && (!variant || p.variant?.id === variant.id)
+      );
       if (existing) {
         qty = existing.qty + 1;
-        return prev.map((p) => (p.id === product.id ? { ...p, qty } : p));
+        return prev.map((p) =>
+          p.id === product.id && (!variant || p.variant?.id === variant.id)
+            ? { ...p, qty }
+            : p
+        );
       }
-      return [...prev, { ...product, qty }];
+      return [...prev, { ...product, qty, variant }];
     });
     addNotification(
       `Added ${product.title} (x${qty}) to cart`,
@@ -168,18 +175,24 @@ export function AppProvider({ children }: AppProviderProps) {
     );
   };
 
-  const changeQty = (id: string, delta: number) => {
+  const changeQty = (id: string, delta: number, variantId?: number) => {
     setCart((prev) => {
       return prev
         .map((item) =>
-          item.id === id ? { ...item, qty: item.qty + delta } : item
+          item.id === id && (!variantId || item.variant?.id === variantId)
+            ? { ...item, qty: item.qty + delta }
+            : item
         )
         .filter((item) => item.qty > 0);
     });
   };
 
-  const removeFromCart = (id: string) => {
-    setCart((prev) => prev.filter((item) => item.id !== id));
+  const removeFromCart = (id: string, variantId?: number) => {
+    setCart((prev) =>
+      prev.filter(
+        (item) => !(item.id === id && (!variantId || item.variant?.id === variantId))
+      )
+    );
     addNotification('Removed from cart', 'info');
   };
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -9,13 +9,13 @@ const reviewsStore = new Map<string, Review[]>();
 export const getDb = () => prisma;
 
 export async function getProductByUuid(uuid: string) {
-  return prisma.product.findUnique({ where: { uuid } });
+  return prisma.product.findUnique({ where: { uuid }, include: { variants: true } });
 }
 
 export async function getProductBySlug(slug: string) {
   return prisma.product.findUnique({
     where: { slug },
-    include: { category: true, vendor: true },
+    include: { category: true, vendor: true, variants: true },
   });
 }
 

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,6 +1,7 @@
 import { JSDOM } from 'jsdom';
 import { getDb } from './db';
 import type { Product, ProductInput } from '../types/product';
+import type { Variant } from '../types/variant';
 import { parseImages } from './utils/parseImages';
 import type { Category } from '../types/category';
 import type { Vendor } from '../types/vendor';
@@ -10,7 +11,7 @@ import { getBestSellingProducts } from './orders';
 import { slugify } from './slugify';
 
 type ProductWithRelations = Prisma.ProductGetPayload<{
-  include: { category: true; vendor: true };
+  include: { category: true; vendor: true; variants: true };
 }>;
 
 interface ProductRow {
@@ -31,6 +32,7 @@ interface ProductRow {
   currency: string;
   discountType?: string | null;
   discountValue?: number | null;
+  variants?: Variant[];
 }
 
 /**
@@ -111,7 +113,7 @@ async function loadProductsData(): Promise<Product[]> {
   try {
     const rows: ProductWithRelations[] = await db.product.findMany({
       where: { status: 'approved' },
-      include: { category: true, vendor: true },
+      include: { category: true, vendor: true, variants: true },
     });
 
     return rows.map((row) => mapDbRowToProduct(row));
@@ -138,6 +140,7 @@ export function mapDbRowToProduct(row: ProductRow): Product {
     category: row.category ?? null,
     images: parseImages(images),
     totalInventory: quantity,
+    variants: row.variants,
     priceRange: {
       minVariantPrice: { amount: minPrice, currencyCode: currency },
       maxVariantPrice: { amount: maxPrice, currencyCode: currency },
@@ -315,7 +318,7 @@ export async function getPendingProducts(): Promise<Product[]> {
   const db = getDb();
   const rows: ProductWithRelations[] = await db.product.findMany({
     where: { status: 'pending' },
-    include: { category: true, vendor: true },
+    include: { category: true, vendor: true, variants: true },
   });
   return rows.map((row) => mapDbRowToProduct(row));
 }
@@ -326,7 +329,7 @@ export async function getProductsByCategorySlug(
   const db = getDb();
   const rows: ProductWithRelations[] = await db.product.findMany({
     where: { status: 'approved', category: { slug } },
-    include: { category: true, vendor: true },
+    include: { category: true, vendor: true, variants: true },
   });
   return rows.map((row) => mapDbRowToProduct(row));
 }
@@ -339,7 +342,7 @@ export async function getProductsByCategorySlugPaginated(
   const db = getDb();
   const rows: ProductWithRelations[] = await db.product.findMany({
     where: { status: 'approved', category: { slug } },
-    include: { category: true, vendor: true },
+    include: { category: true, vendor: true, variants: true },
     take: limit,
     skip: offset,
     orderBy: { id: 'asc' },
@@ -354,7 +357,7 @@ export async function getApprovedProductsPaginated(
   const db = getDb();
   const rows: ProductWithRelations[] = await db.product.findMany({
     where: { status: 'approved' },
-    include: { category: true, vendor: true },
+    include: { category: true, vendor: true, variants: true },
     take: limit,
     skip: offset,
     orderBy: { id: 'asc' },
@@ -368,7 +371,7 @@ export async function getProductsByVendorBrandName(
   const db = getDb();
   const rows: ProductWithRelations[] = await db.product.findMany({
     where: { status: 'approved', vendor: { brandName } },
-    include: { category: true, vendor: true },
+    include: { category: true, vendor: true, variants: true },
     orderBy: { id: 'asc' },
   });
   return rows.map((row) => mapDbRowToProduct(row));
@@ -443,7 +446,7 @@ export async function getProductsPaginated(
 
   let rows = await db.product.findMany({
     where,
-    include: { category: true, vendor: true },
+    include: { category: true, vendor: true, variants: true },
     orderBy,
   });
 

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -8,7 +8,7 @@ import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
 import { getQueryParam } from '../../../lib/utils/getQueryParam';
 import { slugify } from '../../../lib/slugify';
-import { Product, ApiMessage } from '../../../types';
+import { Product, ApiMessage, Variant } from '../../../types';
 import { mapDbRowToProduct } from '../../../lib/products';
 
 export const config = {
@@ -58,7 +58,26 @@ async function handler(
         min_price,
         max_price,
         currency,
+        variants,
       } = fields as Record<string, unknown>;
+
+      let variantList: Variant[] = [];
+      if (variants) {
+        try {
+          variantList = typeof variants === 'string' ? JSON.parse(variants) : (variants as any);
+          if (!Array.isArray(variantList)) variantList = [];
+        } catch {
+          variantList = [];
+        }
+      }
+
+      const seen = new Set<string>();
+      variantList = variantList.filter((v) => {
+        const key = JSON.stringify(v.attributes);
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
       if (!id || !title || !sku) {
         res.status(400).json({ message: 'id, sku and title are required' });
         return;
@@ -130,12 +149,33 @@ async function handler(
       }
 
       if (req.method === 'POST') {
-        await db.product.create({ data });
+        const product = await db.product.create({ data });
+        if (variantList.length > 0) {
+          await db.variant.createMany({
+            data: variantList.map((v) => ({
+              productId: product.id,
+              attributes: v.attributes,
+              quantity: v.quantity || 0,
+              priceModifier: v.priceModifier ?? null,
+            })),
+          });
+        }
         res.status(201).json({ message: 'Product added' });
         return;
       }
 
       await db.product.update({ where: { id: Number(id) }, data });
+      await db.variant.deleteMany({ where: { productId: Number(id) } });
+      if (variantList.length > 0) {
+        await db.variant.createMany({
+          data: variantList.map((v) => ({
+            productId: Number(id),
+            attributes: v.attributes,
+            quantity: v.quantity || 0,
+            priceModifier: v.priceModifier ?? null,
+          })),
+        });
+      }
       res.status(200).json({ message: 'Product updated' });
       return;
     }
@@ -168,7 +208,7 @@ async function handler(
       if (vendor) where.vendor = { brandName: vendor };
       const rows = await db.product.findMany({
         where,
-        include: { category: true, vendor: true },
+        include: { category: true, vendor: true, variants: true },
       });
       const data: Product[] = rows.map((p) => mapDbRowToProduct(p));
       res.status(200).json(data);

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -66,21 +66,21 @@ const Cart: React.FC = () => {
               <div className="flex items-center space-x-2">
                 <button
                   className="btn btn-xs"
-                  onClick={() => changeQty(item.id, -1)}
+                  onClick={() => changeQty(item.id as string, -1, item.variant?.id)}
                 >
                   -
                 </button>
                 <span>{item.qty}</span>
                 <button
                   className="btn btn-xs"
-                  onClick={() => changeQty(item.id, 1)}
+                  onClick={() => changeQty(item.id as string, 1, item.variant?.id)}
                 >
                   +
                 </button>
                 <span className="ml-2">£{subtotal.toFixed(2)}</span>
                 <button
                   className="btn btn-xs btn-error"
-                  onClick={() => removeFromCart(item.id)}
+                  onClick={() => removeFromCart(item.id as string, item.variant?.id)}
                 >
                   Remove
                 </button>

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -87,6 +87,8 @@ export default function ProductDetail({
   if (!appCtx) return null;
   const { addToCart, addToWishlist, removeFromWishlist, wishlist, user } =
     appCtx;
+  const [variantId, setVariantId] = useState<string>('');
+  const selectedVariant = product.variants?.find((v) => String(v.id) === variantId);
 
   return (
     <div className="p-6 max-w-screen-2xl mx-auto bg-base-100 rounded-box shadow-md min-h-screen">
@@ -130,8 +132,24 @@ export default function ProductDetail({
               typeof product.minPrice === 'number'
                 ? product.minPrice.toString()
                 : product.minPrice || '0'
-            ).toFixed(2)}
+          ).toFixed(2)}
           </p>
+          {product.variants && product.variants.length > 0 && (
+            <select
+              className="select select-bordered mb-2"
+              value={variantId}
+              onChange={(e) => setVariantId(e.target.value)}
+            >
+              <option value="">Select Variant</option>
+              {product.variants.map((v) => (
+                <option key={v.id} value={v.id}>
+                  {Object.entries(v.attributes)
+                    .map(([k, val]) => `${k}: ${val}`)
+                    .join(', ')} - Stock {v.quantity}
+                </option>
+              ))}
+            </select>
+          )}
           <p className="mb-2 font-medium">
             Stock:{' '}
             {product.totalInventory && product.totalInventory > 10
@@ -146,7 +164,8 @@ export default function ProductDetail({
           <div className="flex gap-2">
             <button
               className="btn btn-primary transition-all duration-200"
-              onClick={() => addToCart(product)}
+              onClick={() => addToCart(product, selectedVariant)}
+              disabled={product.variants && !selectedVariant}
             >
               Add to Cart
             </button>

--- a/pages/vendor/index.tsx
+++ b/pages/vendor/index.tsx
@@ -44,6 +44,15 @@ export default function VendorDashboard() {
   const [products, setProducts] = useState<Product[]>([]);
   const [message, setMessage] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
+  interface VariantForm {
+    size: string;
+    color: string;
+    material: string;
+    quantity: number;
+    priceModifier: number;
+    id?: number;
+  }
+  const [variants, setVariants] = useState<VariantForm[]>([]);
 
   const fetchProducts = useCallback(async (): Promise<void> => {
     if (!user) return;
@@ -64,6 +73,30 @@ export default function VendorDashboard() {
     setForm({ ...form, [key]: e.target.value });
   };
 
+  const addVariantRow = () => {
+    setVariants((prev) => [
+      ...prev,
+      { size: '', color: '', material: '', quantity: 0, priceModifier: 0 },
+    ]);
+  };
+
+  const updateVariant = (
+    index: number,
+    field: keyof VariantForm,
+    value: string
+  ) => {
+    setVariants((prev) => {
+      const next = [...prev];
+      // @ts-ignore
+      next[index][field] = field === 'quantity' || field === 'priceModifier' ? Number(value) : value;
+      return next;
+    });
+  };
+
+  const removeVariantRow = (index: number) => {
+    setVariants((prev) => prev.filter((_, i) => i !== index));
+  };
+
   const submit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const payload = editingId ? { ...form, id: editingId } : form;
@@ -82,11 +115,13 @@ export default function VendorDashboard() {
         min_price: payload.minPrice,
         max_price: payload.maxPrice,
         currency: payload.currency,
+        variants,
       }),
     });
     if (res.ok) {
       setMessage(editingId ? 'Product updated' : 'Product added');
       setForm(emptyForm);
+      setVariants([]);
       setEditingId(null);
       fetchProducts();
     } else {
@@ -109,12 +144,23 @@ export default function VendorDashboard() {
       maxPrice: p.maxPrice || 0,
       currency: p.currency || 'USD',
     });
+    setVariants(
+      p.variants?.map((v) => ({
+        id: v.id,
+        size: v.attributes.size || '',
+        color: v.attributes.color || '',
+        material: v.attributes.material || '',
+        quantity: v.quantity,
+        priceModifier: v.priceModifier || 0,
+      })) || []
+    );
     setEditingId(p.id);
   };
 
   const cancelEdit = () => {
     setEditingId(null);
     setForm(emptyForm);
+    setVariants([]);
   };
 
   const handleDelete = async (id: string): Promise<void> => {
@@ -164,6 +210,55 @@ export default function VendorDashboard() {
             placeholder={field}
           />
         ))}
+        <div>
+          <h4 className="font-semibold">Variants</h4>
+          {variants.map((v, idx) => (
+            <div key={idx} className="flex gap-2 mb-1">
+              <input
+                className="input input-sm input-bordered"
+                placeholder="Size"
+                value={v.size}
+                onChange={(e) => updateVariant(idx, 'size', e.target.value)}
+              />
+              <input
+                className="input input-sm input-bordered"
+                placeholder="Color"
+                value={v.color}
+                onChange={(e) => updateVariant(idx, 'color', e.target.value)}
+              />
+              <input
+                className="input input-sm input-bordered"
+                placeholder="Material"
+                value={v.material}
+                onChange={(e) => updateVariant(idx, 'material', e.target.value)}
+              />
+              <input
+                type="number"
+                className="input input-sm input-bordered w-20"
+                placeholder="Qty"
+                value={v.quantity}
+                onChange={(e) => updateVariant(idx, 'quantity', e.target.value)}
+              />
+              <input
+                type="number"
+                className="input input-sm input-bordered w-24"
+                placeholder="Price +"
+                value={v.priceModifier}
+                onChange={(e) => updateVariant(idx, 'priceModifier', e.target.value)}
+              />
+              <button
+                type="button"
+                className="btn btn-xs btn-error"
+                onClick={() => removeVariantRow(idx)}
+              >
+                X
+              </button>
+            </div>
+          ))}
+          <button type="button" className="btn btn-xs" onClick={addVariantRow}>
+            Add Variant
+          </button>
+        </div>
         <div className="flex gap-2">
           {editingId && (
             <button type="button" onClick={cancelEdit} className="btn">

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,6 +91,18 @@ model Product {
   vendor   User     @relation(fields: [vendorId], references: [id])
   category Category @relation(fields: [categoryId], references: [id])
   orders   Order[]
+  variants Variant[]
+}
+
+model Variant {
+  id          Int      @id @default(autoincrement())
+  uuid        String   @unique @default(uuid())
+  productId   Int
+  attributes  Json
+  quantity    Int      @default(0)
+  priceModifier Float?
+
+  product Product @relation(fields: [productId], references: [id])
 }
 
 model Order {

--- a/types/cart.ts
+++ b/types/cart.ts
@@ -1,7 +1,9 @@
 import type { Product } from './product';
+import type { Variant } from './variant';
 
 export interface CartItem extends Product {
   qty: number;
+  variant?: Variant;
 }
 
 export interface CartResponse {

--- a/types/context.ts
+++ b/types/context.ts
@@ -1,15 +1,16 @@
 import type { Product } from './product';
+import type { Variant } from './variant';
 import type { ShippingInfo } from './shipping';
 import type { UserInfo } from '../lib/types';
 
 export interface AppContextValue {
   user: UserInfo | null;
-  cart: (Product & { qty: number })[];
+  cart: (Product & { qty: number; variant?: Variant })[];
   wishlist: Product[];
   login: (email: string, password: string) => Promise<void>;
   signup: <T>(url: string, payload: Record<string, unknown>) => Promise<T>;
   logout: () => void;
-  addToCart: (product: Product) => void;
+  addToCart: (product: Product, variant?: Variant) => void;
   changeQty: (id: string, delta: number) => void;
   removeFromCart: (id: string) => void;
   addToWishlist: (product: Product) => void;

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,3 +23,4 @@ export * from "./dashboard";
 export * from './notification';
 export * from './message';
 export * from './context';
+export * from './variant';

--- a/types/product.ts
+++ b/types/product.ts
@@ -4,6 +4,7 @@ import type { Vendor } from './vendor';
 import type { Brand } from './brand';
 import type { Image } from './image';
 import type { PriceRange } from './price';
+import type { Variant } from './variant';
 
 type ProductBase = Pick<
   PrismaProduct,
@@ -31,6 +32,7 @@ export interface Product extends ProductBase {
   category: Category;
   brand?: Brand;
   images?: Image[];
+  variants?: Variant[];
   priceRange?: PriceRange;
   soldCount: number;
   reviewCount: number;

--- a/types/variant.ts
+++ b/types/variant.ts
@@ -1,0 +1,13 @@
+export interface Variant {
+  id: number;
+  uuid: string;
+  productId: number;
+  attributes: {
+    size?: string;
+    color?: string;
+    material?: string;
+    [key: string]: string | undefined;
+  };
+  quantity: number;
+  priceModifier?: number | null;
+}


### PR DESCRIPTION
## Summary
- support product variants in schema and types
- manage variants in vendor admin
- select variant on product page
- include variant info in cart and APIs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e28d83e20832fbd093f372d8707d0