### PR TITLE
Implement basic admin analytics filters and low-stock API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,4 @@ BROWSERLESS_API_TOKEN=
 # Toggle use of dummy data for development
 NEXT_PUBLIC_USE_DUMMY_DATA=true
 
+DEFAULT_LOW_STOCK_THRESHOLD=5

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_LOW_STOCK_THRESHOLD = parseInt(
+  process.env.DEFAULT_LOW_STOCK_THRESHOLD || '5',
+  10
+);

--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from 'react';
 import { AppContext } from '../../contexts/AppContext';
 import Link from 'next/link';
-import { AnalyticsData } from '../../types';
+import { AnalyticsData, LowStockProduct } from '../../types';
 import { fetchJson } from '../../lib/utils/fetchJson';
 import Head from 'next/head';
 import { getPageTitle } from '../../lib/pageTitle';
@@ -11,16 +11,31 @@ export default function AdminAnalytics() {
   const { user } = useContext(AppContext)!;
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [lowStock, setLowStock] = useState<LowStockProduct[]>([]);
 
-  useEffect(() => {
+  const load = () => {
     if (!user) return;
     setLoading(true);
-    fetchJson<AnalyticsData>('/api/admin/analytics')
+    const params = new URLSearchParams();
+    if (start) params.set('start', start);
+    if (end) params.set('end', end);
+    fetchJson<AnalyticsData>(
+      '/api/admin/analytics' + (params.toString() ? `?${params}` : '')
+    )
       .then((res) => setData(res))
       .catch(() =>
         setData({ totalOrders: 0, totalRevenue: 0, topProducts: [] })
       )
       .finally(() => setLoading(false));
+    fetchJson<{ products: LowStockProduct[] }>('/api/admin/low-stock')
+      .then((res) => setLowStock(res.products))
+      .catch(() => setLowStock([]));
+  };
+
+  useEffect(() => {
+    load();
   }, [user]);
 
   if (!user) return <div className="p-4">Please log in to view analytics.</div>;
@@ -49,6 +64,29 @@ export default function AdminAnalytics() {
           Search Logs
         </Link>
       </div>
+      <form
+        className="flex flex-wrap gap-2 mb-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          load();
+        }}
+      >
+        <input
+          type="date"
+          value={start}
+          onChange={(e) => setStart(e.target.value)}
+          className="input input-sm input-bordered"
+        />
+        <input
+          type="date"
+          value={end}
+          onChange={(e) => setEnd(e.target.value)}
+          className="input input-sm input-bordered"
+        />
+        <button type="submit" className="btn btn-sm btn-primary">
+          Apply
+        </button>
+      </form>
       <p>Total Orders: {data.totalOrders}</p>
       <p>Total Revenue: £{data.totalRevenue.toFixed(2)}</p>
       <h2 className="text-xl font-semibold mt-4 mb-2">Top Products</h2>
@@ -65,6 +103,18 @@ export default function AdminAnalytics() {
           data={data.topProducts.map((p) => ({ label: p.id, value: p.qty }))}
         />
       </div>
+      {lowStock.length > 0 && (
+        <div className="mt-6">
+          <h2 className="text-xl font-semibold mb-2">Low Stock Products</h2>
+          <ul className="list-disc list-inside text-rose-600">
+            {lowStock.map((p) => (
+              <li key={p.id}>
+                {p.title} - {p.quantity} left
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/pages/api/admin/analytics.ts
+++ b/pages/api/admin/analytics.ts
@@ -1,8 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getAllOrders } from '../../../lib/orders';
 import { withRole } from '../../../lib/withRole';
 import { handleApiError } from '../../../lib/utils/handleApiError';
-import { AnalyticsData, ApiMessage, Order } from '../../../types';
+import { AnalyticsData, ApiMessage } from '../../../types';
+import { getDb } from '../../../lib/db';
+import { getQueryParam } from '../../../lib/utils/getQueryParam';
 
 async function handler(
   req: NextApiRequest,
@@ -13,21 +14,50 @@ async function handler(
     return;
   }
   try {
-    const orders: Order[] = await getAllOrders();
-    const summary: AnalyticsData = {
-      totalOrders: orders.length,
-      totalRevenue: 0,
-      topProducts: [],
-    };
-    const counts: Record<string, number> = {};
-    for (const o of orders) {
-      summary.totalRevenue += o.total ?? 0;
-      counts[o.product.id] = (counts[o.product.id] ?? 0) + o.quantity;
+    const db = getDb();
+    const startParam = getQueryParam(req.query.start);
+    const endParam = getQueryParam(req.query.end);
+    const brandIdParam = getQueryParam(req.query.brandId);
+    const categoryParam = getQueryParam(req.query.categoryId);
+    const where: any = {};
+    if (startParam || endParam) {
+      const start = startParam ? new Date(startParam) : new Date(0);
+      const end = endParam ? new Date(endParam) : new Date();
+      where.createdAt = { gte: start, lte: end };
     }
-    summary.topProducts = Object.entries(counts)
-      .sort(([, a], [, b]) => b - a)
-      .slice(0, 5)
-      .map(([id, qty]): { id: string; qty: number } => ({ id, qty }));
+    if (brandIdParam) {
+      const id = parseInt(brandIdParam, 10);
+      if (!isNaN(id)) where.product = { ...(where.product || {}), vendorId: id };
+    }
+    if (categoryParam) {
+      const cid = parseInt(categoryParam, 10);
+      if (!isNaN(cid))
+        where.product = { ...(where.product || {}), categoryId: cid };
+    }
+
+    const totalOrders = await db.order.count({ where });
+    const revenueAgg = await db.order.aggregate({ where, _sum: { total: true } });
+    const grouped = await db.order.groupBy({
+      by: ['productId'],
+      where,
+      _sum: { quantity: true },
+      orderBy: { _sum: { quantity: 'desc' } },
+      take: 5,
+    });
+    const ids = grouped.map((g) => g.productId);
+    const products = await db.product.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, title: true },
+    });
+    const titles = new Map(products.map((p) => [p.id, p.title]));
+    const summary: AnalyticsData = {
+      totalOrders,
+      totalRevenue: revenueAgg._sum.total ?? 0,
+      topProducts: grouped.map((g) => ({
+        id: String(titles.get(g.productId) ?? g.productId),
+        qty: g._sum.quantity || 0,
+      })),
+    };
     res.status(200).json(summary);
   } catch (error) {
     handleApiError(res, error, 'Failed to load analytics');

--- a/pages/api/admin/low-stock.ts
+++ b/pages/api/admin/low-stock.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDb } from '../../../lib/db';
+import { withRole } from '../../../lib/withRole';
+import { handleApiError } from '../../../lib/utils/handleApiError';
+import type { ApiMessage, LowStockProduct } from '../../../types';
+import { DEFAULT_LOW_STOCK_THRESHOLD } from '../../../lib/config';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ products: LowStockProduct[] } | ApiMessage>
+): Promise<void> {
+  if (req.method !== 'GET') {
+    res.status(405).json({ message: 'Method Not Allowed' });
+    return;
+  }
+  try {
+    const db = getDb();
+    const param = parseInt(String(req.query.threshold || ''), 10);
+    const threshold = Number.isNaN(param) ? DEFAULT_LOW_STOCK_THRESHOLD : param;
+    const rows = await db.product.findMany({
+      select: { id: true, title: true, quantity: true, lowStockThreshold: true },
+    });
+    const products = rows
+      .filter((p) => p.quantity < (p.lowStockThreshold ?? threshold))
+      .map((p) => ({
+        id: String(p.id),
+        title: p.title,
+        quantity: p.quantity,
+      }));
+    res.status(200).json({ products });
+  } catch (error) {
+    handleApiError(res, error, 'Failed to load low stock products');
+  }
+}
+
+export default withRole(['SUPER_ADMIN'])(handler);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,7 @@ model Product {
   productType   String
   tags          String?
   quantity      Int      @default(0)
+  lowStockThreshold Int? @default(5)
   minPrice      Float    @default(0)
   maxPrice      Float    @default(0)
   currency      String   @default("USD")

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -52,3 +52,9 @@ export interface AnalyticsData {
   totalRevenue: number;
   topProducts: { id: string; qty: number }[];
 }
+
+export interface LowStockProduct {
+  id: string;
+  title: string;
+  quantity: number;
+}


### PR DESCRIPTION
## Summary
- add config constant for low stock threshold
- expose DEFAULT_LOW_STOCK_THRESHOLD in env example
- store optional `lowStockThreshold` per product
- extend admin analytics API with filtering
- add new API to list low stock products
- enhance admin analytics page with date range filters and low stock list

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685e3498b748832f8f7900ff201e0123