### PR TITLE
Fix brand dashboard product fetch

### DIFF
--- a/components/dashboard/ExistingProductsCard.tsx
+++ b/components/dashboard/ExistingProductsCard.tsx
@@ -19,7 +19,9 @@ const ExistingProductsCard: React.FC<Props> = ({ previewCount = 3 }) => {
     setError('');
     async function load() {
       try {
-        const res = await fetch('/api/brand/products');
+        const res = await fetch('/api/brand/products', {
+          credentials: 'include',
+        });
         if (res.ok) {
           const data: { products: Product[]; total: number } = await res.json();
           setProducts(data.products);

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -56,16 +56,21 @@ async function handler(
       const limit = parseInt(String((req.query.limit as string) || '20'), 10);
       const skip = (page - 1) * limit;
 
-      const brandId = (session.user as { brandId?: number }).brandId;
+      const vendorId = (session.user as { brandId?: number }).brandId;
+      if (!vendorId) {
+        console.warn('Missing brandId for brand user', session.user);
+        return res.status(400).json({ message: 'Invalid session data' });
+      }
+
       const [rows, total] = await Promise.all([
         db.product.findMany({
-          where: { brandId: session.user.brandId },
+          where: { vendorId },
           include: { category: true, vendor: true },
           orderBy: { id: 'asc' },
           take: limit,
           skip,
         }),
-        db.product.count({ where: { brandId: session.user.brandId } }),
+        db.product.count({ where: { vendorId } }),
       ]);
 
       const products = rows.map((row: any) => mapDbRowToProduct(row));

--- a/pages/brand/products/index.tsx
+++ b/pages/brand/products/index.tsx
@@ -11,15 +11,18 @@ const BrandProductsPage: React.FC = () => {
   const [products, setProducts] = useState<Product[]>([]);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     if (!user) return;
     setLoading(true);
-    fetch('/api/brand/products')
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
+    setError('');
+    fetch('/api/brand/products', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : Promise.reject(res)))
       .then((data: { products: Product[]; total: number }) =>
         setProducts(data.products)
       )
+      .catch(() => setError('Failed to load products'))
       .finally(() => setLoading(false));
   }, [user]);
 
@@ -60,6 +63,8 @@ const BrandProductsPage: React.FC = () => {
         <div className="flex justify-center my-4">
           <span className="loading loading-spinner"></span>
         </div>
+      ) : error ? (
+        <div className="text-error py-4">{error}</div>
       ) : (
         <ul className="space-y-1">
           {filtered.map((p) => (

--- a/pages/brand/products/new.tsx
+++ b/pages/brand/products/new.tsx
@@ -28,6 +28,7 @@ const NewProductPage: React.FC = () => {
     try {
       const res = await fetch('/api/brand/products', {
         method: 'POST',
+        credentials: 'include',
         body: values,
       });
       if (res.ok) {


### PR DESCRIPTION
## Summary
- make brand product API look up `vendorId` from session
- handle invalid session state on the API
- ensure brand dashboard components use credentials and show errors

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3358a288832fbcdf776a77c3399d