### PR TITLE
Add success toast for add-to-cart

### DIFF
--- a/components/UI/Toast.tsx
+++ b/components/UI/Toast.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export interface ToastProps {
+  message: React.ReactNode;
+  type?: 'info' | 'success' | 'warning' | 'error';
+  onClose: () => void;
+}
+
+const Toast: React.FC<ToastProps> = ({ message, type = 'info', onClose }) => (
+  <div
+    role="alert"
+    aria-live="assertive"
+    className={`alert alert-${type} shadow-md relative`}
+  >
+    {message}
+    <button type="button" className="absolute right-2 top-1" onClick={onClose}>
+      ✕
+    </button>
+  </div>
+);
+
+export default Toast;

--- a/components/UI/index.ts
+++ b/components/UI/index.ts
@@ -1,3 +1,4 @@
 export { default as InputField } from './InputField';
 export { default as GenericInput } from './GenericInput';
 export { default as GenericModal } from '../Modals/GenericModal';
+export { default as Toast } from './Toast';

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -23,7 +23,9 @@ export function AppProvider({ children }: AppProviderProps) {
   const { data: session } = useSession();
   const [user, setUser] = useState<UserInfo | null>(null);
   const [wishlist, setWishlist] = useState<WishlistItem[]>([]);
-  const [cart, setCart] = useState<(Product & { qty: number; variant?: Variant })[]>([]);
+  const [cart, setCart] = useState<
+    (Product & { qty: number; variant?: Variant })[]
+  >([]);
   const { addNotification } = useContext(NotificationContext);
 
   useEffect(() => {
@@ -165,9 +167,9 @@ export function AppProvider({ children }: AppProviderProps) {
       return [...prev, { ...product, qty, variant }];
     });
     addNotification(
-      `Added ${product.title} (x${qty}) to cart`,
+      `✅ ${product.title} added to cart!`,
       'success',
-      'center'
+      'top-right'
     );
   };
 
@@ -186,7 +188,8 @@ export function AppProvider({ children }: AppProviderProps) {
   const removeFromCart = (id: string, variantId?: number) => {
     setCart((prev) =>
       prev.filter(
-        (item) => !(item.id === id && (!variantId || item.variant?.id === variantId))
+        (item) =>
+          !(item.id === id && (!variantId || item.variant?.id === variantId))
       )
     );
     addNotification('Removed from cart', 'info');
@@ -228,7 +231,9 @@ export function AppProvider({ children }: AppProviderProps) {
   const removeFromWishlist = (productId: string | number) => {
     const item = wishlist.find((w) => w.product.id === productId);
     if (item && user) {
-      fetch(`/api/user/wishlist/${item.id}`, { method: 'DELETE' }).catch(() => {});
+      fetch(`/api/user/wishlist/${item.id}`, { method: 'DELETE' }).catch(
+        () => {}
+      );
     }
     setWishlist((prev) => prev.filter((w) => w.product.id !== productId));
     addNotification('Removed from wishlist', 'warning');

--- a/contexts/NotificationContext.tsx
+++ b/contexts/NotificationContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useState, useCallback, ReactNode } from 'react';
+import { Toast } from '@/components/UI';
 
 type NotificationType = 'info' | 'success' | 'warning' | 'error';
 type NotificationPosition = 'center' | 'end' | string;
@@ -56,38 +57,38 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
           {notifs
             .filter((n) => n.position === 'center')
             .map((n) => (
-              <div
+              <Toast
                 key={n.id}
-                className={`alert alert-${n.type} shadow-md relative`}
-              >
-                {n.message}
-                <button
-                  type="button"
-                  className="absolute right-2 top-1"
-                  onClick={() => removeNotification(n.id)}
-                >
-                  ✕
-                </button>
-              </div>
+                message={n.message}
+                type={n.type}
+                onClose={() => removeNotification(n.id)}
+              />
+            ))}
+        </div>
+        <div className="absolute right-5 top-5 space-y-2">
+          {notifs
+            .filter((n) => n.position === 'top-right')
+            .map((n) => (
+              <Toast
+                key={n.id}
+                message={n.message}
+                type={n.type}
+                onClose={() => removeNotification(n.id)}
+              />
             ))}
         </div>
         <div className="absolute right-5 bottom-5 space-y-2">
           {notifs
-            .filter((n) => n.position !== 'center')
+            .filter(
+              (n) => n.position !== 'center' && n.position !== 'top-right'
+            )
             .map((n) => (
-              <div
+              <Toast
                 key={n.id}
-                className={`alert alert-${n.type} shadow-md relative`}
-              >
-                {n.message}
-                <button
-                  type="button"
-                  className="absolute right-2 top-1"
-                  onClick={() => removeNotification(n.id)}
-                >
-                  ✕
-                </button>
-              </div>
+                message={n.message}
+                type={n.type}
+                onClose={() => removeNotification(n.id)}
+              />
             ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- create reusable `Toast` component
- export `Toast` from UI index
- support `top-right` toasts in `NotificationProvider`
- show success toast in `addToCart`

## Testing
- `npx jest` *(fails: Need to install jest)*
- `npm install` *(failed: blocked by binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_685e354955e4832fad86eb763d894dec