### PR TITLE
Add wishlist with stock notifications

### DIFF
--- a/components/Product/ProductCard.tsx
+++ b/components/Product/ProductCard.tsx
@@ -24,6 +24,10 @@ const ProductCard: React.FC<ProductCardProps> = ({
 }) => {
   const context = useContext(AppContext) as AppContextValue;
   const addToCart = context?.addToCart;
+  const addToWish = context?.addToWishlist;
+  const removeFromWish = context?.removeFromWishlist;
+  const wishlist = context?.wishlist || [];
+  const inWishlist = wishlist.some((w) => w.product.id === product.id);
 
   const inventory =
     product.totalInventory !== undefined
@@ -47,6 +51,18 @@ const ProductCard: React.FC<ProductCardProps> = ({
     <div
       className={`group relative flex flex-col h-full border border-base-300 rounded-xl overflow-hidden shadow hover:shadow-lg transition-shadow duration-200 w-4/5 mx-auto ${className}`}
     >
+      <button
+        type="button"
+        className="absolute top-2 right-2 z-10 btn btn-ghost btn-xs"
+        onClick={(e) => {
+          e.preventDefault();
+          inWishlist
+            ? removeFromWish && removeFromWish(product.id)
+            : addToWish && addToWish(product);
+        }}
+      >
+        {inWishlist ? '❤' : '♡'}
+      </button>
       <Link href={`/product/${product.slug}`} className="block overflow-hidden">
         <ProductImageSlider
           images={

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -10,6 +10,7 @@ import type { UserInfo } from '../lib/types';
 import type { AppContextValue } from '../types';
 import { Product } from '../types/product';
 import type { ShippingInfo } from '../types/shipping';
+import type { WishlistItem } from '../types/wishlist';
 
 export const AppContext = createContext<AppContextValue | undefined>(undefined);
 
@@ -21,7 +22,7 @@ export function AppProvider({ children }: AppProviderProps) {
   const { data: session } = useSession();
   const [user, setUser] = useState<UserInfo | null>(null);
   const [cart, setCart] = useState<(Product & { qty: number })[]>([]);
-  const [wishlist, setWishlist] = useState<Product[]>([]);
+  const [wishlist, setWishlist] = useState<WishlistItem[]>([]);
   const { addNotification } = useContext(NotificationContext);
 
   useEffect(() => {
@@ -43,7 +44,7 @@ export function AppProvider({ children }: AppProviderProps) {
         if (Array.isArray(data)) setCart(data);
       })
       .catch(() => {});
-    fetch('/api/wishlist')
+    fetch('/api/user/wishlist')
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => {
         if (Array.isArray(data)) setWishlist(data);
@@ -81,11 +82,6 @@ export function AppProvider({ children }: AppProviderProps) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ items: cart }),
-      }).catch(() => {});
-      fetch('/api/wishlist', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ items: wishlist }),
       }).catch(() => {});
     }
   }, [cart, wishlist, user]);
@@ -183,16 +179,45 @@ export function AppProvider({ children }: AppProviderProps) {
     addNotification('Removed from cart', 'info');
   };
 
-  const addToWishlist = (product: Product) => {
+  const addToWishlist = (product: Product, notifyOnStock = false) => {
     setWishlist((prev) => {
-      if (prev.find((p) => p.id === product.id)) return prev;
-      return [...prev, product];
+      if (prev.find((p) => p.product.id === product.id)) return prev;
+      const temp: WishlistItem = {
+        id: Date.now(),
+        userId: 0,
+        productId: product.id,
+        variantId: null,
+        notifyOnStock,
+        createdAt: new Date(),
+        product,
+      };
+      return [...prev, temp];
     });
+    if (user) {
+      fetch('/api/user/wishlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ productId: product.id, notifyOnStock }),
+      })
+        .then((res) => res.json())
+        .then((item) => {
+          setWishlist((prev) =>
+            prev.map((w) =>
+              w.product.id === product.id ? { ...w, id: item.id } : w
+            )
+          );
+        })
+        .catch(() => {});
+    }
     addNotification('Added to wishlist', 'success');
   };
 
-  const removeFromWishlist = (id: string) => {
-    setWishlist((prev) => prev.filter((item) => item.id !== id));
+  const removeFromWishlist = (productId: string | number) => {
+    const item = wishlist.find((w) => w.product.id === productId);
+    if (item && user) {
+      fetch(`/api/user/wishlist/${item.id}`, { method: 'DELETE' }).catch(() => {});
+    }
+    setWishlist((prev) => prev.filter((w) => w.product.id !== productId));
     addNotification('Removed from wishlist', 'warning');
   };
 

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -61,3 +61,33 @@ export async function sendOrderStatusUpdate(
     console.error('Email error', e);
   }
 }
+
+export async function sendBackInStock(to: string, title: string) {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.RESEND_FROM || 'orders@example.com';
+  if (!apiKey) {
+    console.log('No RESEND_API_KEY configured');
+    return;
+  }
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from,
+        to,
+        subject: `${title} back in stock`,
+        html: `<p>Your saved item <b>${title}</b> is back in stock.</p>`,
+      }),
+    });
+    if (!res.ok) {
+      console.error('Failed to send email', await res.text());
+    }
+  } catch (e) {
+    console.error('Email error', e);
+  }
+}
+

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -259,6 +259,9 @@ export async function updateProduct(
   product: ProductInput & { id?: string | number }
 ): Promise<void> {
   const db = getDb();
+  const existing = await db.product.findUnique({
+    where: { uuid: product.uuid || String(product.id) },
+  });
   if (!product.vendor?.brandName) {
     const err = new Error('Vendor is required') as Error & { code?: string };
     err.code = 'BAD_REQUEST';
@@ -309,6 +312,15 @@ export async function updateProduct(
       category: { connect: { id: category.id } },
     } as Prisma.ProductUpdateInput,
   });
+  if (existing && existing.quantity <= 0 && (product.quantity ?? 0) > 0) {
+    try {
+      await import('./wishlist').then(({ notifyBackInStock }) =>
+        notifyBackInStock(existing.id)
+      );
+    } catch {
+      // ignore
+    }
+  }
 }
 
 export async function getPendingProducts(): Promise<Product[]> {

--- a/lib/wishlist.ts
+++ b/lib/wishlist.ts
@@ -1,0 +1,77 @@
+import { prisma } from './prisma';
+import type { WishlistItem } from '../types/wishlist';
+
+export async function addWishlistItem(params: {
+  userId: number;
+  productId: number;
+  variantId?: string | null;
+  notifyOnStock?: boolean;
+}): Promise<WishlistItem> {
+  const existing = await prisma.wishlistItem.findFirst({
+    where: {
+      userId: params.userId,
+      productId: params.productId,
+      variantId: params.variantId ?? null,
+    },
+    include: { product: { include: { vendor: true, category: true } } },
+  });
+  if (existing) {
+    return prisma.wishlistItem.update({
+      where: { id: existing.id },
+      data: { notifyOnStock: params.notifyOnStock ?? existing.notifyOnStock },
+      include: { product: { include: { vendor: true, category: true } } },
+    });
+  }
+  return prisma.wishlistItem.create({
+    data: {
+      user: { connect: { id: params.userId } },
+      product: { connect: { id: params.productId } },
+      variantId: params.variantId,
+      notifyOnStock: params.notifyOnStock ?? false,
+    },
+    include: { product: { include: { vendor: true, category: true } } },
+  });
+}
+
+export function getWishlistForUser(userId: number): Promise<WishlistItem[]> {
+  return prisma.wishlistItem.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    include: { product: { include: { vendor: true, category: true } } },
+  });
+}
+
+export function removeWishlistItem(id: number, userId: number): Promise<void> {
+  return prisma.wishlistItem
+    .deleteMany({ where: { id, userId } })
+    .then(() => {});
+}
+
+export async function getStockWatchers(productId: number): Promise<WishlistItem[]> {
+  return prisma.wishlistItem.findMany({
+    where: { productId, notifyOnStock: true },
+    include: { user: true, product: true },
+  });
+}
+
+export async function disableNotify(id: number): Promise<void> {
+  await prisma.wishlistItem.update({
+    where: { id },
+    data: { notifyOnStock: false },
+  });
+}
+
+export async function notifyBackInStock(productId: number): Promise<void> {
+  const watchers = await getStockWatchers(productId);
+  for (const item of watchers) {
+    if (!item.user?.email) continue;
+    try {
+      await import('./email').then(({ sendBackInStock }) =>
+        sendBackInStock(item.user.email, item.product.title)
+      );
+    } catch {
+      // ignore email errors
+    }
+    await disableNotify(item.id);
+  }
+}

--- a/pages/api/user/wishlist/[id].ts
+++ b/pages/api/user/wishlist/[id].ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { findUser } from '../../../../lib/users';
+import { removeWishlistItem } from '../../../../lib/wishlist';
+import { handleApiError } from '../../../../lib/utils/handleApiError';
+import type { ApiMessage } from '../../../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const user = await findUser(session.user.email);
+    if (!user) return res.status(404).json({ message: 'User not found' });
+
+    if (req.method === 'DELETE') {
+      const { id } = req.query as { id?: string };
+      if (!id) return res.status(400).json({ message: 'id required' });
+      await removeWishlistItem(parseInt(id, 10), user.id);
+      return res.status(200).json({ message: 'removed' });
+    }
+
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to remove wishlist item');
+  }
+}

--- a/pages/api/user/wishlist/index.ts
+++ b/pages/api/user/wishlist/index.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { findUser } from '../../../../lib/users';
+import {
+  addWishlistItem,
+  getWishlistForUser,
+} from '../../../../lib/wishlist';
+import { handleApiError } from '../../../../lib/utils/handleApiError';
+import type { WishlistItem, ApiMessage } from '../../../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WishlistItem[] | WishlistItem | ApiMessage>
+): Promise<void> {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const user = await findUser(session.user.email);
+    if (!user) return res.status(404).json({ message: 'User not found' });
+
+    if (req.method === 'GET') {
+      const items = await getWishlistForUser(user.id);
+      return res.status(200).json(items);
+    }
+
+    if (req.method === 'POST') {
+      const { productId, variantId, notifyOnStock } = req.body as {
+        productId?: number;
+        variantId?: string;
+        notifyOnStock?: boolean;
+      };
+      if (!productId) {
+        return res.status(400).json({ message: 'productId required' });
+      }
+      const item = await addWishlistItem({
+        userId: user.id,
+        productId,
+        variantId: variantId ?? null,
+        notifyOnStock,
+      });
+      return res.status(200).json(item);
+    }
+
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage wishlist');
+  }
+}

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -150,7 +150,7 @@ export default function ProductDetail({
             >
               Add to Cart
             </button>
-            {wishlist?.some((w) => w.id === product.id) ? (
+            {wishlist?.some((w) => w.product.id === product.id) ? (
               <button
                 className="btn transition-all duration-200"
                 onClick={() => removeFromWishlist(product.id)}

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -140,7 +140,7 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
         >
           Add to Cart
         </button>
-        {(wishlist ?? []).some((w: Product) => w.id === product.id) ? (
+        {(wishlist ?? []).some((w) => w.product.id === product.id) ? (
           <button
             className="btn"
             onClick={() => removeFromWishlist?.(product.id)}

--- a/pages/user/wishlist.tsx
+++ b/pages/user/wishlist.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import Link from 'next/link';
 import { AppContext } from '../../contexts/AppContext';
-import type { AppContextValue } from '../../types';
+import type { AppContextValue, WishlistItem } from '../../types';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
 
@@ -12,7 +12,7 @@ const UserWishlist: React.FC = () => {
     return <div className="p-4">Please log in to view wishlist.</div>;
   }
 
-  const { wishlist, addToCart, removeFromWishlist } = context;
+  const { wishlist, addToCart, removeFromWishlist, addToWishlist } = context;
 
   return (
     <div className="max-w-2xl mx-auto">
@@ -21,23 +21,42 @@ const UserWishlist: React.FC = () => {
       </Head>
       <h1 className="text-2xl font-bold mb-4">My Wishlist</h1>
       <ul className="space-y-2">
-        {wishlist.map((item) => (
+        {wishlist.map((item: WishlistItem) => (
           <li
             key={item.id}
             className="border p-2 flex justify-between items-center"
           >
             <div>
-              <Link href={`/product/${item.slug}`} className="font-semibold">
-                {item.title}
+              <Link
+                href={`/product/${item.product.slug}`}
+                className="font-semibold"
+              >
+                {item.product.title}
               </Link>
+              <div className="text-sm">
+                {item.product.quantity > 0 ? 'In Stock' : 'Out of Stock'}
+              </div>
+              <label className="flex items-center gap-1 mt-1 text-sm">
+                <input
+                  type="checkbox"
+                  checked={item.notifyOnStock}
+                  onChange={() =>
+                    addToWishlist(item.product, !item.notifyOnStock)
+                  }
+                />
+                Notify when in stock
+              </label>
             </div>
             <div className="flex gap-2">
-              <button className="btn btn-sm" onClick={() => addToCart(item)}>
+              <button
+                className="btn btn-sm"
+                onClick={() => addToCart(item.product)}
+              >
                 Add to Cart
               </button>
               <button
                 className="btn btn-sm"
-                onClick={() => removeFromWishlist(item.id)}
+                onClick={() => removeFromWishlist(item.product.id)}
               >
                 Remove
               </button>

--- a/prisma/migrations/20250627052000_add-wishlist/migration.sql
+++ b/prisma/migrations/20250627052000_add-wishlist/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "WishlistItem" (
+    "id" SERIAL NOT NULL,
+    "uuid" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "productId" INTEGER NOT NULL,
+    "variantId" TEXT,
+    "notifyOnStock" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WishlistItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WishlistItem_uuid_key" ON "WishlistItem"("uuid");
+
+-- AddForeignKey
+ALTER TABLE "WishlistItem" ADD CONSTRAINT "WishlistItem_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "WishlistItem" ADD CONSTRAINT "WishlistItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,7 @@ model User {
   receivedMessages Message[]         @relation("ReceivedMessages")
   updatedPolicies  PolicyDocument[]  @relation("UserToPolicyDocuments")
   supportTickets   SupportTicket[]
+  wishlistItems    WishlistItem[]
 }
 
 model Category {
@@ -91,6 +92,7 @@ model Product {
   vendor   User     @relation(fields: [vendorId], references: [id])
   category Category @relation(fields: [categoryId], references: [id])
   orders   Order[]
+  wishlistItems WishlistItem[]
 }
 
 model Order {
@@ -246,4 +248,17 @@ model SupportTicket {
   updatedAt DateTime @updatedAt
 
   user User? @relation(fields: [userId], references: [id])
+}
+
+model WishlistItem {
+  id           Int      @id @default(autoincrement())
+  uuid         String   @unique @default(uuid())
+  userId       Int
+  productId    Int
+  variantId    String?
+  notifyOnStock Boolean @default(false)
+  createdAt    DateTime @default(now())
+
+  user    User    @relation(fields: [userId], references: [id])
+  product Product @relation(fields: [productId], references: [id])
 }

--- a/types/context.ts
+++ b/types/context.ts
@@ -1,18 +1,19 @@
 import type { Product } from './product';
 import type { ShippingInfo } from './shipping';
 import type { UserInfo } from '../lib/types';
+import type { WishlistItem } from './wishlist';
 
 export interface AppContextValue {
   user: UserInfo | null;
   cart: (Product & { qty: number })[];
-  wishlist: Product[];
+  wishlist: WishlistItem[];
   login: (email: string, password: string) => Promise<void>;
   signup: <T>(url: string, payload: Record<string, unknown>) => Promise<T>;
   logout: () => void;
   addToCart: (product: Product) => void;
   changeQty: (id: string, delta: number) => void;
   removeFromCart: (id: string) => void;
-  addToWishlist: (product: Product) => void;
-  removeFromWishlist: (id: string) => void;
+  addToWishlist: (product: Product, notifyOnStock?: boolean) => void;
+  removeFromWishlist: (productId: string | number) => void;
   placeOrder: (shipping: ShippingInfo) => Promise<boolean>;
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,3 +23,4 @@ export * from "./dashboard";
 export * from './notification';
 export * from './message';
 export * from './context';
+export * from './wishlist';

--- a/types/wishlist.ts
+++ b/types/wishlist.ts
@@ -1,0 +1,6 @@
+import type { WishlistItem as PrismaWishlistItem } from '@prisma/client';
+import type { Product } from './product';
+
+export interface WishlistItem extends PrismaWishlistItem {
+  product: Product;
+}


### PR DESCRIPTION
## Summary
- persist wishlist items in database
- add API endpoints under `/api/user/wishlist`
- send email when a saved product comes back in stock
- show wishlist with stock toggle and heart buttons
- support notifications when restocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e292ca958832f8cb89f6b14710994