### PR TITLE
Implement order tracking and reorder APIs

### DIFF
--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -50,7 +50,7 @@ export async function addOrder({
   userEmail,
   items,
   total,
-  status = 'pending',
+  status = 'processing',
   paymentMethod,
   paymentReference,
   paymentProof,

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -39,9 +39,10 @@ export default function AdminOrders() {
           onChange={(e) => setStatus(e.target.value)}
         >
           <option value="">All Status</option>
-          <option value="pending">Pending</option>
+          <option value="processing">Processing</option>
           <option value="shipped">Shipped</option>
-          <option value="completed">Completed</option>
+          <option value="delivered">Delivered</option>
+          <option value="cancelled">Cancelled</option>
         </select>
         <input
           className="input input-bordered flex-1"

--- a/pages/api/brand/earnings.ts
+++ b/pages/api/brand/earnings.ts
@@ -24,7 +24,7 @@ export default async function handler(
     const orders = await getOrdersForVendorId(brandId);
     const totalEarned = orders.reduce((s, o) => s + (o.total || 0), 0);
     const pending = orders
-      .filter((o) => o.status !== 'completed')
+      .filter((o) => o.status !== 'delivered')
       .reduce((s, o) => s + (o.total || 0), 0);
     const data: EarningsData = {
       totalEarned,

--- a/pages/api/checkout/complete.ts
+++ b/pages/api/checkout/complete.ts
@@ -29,7 +29,7 @@ export default async function handler(
       userEmail: metadata.email,
       items: JSON.parse(metadata.items || '[]'),
       total: (session.amount_total ?? 0) / 100,
-      status: 'completed',
+      status: 'processing',
     });
     const orderId =
       Array.isArray(orders) && orders.length > 0 ? orders[0].id : '';

--- a/pages/api/dashboard/orders-this-month.ts
+++ b/pages/api/dashboard/orders-this-month.ts
@@ -34,7 +34,7 @@ async function handler(
     const end = dayjs(start).endOf('month').toDate();
     const where: any = {
       createdAt: { gte: start, lte: end },
-      status: 'completed',
+      status: 'delivered',
     };
     if (vendorId) where.product = { vendorId };
     const count = await db.order.count({ where });

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -23,7 +23,7 @@ async function handler(
       return res.status(401).json({ message: 'Unauthorized' });
     }
     const monthOffset = getQueryParam(req.query.monthOffset);
-    const where: any = { status: 'completed' };
+    const where: any = { status: 'delivered' };
     if (
       monthOffset !== null &&
       monthOffset !== undefined &&

--- a/pages/api/dashboard/weekly-summary.ts
+++ b/pages/api/dashboard/weekly-summary.ts
@@ -24,7 +24,7 @@ async function handler(
       return res.status(401).json({ message: 'Unauthorized' });
     }
     const start = dayjs().subtract(7, 'day').startOf('day').toDate();
-    const where: any = { createdAt: { gte: start }, status: 'completed' };
+    const where: any = { createdAt: { gte: start }, status: 'delivered' };
     if (vendorId) where.product = { vendorId };
     const count = await db.order.count({ where });
     const result = await db.order.aggregate({ where, _sum: { total: true } });

--- a/pages/api/orders/[uuid].ts
+++ b/pages/api/orders/[uuid].ts
@@ -25,7 +25,10 @@ async function handler(
 
     if (req.method === 'PATCH') {
       const { status } = req.body || {};
-      if (!status || !['pending', 'shipped', 'completed'].includes(status)) {
+      if (
+        !status ||
+        !['processing', 'shipped', 'delivered', 'cancelled'].includes(status)
+      ) {
         return res.status(400).json({ message: 'invalid status' });
       }
       await updateOrderStatus(String(uuid), status);

--- a/pages/api/payments/charge.ts
+++ b/pages/api/payments/charge.ts
@@ -36,7 +36,7 @@ export default async function handler(
     if (charge.status === 'succeeded') {
       await db.order.update({
         where: { id: Number(orderId) },
-        data: { status: 'completed' },
+        data: { status: 'processing' },
       });
     }
     return res.status(200).json(charge);

--- a/pages/api/user/orders/[uuid].ts
+++ b/pages/api/user/orders/[uuid].ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { getOrderByUuid } from '../../../../lib/orders';
+import { handleApiError } from '../../../../lib/utils/handleApiError';
+import type { Order, ApiMessage } from '../../../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Order | ApiMessage>
+): Promise<void> {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const uuid = Array.isArray(req.query.uuid) ? req.query.uuid[0] : req.query.uuid;
+    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    const order = await getOrderByUuid(String(uuid));
+    if (!order || order.userEmail !== session.user.email) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+    return res.status(200).json(order);
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to get order');
+  }
+}

--- a/pages/api/user/orders/[uuid]/reorder.ts
+++ b/pages/api/user/orders/[uuid]/reorder.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]';
+import { getOrderByUuid } from '../../../../../lib/orders';
+import { getProductByUuid, getCart, setCart } from '../../../../../lib/db';
+import { handleApiError } from '../../../../../lib/utils/handleApiError';
+import type { ApiMessage } from '../../../../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'POST') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
+
+    const uuid = Array.isArray(req.query.uuid) ? req.query.uuid[0] : req.query.uuid;
+    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+
+    const order = await getOrderByUuid(String(uuid));
+    if (!order || order.userEmail !== session.user.email) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+
+    const product = await getProductByUuid(order.product.uuid);
+    if (!product) return res.status(404).json({ message: 'Product not found' });
+
+    const qty = Math.min(product.quantity || 0, order.quantity);
+    if (qty <= 0) return res.status(409).json({ message: 'Out of stock' });
+
+    const cart = getCart(session.user.email);
+    const existing = cart.find((c) => c.id === product.id);
+    if (existing) existing.qty += qty; else cart.push({ ...product, qty });
+    setCart(session.user.email, cart);
+
+    return res.status(200).json({ message: 'added to cart' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to reorder');
+  }
+}

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -91,11 +91,13 @@ const Orders: React.FC<OrdersProps> = (_props) => {
                   <td>
                     <span
                       className={`badge ${
-                        o.status === 'pending'
+                        o.status === 'processing'
                           ? 'badge-warning'
                           : o.status === 'shipped'
-                            ? 'badge-info'
-                            : 'badge-success'
+                          ? 'badge-info'
+                          : o.status === 'delivered'
+                          ? 'badge-success'
+                          : 'badge-error'
                       }`}
                     >
                       {o.status}

--- a/pages/user/orders.tsx
+++ b/pages/user/orders.tsx
@@ -42,7 +42,20 @@ const UserOrders: React.FC = () => {
         {orders.map((o) => (
           <li key={o.id} className="border p-2">
             <p>
-              Order #{o.id} - {o.status}
+              Order #{o.id} -
+              <span
+                className={`badge ml-2 ${
+                  o.status === 'processing'
+                    ? 'badge-warning'
+                    : o.status === 'shipped'
+                    ? 'badge-info'
+                    : o.status === 'delivered'
+                    ? 'badge-success'
+                    : 'badge-error'
+                }`}
+              >
+                {o.status}
+              </span>
             </p>
             <ul className="list-disc pl-4 text-sm mb-1">
               <li>
@@ -50,10 +63,21 @@ const UserOrders: React.FC = () => {
               </li>
             </ul>
             <p>Total: £{o.total}</p>
-            <p>
+            <p className="space-x-2">
+              <a className="btn btn-sm" href={`/user/orders/${o.uuid}`}>View</a>
               <a className="link" href={`/api/orders/${o.uuid}/invoice`}>
-                Download Invoice
+                Invoice
               </a>
+              <button
+                className="btn btn-sm"
+                onClick={() =>
+                  fetch(`/api/user/orders/${o.uuid}/reorder`, {
+                    method: 'POST',
+                  }).then(() => window.location.assign('/cart'))
+                }
+              >
+                Reorder
+              </button>
             </p>
           </li>
         ))}

--- a/pages/user/orders/[uuid].tsx
+++ b/pages/user/orders/[uuid].tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import type { Order } from '../../../types';
+import Head from 'next/head';
+import { getPageTitle } from '../../../lib/pageTitle';
+
+export default function UserOrderDetail() {
+  const router = useRouter();
+  const { uuid } = router.query;
+  const [order, setOrder] = useState<Order | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!uuid) return;
+    fetch(`/api/user/orders/${uuid}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((d) => {
+        setOrder(d);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [uuid]);
+
+  if (loading) return <p className="p-4">Loading...</p>;
+  if (!order) return <p className="p-4">Order not found.</p>;
+
+  return (
+    <div className="max-w-xl mx-auto space-y-2">
+      <Head>
+        <title>{getPageTitle(`Order ${order.id}`)}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Order #{order.id}</h1>
+      <p>Status: {order.status}</p>
+      <p>Product: {order.product.title}</p>
+      <p>Quantity: {order.quantity}</p>
+      <p>Total: £{order.total}</p>
+      <button
+        className="btn btn-primary mt-4"
+        onClick={() =>
+          fetch(`/api/user/orders/${order.uuid}/reorder`, { method: 'POST' }).then(() =>
+            router.push('/cart')
+          )
+        }
+      >
+        Reorder
+      </button>
+    </div>
+  );
+}

--- a/pages/vendor/orders.tsx
+++ b/pages/vendor/orders.tsx
@@ -73,7 +73,7 @@ export default function VendorOrders() {
               value={o.status}
               onChange={(e) => updateStatus(o.id, e.target.value)}
             >
-              {['pending', 'shipped', 'completed'].map((s) => (
+              {['processing', 'shipped', 'delivered', 'cancelled'].map((s) => (
                 <option key={s} value={s}>
                   {s}
                 </option>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,7 +100,7 @@ model Order {
   productId        Int
   quantity         Int
   total            Float
-  status           String   @default("pending")
+  status           String   @default("processing")
   paymentMethod    String?
   paymentReference String?
   paymentProof     String?

--- a/types/order.ts
+++ b/types/order.ts
@@ -2,9 +2,17 @@ import type { Order as PrismaOrder } from '@prisma/client';
 import type { User } from './user';
 import type { Product } from './product';
 
+export enum OrderStatus {
+  PROCESSING = 'processing',
+  SHIPPED = 'shipped',
+  DELIVERED = 'delivered',
+  CANCELLED = 'cancelled',
+}
+
 export interface Order extends PrismaOrder {
   user: User;
   product: Product;
+  status: OrderStatus;
   paymentMethod?: string | null;
   paymentReference?: string | null;
   paymentProof?: string | null;
@@ -20,4 +28,5 @@ export type OrderInput = Pick<
 export interface OrderRow extends PrismaOrder {
   user?: User | null;
   product?: Product | null;
+  status: OrderStatus;
 }


### PR DESCRIPTION
## Summary
- add OrderStatus enum and use in order type
- support new status flow in orders API and Prisma schema
- add reorder endpoint and user order detail API
- allow reorder from user order history page
- update status handling across dashboard APIs and pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e303d8cbc832fb3e650d1810965c5