### PR TITLE
Improve cart hover UI

### DIFF
--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -16,7 +16,7 @@ import FashionIcon from '../icons/FashionIcon';
 import HomeIcon from '../icons/HomeIcon';
 import ToysIcon from '../icons/ToysIcon';
 import SportsIcon from '../icons/SportsIcon';
-import XCircleIcon from '../icons/XCircleIcon';
+import TrashIcon from '../icons/TrashIcon';
 import DEFAULT_CATEGORIES from '../../lib/defaultCategories';
 import SearchBar from './SearchBar';
 import type { Category } from '../../types/category';
@@ -261,14 +261,14 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
             </label>
             <div
               tabIndex={0}
-              className="dropdown-content card card-compact w-80 bg-base-100 shadow z-50"
+              className="dropdown-content card card-compact w-80 sm:w-96 bg-base-100 shadow z-50"
             >
-              <div className="card-body">
+              <div className="card-body p-4">
                 {cart.length === 0 ? (
                   <p className="text-sm">Your cart is empty</p>
                 ) : (
-                  <>
-                    <ul className="space-y-2 max-h-40 overflow-y-auto text-sm">
+                  <div className="flex flex-col h-72">
+                    <ul className="flex-1 overflow-y-auto divide-y divide-base-200 text-sm">
                       {cart.map((item) => {
                         const price = parseFloat(
                           typeof item.minPrice === 'number'
@@ -276,13 +276,13 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                             : item.minPrice || '0'
                         );
                         return (
-                          <li key={item.id} className="flex items-center gap-2">
+                          <li key={item.id} className="flex items-center gap-2 py-2">
                             <img
                               src={item.featuredImage?.url || '/placeholder.png'}
                               alt={item.title}
-                              className="w-10 h-10 object-cover rounded"
+                              className="w-12 h-12 object-cover rounded"
                             />
-                            <div className="flex-1">
+                            <div className="flex flex-col flex-1">
                               <p className="font-medium truncate">{item.title}</p>
                               <p className="text-xs">£{price.toFixed(2)}</p>
                             </div>
@@ -302,26 +302,28 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                               >
                                 +
                               </button>
-                              <button
-                                type="button"
-                                className="btn btn-ghost btn-xs text-error"
-                                onClick={() => removeFromCart(item.id as string, item.variant?.id)}
-                              >
-                                <XCircleIcon className="w-4 h-4" />
-                                <span className="sr-only">Remove</span>
-                              </button>
                             </div>
+                            <button
+                              type="button"
+                              className="btn btn-ghost btn-xs text-error hover:text-red-600"
+                              onClick={() => removeFromCart(item.id as string, item.variant?.id)}
+                            >
+                              <TrashIcon className="w-4 h-4" />
+                              <span className="sr-only">Remove</span>
+                            </button>
                           </li>
                         );
                       })}
                     </ul>
-                    <p className="font-semibold mt-2">
-                      Total: £{cart.reduce((s, i) => s + i.qty * parseFloat(typeof i.minPrice === 'number' ? i.minPrice.toString() : i.minPrice || '0'), 0).toFixed(2)}
-                    </p>
-                    <Link href="/cart" className="btn btn-primary btn-sm mt-2">
-                      View Cart
-                    </Link>
-                  </>
+                    <div className="pt-2 mt-2 border-t">
+                      <p className="font-semibold">
+                        Total: £{cart.reduce((s, i) => s + i.qty * parseFloat(typeof i.minPrice === 'number' ? i.minPrice.toString() : i.minPrice || '0'), 0).toFixed(2)}
+                      </p>
+                      <Link href="/cart" className="btn btn-primary btn-sm w-full mt-2">
+                        View Cart
+                      </Link>
+                    </div>
+                  </div>
                 )}
               </div>
             </div>

--- a/components/icons/TrashIcon.tsx
+++ b/components/icons/TrashIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const TrashIcon: React.FC<IconProps> = ({
+  size = 24,
+  color = 'currentColor',
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+    />
+  </svg>
+);
+
+export default TrashIcon;


### PR DESCRIPTION
## Summary
- use new `<TrashIcon>` instead of X icon for cart item removal
- align cart dropdown items with flex layout and better spacing
- ensure cart dropdown fits small screens and view cart button anchors to bottom

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3b456480832fa321099080af290a