### PR TITLE
Add mini cart hover with alerts

### DIFF
--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -16,6 +16,7 @@ import FashionIcon from '../icons/FashionIcon';
 import HomeIcon from '../icons/HomeIcon';
 import ToysIcon from '../icons/ToysIcon';
 import SportsIcon from '../icons/SportsIcon';
+import XCircleIcon from '../icons/XCircleIcon';
 import DEFAULT_CATEGORIES from '../../lib/defaultCategories';
 import SearchBar from './SearchBar';
 import type { Category } from '../../types/category';
@@ -246,7 +247,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
         </div>
 
         <nav className="flex items-center gap-2">
-          <div className="dropdown dropdown-end">
+          <div className="dropdown dropdown-end dropdown-hover">
             <label
               tabIndex={0}
               className="relative p-2 cursor-pointer transition-colors transition-transform duration-200 hover:text-white hover:scale-105"
@@ -260,22 +261,56 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
             </label>
             <div
               tabIndex={0}
-              className="dropdown-content card card-compact w-64 bg-base-100 shadow z-50"
+              className="dropdown-content card card-compact w-80 bg-base-100 shadow z-50"
             >
               <div className="card-body">
                 {cart.length === 0 ? (
                   <p className="text-sm">Your cart is empty</p>
                 ) : (
                   <>
-                    <ul className="space-y-1 max-h-40 overflow-y-auto text-sm">
+                    <ul className="space-y-2 max-h-40 overflow-y-auto text-sm">
                       {cart.map((item) => {
-                        const price = parseFloat(typeof item.minPrice === 'number' ? item.minPrice.toString() : item.minPrice || '0');
+                        const price = parseFloat(
+                          typeof item.minPrice === 'number'
+                            ? item.minPrice.toString()
+                            : item.minPrice || '0'
+                        );
                         return (
-                          <li key={item.id} className="flex justify-between">
-                            <span>
-                              {item.title} x{item.qty}
-                            </span>
-                            <span>£{(price * item.qty).toFixed(2)}</span>
+                          <li key={item.id} className="flex items-center gap-2">
+                            <img
+                              src={item.featuredImage?.url || '/placeholder.png'}
+                              alt={item.title}
+                              className="w-10 h-10 object-cover rounded"
+                            />
+                            <div className="flex-1">
+                              <p className="font-medium truncate">{item.title}</p>
+                              <p className="text-xs">£{price.toFixed(2)}</p>
+                            </div>
+                            <div className="flex items-center gap-1">
+                              <button
+                                type="button"
+                                className="btn btn-xs"
+                                onClick={() => changeQty(item.id as string, -1, item.variant?.id)}
+                              >
+                                -
+                              </button>
+                              <span className="px-1">{item.qty}</span>
+                              <button
+                                type="button"
+                                className="btn btn-xs"
+                                onClick={() => changeQty(item.id as string, 1, item.variant?.id)}
+                              >
+                                +
+                              </button>
+                              <button
+                                type="button"
+                                className="btn btn-ghost btn-xs text-error"
+                                onClick={() => removeFromCart(item.id as string, item.variant?.id)}
+                              >
+                                <XCircleIcon className="w-4 h-4" />
+                                <span className="sr-only">Remove</span>
+                              </button>
+                            </div>
                           </li>
                         );
                       })}

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -183,6 +183,7 @@ export function AppProvider({ children }: AppProviderProps) {
         )
         .filter((item) => item.qty > 0);
     });
+    addNotification('✅ Quantity updated', 'success', 'top-left');
   };
 
   const removeFromCart = (id: string, variantId?: number) => {
@@ -192,7 +193,7 @@ export function AppProvider({ children }: AppProviderProps) {
           !(item.id === id && (!variantId || item.variant?.id === variantId))
       )
     );
-    addNotification('Removed from cart', 'info');
+    addNotification('❌ Product removed from cart', 'error', 'top-left');
   };
 
   const addToWishlist = (product: Product, notifyOnStock = false) => {

--- a/contexts/NotificationContext.tsx
+++ b/contexts/NotificationContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useState, useCallback, ReactNode } from 'react';
 import { Toast } from '@/components/UI';
 
 type NotificationType = 'info' | 'success' | 'warning' | 'error';
-type NotificationPosition = 'center' | 'end' | string;
+type NotificationPosition = 'center' | 'top-right' | 'top-left' | 'end' | string;
 
 interface Notification {
   id: number;
@@ -77,10 +77,25 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
               />
             ))}
         </div>
+        <div className="absolute left-5 top-5 space-y-2">
+          {notifs
+            .filter((n) => n.position === 'top-left')
+            .map((n) => (
+              <Toast
+                key={n.id}
+                message={n.message}
+                type={n.type}
+                onClose={() => removeNotification(n.id)}
+              />
+            ))}
+        </div>
         <div className="absolute right-5 bottom-5 space-y-2">
           {notifs
             .filter(
-              (n) => n.position !== 'center' && n.position !== 'top-right'
+              (n) =>
+                n.position !== 'center' &&
+                n.position !== 'top-right' &&
+                n.position !== 'top-left'
             )
             .map((n) => (
               <Toast


### PR DESCRIPTION
## Summary
- show toast alerts in a new top-left position
- notify on cart quantity changes and removals
- enhance header cart dropdown with hover preview and item controls

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e38224924832fb166c5cd49420333