### PR TITLE
Enable path aliases

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,8 @@
 {
-  "extends": ["next/core-web-vitals", "prettier"]
+  "extends": ["next/core-web-vitals", "prettier"],
+  "settings": {
+    "import/resolver": {
+      "typescript": {}
+    }
+  }
 }

--- a/__tests__/Header.test.tsx
+++ b/__tests__/Header.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
-import Header from '../components/Layout/Header';
-import { AppContext } from '../contexts/AppContext';
+import Header from '@components/Layout/Header';
+import { AppContext } from '@contexts/AppContext';
 
 let mockPathname = '/';
 jest.mock('next/router', () => ({

--- a/__tests__/SelectDropdown.test.tsx
+++ b/__tests__/SelectDropdown.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import SelectDropdown, {
   SelectOption,
-} from '../components/form-fields/SelectDropdown';
+} from '@components/form-fields/SelectDropdown';
 
 const options: SelectOption[] = [
   { label: 'Apple', value: 'apple' },

--- a/__tests__/TagInput.test.tsx
+++ b/__tests__/TagInput.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
-import TagInput from '../components/form-fields/TagInput';
+import TagInput from '@components/form-fields/TagInput';
 
 interface FormValues {
   tags: string[];

--- a/__tests__/ThemeToggle.test.tsx
+++ b/__tests__/ThemeToggle.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import Layout from '../components/Layout/Layout';
-import { AppContext } from '../contexts/AppContext';
+import Layout from '@components/Layout/Layout';
+import { AppContext } from '@contexts/AppContext';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({ push: jest.fn(), pathname: '/' }),

--- a/__tests__/categories-check.api.test.ts
+++ b/__tests__/categories-check.api.test.ts
@@ -1,7 +1,7 @@
-import handler from '../pages/api/categories/check';
-import { getCategoriesFlat } from '../lib/products';
+import handler from '@pages/api/categories/check';
+import { getCategoriesFlat } from '@lib/products';
 
-jest.mock('../lib/products', () => ({
+jest.mock('@lib/products', () => ({
   getCategoriesFlat: jest.fn(),
 }));
 

--- a/__tests__/categories.api.test.ts
+++ b/__tests__/categories.api.test.ts
@@ -1,10 +1,10 @@
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
-jest.mock('../pages/api/auth/[...nextauth]', () => ({ authOptions: {} }));
+jest.mock('@pages/api/auth/[...nextauth]', () => ({ authOptions: {} }));
 
-import handler from '../pages/api/categories';
-import { getCategoryTree } from '../lib/products';
+import handler from '@pages/api/categories';
+import { getCategoryTree } from '@lib/products';
 
-jest.mock('../lib/products', () => ({
+jest.mock('@lib/products', () => ({
   getCategoryTree: jest.fn(),
 }));
 

--- a/__tests__/coupon.api.test.ts
+++ b/__tests__/coupon.api.test.ts
@@ -1,7 +1,7 @@
-import handler from '../pages/api/coupons/[code]';
-import { findCouponByCode } from '../lib/coupons';
+import handler from '@pages/api/coupons/[code]';
+import { findCouponByCode } from '@lib/coupons';
 
-jest.mock('../lib/coupons', () => ({
+jest.mock('@lib/coupons', () => ({
   findCouponByCode: jest.fn(),
 }));
 

--- a/__tests__/profile.ssr.test.ts
+++ b/__tests__/profile.ssr.test.ts
@@ -1,7 +1,7 @@
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
-jest.mock('../pages/api/auth/[...nextauth]', () => ({ authOptions: {} }));
+jest.mock('@pages/api/auth/[...nextauth]', () => ({ authOptions: {} }));
 
-import { getServerSideProps } from '../pages/profile';
+import { getServerSideProps } from '@pages/profile';
 import { getServerSession } from 'next-auth/next';
 
 const mockedGetServerSession = getServerSession as jest.Mock;

--- a/__tests__/useRequireAuth.test.tsx
+++ b/__tests__/useRequireAuth.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import useRequireAuth from '../hooks/useRequireAuth';
-import { AppContext } from '../contexts/AppContext';
+import useRequireAuth from '@hooks/useRequireAuth';
+import { AppContext } from '@contexts/AppContext';
 import { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
 

--- a/components/ActiveFilters.tsx
+++ b/components/ActiveFilters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ActiveFilter } from '../types/shared';
+import type { ActiveFilter } from '@types/shared';
 
 interface ActiveFiltersProps {
   filters: ActiveFilter[];

--- a/components/Category/CategoryCard.tsx
+++ b/components/Category/CategoryCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import type { Category } from '../../types';
-import CATEGORY_IMAGES from '../../lib/categoryImages';
+import CATEGORY_IMAGES from '@lib/categoryImages';
 
 interface CategoryCardProps {
   category: Category;

--- a/components/Category/CreateCategoryModal.tsx
+++ b/components/Category/CreateCategoryModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { GenericInput } from '../UI';
 import GenericModal from '../Modals/GenericModal';
-import { slugify } from '../../lib/slugify';
+import { slugify } from '@lib/slugify';
 
 interface CreateCategoryModalProps {
   isOpen: boolean;

--- a/components/InfiniteLoader.tsx
+++ b/components/InfiniteLoader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import type { InfiniteLoaderProps } from '../types/shared';
+import type { InfiniteLoaderProps } from '@types/shared';
 
 const InfiniteLoader: React.FC<InfiniteLoaderProps> = ({
   onLoadMore,

--- a/components/Layout/BrandHeader.tsx
+++ b/components/Layout/BrandHeader.tsx
@@ -4,12 +4,12 @@ import { useContext } from 'react';
 import { useRouter } from 'next/router';
 import { useSession, signOut } from 'next-auth/react';
 import type { FC } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import MoonIcon from '../icons/MoonIcon';
 import SunIcon from '../icons/SunIcon';
 import UserIcon from '../icons/UserIcon';
 import NotificationBell from './NotificationBell';
-import type { User } from '../../types/user';
+import type { User } from '@types/user';
 
 interface HeaderProps {
   theme?: string;

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useContext } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import { useSession } from 'next-auth/react';
 import UserHeader from './UserHeader';
 import BrandHeader from './BrandHeader';

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode, Dispatch, SetStateAction } from 'react';
-import useTheme, { Theme } from '../../hooks/useTheme';
+import useTheme, { Theme } from '@hooks/useTheme';
 import Header from './Header';
 import Footer from './Footer';
 

--- a/components/Layout/SearchBar.tsx
+++ b/components/Layout/SearchBar.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
 import SearchIcon from '../icons/SearchIcon';
-import type { TrendingResponse, SuggestionsResponse } from '../../types/api';
+import type { TrendingResponse, SuggestionsResponse } from '@types/api';
 
 interface SearchBarProps {
   placeholder?: string;

--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -4,7 +4,7 @@ import { useContext, useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { useSession, signOut } from 'next-auth/react';
 import type { FC } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import CartIcon from '../icons/CartIcon';
 import MoonIcon from '../icons/MoonIcon';
 import SunIcon from '../icons/SunIcon';
@@ -16,10 +16,10 @@ import FashionIcon from '../icons/FashionIcon';
 import HomeIcon from '../icons/HomeIcon';
 import ToysIcon from '../icons/ToysIcon';
 import SportsIcon from '../icons/SportsIcon';
-import DEFAULT_CATEGORIES from '../../lib/defaultCategories';
+import DEFAULT_CATEGORIES from '@lib/defaultCategories';
 import SearchBar from './SearchBar';
-import type { Category } from '../../types/category';
-import type { User } from '../../types/user';
+import type { Category } from '@types/category';
+import type { User } from '@types/user';
 
 interface HeaderProps {
   theme?: string;

--- a/components/Product/FeaturedProducts.tsx
+++ b/components/Product/FeaturedProducts.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import ProductCard from './ProductCard';
-import type { Product } from '../../types/product';
+import type { Product } from '@types/product';
 
 const FeaturedProducts: React.FC = () => {
   const [products, setProducts] = useState<Product[]>([]);

--- a/components/Product/ProductCard.tsx
+++ b/components/Product/ProductCard.tsx
@@ -1,10 +1,10 @@
 import React, { useContext } from 'react';
 import Link from 'next/link';
 import ProductImageSlider from './ProductImageSlider';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import type { AppContextValue } from '../../types';
-import type { Product } from '../../types/product';
-import { formatCurrency } from '../../lib/utils/formatCurrency';
+import type { Product } from '@types/product';
+import { formatCurrency } from '@utils/formatCurrency';
 
 interface ProductCardProps {
   product: Product;

--- a/components/Product/ProductFilters.tsx
+++ b/components/Product/ProductFilters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Category } from '../../types/category';
+import type { Category } from '@types/category';
 import InputField from '../UI/InputField';
 import { Checkbox } from '../form-fields';
 

--- a/components/Product/ProductForm.tsx
+++ b/components/Product/ProductForm.tsx
@@ -10,7 +10,7 @@ import {
   TagInput,
 } from '../form-fields';
 
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import type { ProductFormValues } from '../../types';
 
 interface ProductFormProps {

--- a/components/Product/ProductGrid.tsx
+++ b/components/Product/ProductGrid.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ProductCard from './ProductCard';
 import ProductCardSkeleton from './ProductCardSkeleton';
-import type { Product } from '../../types/product';
+import type { Product } from '@types/product';
 
 interface ProductGridProps {
   products: Product[];

--- a/components/Product/ProductImageSlider.tsx
+++ b/components/Product/ProductImageSlider.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
-import type { Image as ProductImage } from '../../types/image';
+import type { Image as ProductImage } from '@types/image';
 import ChevronLeftIcon from '../icons/ChevronLeftIcon';
 import ChevronRightIcon from '../icons/ChevronRightIcon';
 

--- a/components/Product/RecommendedProducts.tsx
+++ b/components/Product/RecommendedProducts.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ProductCard from './ProductCard';
-import { Product } from '../../types/product';
-import type { SearchResults } from '../../types/api';
+import { Product } from '@types/product';
+import type { SearchResults } from '@types/api';
 
 interface RecommendedProductsProps {
   category?: string;

--- a/components/dashboard/ExistingProductsCard.tsx
+++ b/components/dashboard/ExistingProductsCard.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import DashboardCard from './DashboardCard';
 import BoxIcon from '../icons/BoxIcon';
-import type { Product } from '../../types/product';
+import type { Product } from '@types/product';
 
 interface Props {
   previewCount?: number;

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -6,12 +6,12 @@ import {
 } from 'next-auth/react';
 import { NotificationContext } from './NotificationContext';
 
-import type { UserInfo } from '../lib/types';
+import type { UserInfo } from '@lib/types';
 import type { AppContextValue } from '../types';
-import { Product } from '../types/product';
-import { Variant } from '../types/variant';
-import type { ShippingInfo } from '../types/shipping';
-import type { WishlistItem } from '../types/wishlist';
+import { Product } from '@types/product';
+import { Variant } from '@types/variant';
+import type { ShippingInfo } from '@types/shipping';
+import type { WishlistItem } from '@types/wishlist';
 
 export const AppContext = createContext<AppContextValue | undefined>(undefined);
 

--- a/contexts/NotificationContext.tsx
+++ b/contexts/NotificationContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useState, useCallback, ReactNode } from 'react';
 // Update the import path below to the actual location of your Toast component.
 // For example, if Toast is in components/UI/Toast.tsx, use:
-import Toast from '../components/UI/Toast';
+import Toast from '@components/UI/Toast';
 // Or adjust the path as needed for your project structure.
 
 type NotificationType = 'info' | 'success' | 'warning' | 'error';

--- a/hooks/useRequireAuth.ts
+++ b/hooks/useRequireAuth.ts
@@ -1,8 +1,8 @@
 import { useRouter } from 'next/router';
 import { useContext, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
-import { AppContext } from '../contexts/AppContext';
-import type { User } from '../types/user';
+import { AppContext } from '@contexts/AppContext';
+import type { User } from '@types/user';
 
 export default function useRequireAuth() {
   const { user } = useContext(AppContext) as { user: User | null };

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,6 +1,6 @@
 import { prisma } from './prisma';
-import type { Product } from '../types/product';
-import type { Review } from '../types/review';
+import type { Product } from '@types/product';
+import type { Review } from '@types/review';
 
 const cartStore = new Map<string, (Product & { qty: number })[]>();
 const wishlistStore = new Map<string, Product[]>();

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,10 +1,10 @@
 import { JSDOM } from 'jsdom';
 import { getDb } from './db';
-import type { Product, ProductInput } from '../types/product';
-import type { Variant } from '../types/variant';
+import type { Product, ProductInput } from '@types/product';
+import type { Variant } from '@types/variant';
 import { parseImages } from './utils/parseImages';
-import type { Category } from '../types/category';
-import type { Vendor } from '../types/vendor';
+import type { Category } from '@types/category';
+import type { Vendor } from '@types/vendor';
 import { Prisma } from '@prisma/client';
 import client from './typesenseClient';
 import { getBestSellingProducts } from './orders';

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,6 +1,6 @@
 import { getDb } from './db';
 import type { Prisma, Role } from '@prisma/client';
-import type { UserInput } from '../types/user';
+import type { UserInput } from '@types/user';
 import bcrypt from 'bcryptjs';
 import { slugify } from './slugify';
 

--- a/lib/wishlist.ts
+++ b/lib/wishlist.ts
@@ -1,5 +1,5 @@
 import { prisma } from './prisma';
-import type { WishlistItem } from '../types/wishlist';
+import type { WishlistItem } from '@types/wishlist';
 
 export async function addWishlistItem(params: {
   userId: number;

--- a/lib/withRole.ts
+++ b/lib/withRole.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from 'next-auth/next';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import type { Session } from 'next-auth';
-import { authOptions } from '../pages/api/auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 
 export interface AuthedNextApiRequest extends NextApiRequest {
   user?: Session['user'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "eslint": "^8.56.0",
         "eslint-config-next": "14.2.3",
         "eslint-config-prettier": "^10.1.5",
+        "eslint-import-resolver-typescript": "^3.6.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
         "postcss": "^8.4.38",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "stripe": "^12.18.0",
     "swiper": "^11.2.8",
     "typesense": "^2.0.3",
-    "zod": "^3.22.4",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",
@@ -62,6 +62,7 @@
     "eslint": "^8.56.0",
     "eslint-config-next": "14.2.3",
     "eslint-config-prettier": "^10.1.5",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "postcss": "^8.4.38",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,8 @@
 import '../styles/globals.css';
-import { AppProvider } from '../contexts/AppContext';
-import Layout from '../components/Layout/Layout';
+import { AppProvider } from '@contexts/AppContext';
+import Layout from '@components/Layout/Layout';
 import { SessionProvider } from 'next-auth/react';
-import { NotificationProvider } from '../contexts/NotificationContext';
+import { NotificationProvider } from '@contexts/NotificationContext';
 
 import type { AppProps } from 'next/app';
 

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { getPageTitle } from '../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 const AboutPage: React.FC = () => {
   return (

--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -1,11 +1,11 @@
 import { useContext, useEffect, useState } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import Link from 'next/link';
 import { AnalyticsData, LowStockProduct } from '../../types';
-import { fetchJson } from '../../lib/utils/fetchJson';
+import { fetchJson } from '@utils/fetchJson';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
-import BarChart from '../../components/BarChart';
+import { getPageTitle } from '@lib/pageTitle';
+import BarChart from '@components/BarChart';
 
 export default function AdminAnalytics() {
   const { user } = useContext(AppContext)!;

--- a/pages/admin/approvals.tsx
+++ b/pages/admin/approvals.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import { PendingProduct, ApiMessage } from '../../types';
-import { fetchJson } from '../../lib/utils/fetchJson';
+import { fetchJson } from '@utils/fetchJson';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function Approvals() {
   const { user } = useContext(AppContext)!;

--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -1,11 +1,11 @@
 import { useContext, useEffect, useState, useCallback } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import { Category, CategoryInput, ApiMessage } from '../../types';
-import { fetchJson } from '../../lib/utils/fetchJson';
-import { TextInput } from '../../components/form-fields';
-import { slugify } from '../../lib/slugify';
+import { fetchJson } from '@utils/fetchJson';
+import { TextInput } from '@components/form-fields';
+import { slugify } from '@lib/slugify';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function Categories() {
   const { user } = useContext(AppContext)!;

--- a/pages/admin/coupons.tsx
+++ b/pages/admin/coupons.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, useContext, ChangeEvent } from 'react';
 import Head from 'next/head';
-import { AppContext } from '../../contexts/AppContext';
-import { TextInput } from '../../components/form-fields';
+import { AppContext } from '@contexts/AppContext';
+import { TextInput } from '@components/form-fields';
 import type { Coupon } from '../../types';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function AdminCoupons() {
   const { user } = useContext(AppContext)!;

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -6,12 +6,12 @@ import {
   ChangeEvent,
 } from 'react';
 import Link from 'next/link';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import { Product, ProductInput, ApiMessage } from '../../types';
-import { fetchJson } from '../../lib/utils/fetchJson';
-import { TextInput } from '../../components/form-fields';
+import { fetchJson } from '@utils/fetchJson';
+import { TextInput } from '@components/form-fields';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function Admin() {
   const { user } = useContext(AppContext)!;

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import type { Order } from '../../types';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function AdminOrders() {
   const { data: session } = useSession();

--- a/pages/admin/policies.tsx
+++ b/pages/admin/policies.tsx
@@ -1,9 +1,9 @@
 import { useContext, useEffect, useState } from 'react';
 import Head from 'next/head';
 import ReactMarkdown from 'react-markdown';
-import { AppContext } from '../../contexts/AppContext';
-import { fetchJson } from '../../lib/utils/fetchJson';
-import { getPageTitle } from '../../lib/pageTitle';
+import { AppContext } from '@contexts/AppContext';
+import { fetchJson } from '@utils/fetchJson';
+import { getPageTitle } from '@lib/pageTitle';
 
 const TYPES = [
   { value: 'terms', label: 'Terms & Conditions' },

--- a/pages/admin/search-analytics.tsx
+++ b/pages/admin/search-analytics.tsx
@@ -1,10 +1,10 @@
 import { useContext, useEffect, useState } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import Link from 'next/link';
 import { SearchAnalyticsResponse } from '../../types';
-import { fetchJson } from '../../lib/utils/fetchJson';
+import { fetchJson } from '@utils/fetchJson';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function SearchAnalytics() {
   const { user } = useContext(AppContext)!;

--- a/pages/admin/support.tsx
+++ b/pages/admin/support.tsx
@@ -1,8 +1,8 @@
 import { useContext, useEffect, useState } from 'react';
 import Head from 'next/head';
-import { AppContext } from '../../contexts/AppContext';
-import { fetchJson } from '../../lib/utils/fetchJson';
-import { getPageTitle } from '../../lib/pageTitle';
+import { AppContext } from '@contexts/AppContext';
+import { fetchJson } from '@utils/fetchJson';
+import { getPageTitle } from '@lib/pageTitle';
 import type { SupportTicket } from '../../types';
 
 export default function SupportTickets() {

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,14 +1,14 @@
 import { useContext, useEffect, useState, useCallback } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import {
   AdminUser,
   UserRoleUpdateRequest,
   UserDisabledUpdateRequest,
   ApiMessage,
 } from '../../types';
-import { fetchJson } from '../../lib/utils/fetchJson';
+import { fetchJson } from '@utils/fetchJson';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function ManageUsers() {
   const { user } = useContext(AppContext)!;

--- a/pages/api/address-autocomplete.ts
+++ b/pages/api/address-autocomplete.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/admin/analytics.ts
+++ b/pages/api/admin/analytics.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { withRole } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
 import { AnalyticsData, ApiMessage } from '../../../types';
-import { getDb } from '../../../lib/db';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getDb } from '@lib/db';
+import { getQueryParam } from '@utils/getQueryParam';
 
 async function handler(
   req: NextApiRequest,

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -4,11 +4,11 @@ import {
   createCategory,
   renameCategory,
   removeCategory,
-} from '../../../lib/products';
-import { withRole } from '../../../lib/withRole';
-import { logAudit } from '../../../lib/audit';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+} from '@lib/products';
+import { withRole } from '@lib/withRole';
+import { logAudit } from '@lib/audit';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import { Category, CategoryInput, ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/admin/coupons.ts
+++ b/pages/api/admin/coupons.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { withRole } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { createCoupon, listCoupons, updateCoupon } from '../../../lib/coupons';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { createCoupon, listCoupons, updateCoupon } from '@lib/coupons';
 import type { Coupon, ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/admin/low-stock.ts
+++ b/pages/api/admin/low-stock.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getDb } from '../../../lib/db';
-import { withRole } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getDb } from '@lib/db';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage, LowStockProduct } from '../../../types';
-import { DEFAULT_LOW_STOCK_THRESHOLD } from '../../../lib/config';
+import { DEFAULT_LOW_STOCK_THRESHOLD } from '@lib/config';
 
 async function handler(
   req: NextApiRequest,

--- a/pages/api/admin/orders.ts
+++ b/pages/api/admin/orders.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getAllOrdersFiltered, updateOrderStatus } from '../../../lib/orders';
-import { withRole } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getAllOrdersFiltered, updateOrderStatus } from '@lib/orders';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/admin/policies.ts
+++ b/pages/api/admin/policies.ts
@@ -1,7 +1,7 @@
 import type { NextApiResponse } from 'next';
-import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
-import { getDb } from '../../../lib/db';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { withRole, AuthedNextApiRequest } from '@lib/withRole';
+import { getDb } from '@lib/db';
+import { handleApiError } from '@utils/handleApiError';
 
 async function handler(req: AuthedNextApiRequest, res: NextApiResponse) {
   try {

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -1,15 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getDb } from '../../../lib/db';
-import { hasOrdersForProduct } from '../../../lib/orders';
+import { getDb } from '@lib/db';
+import { hasOrdersForProduct } from '@lib/orders';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import fs from 'fs';
 import path from 'path';
-import { withRole } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
-import { slugify } from '../../../lib/slugify';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
+import { slugify } from '@lib/slugify';
 import { Product, ApiMessage, Variant } from '../../../types';
-import { mapDbRowToProduct } from '../../../lib/products';
+import { mapDbRowToProduct } from '@lib/products';
 
 export const config = {
   api: {

--- a/pages/api/admin/search-analytics.ts
+++ b/pages/api/admin/search-analytics.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { SearchAnalyticsResponse, ApiMessage } from '../../../types';
-import { getDb } from '../../../lib/db';
-import { withRole } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getDb } from '@lib/db';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
 
 interface SearchLog {
   query: string;

--- a/pages/api/admin/support.ts
+++ b/pages/api/admin/support.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { withRole } from '../../../lib/withRole';
-import { getDb } from '../../../lib/db';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { withRole } from '@lib/withRole';
+import { getDb } from '@lib/db';
+import { handleApiError } from '@utils/handleApiError';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -5,11 +5,11 @@ import {
   deleteUser,
   addUser,
   setUserDisabled,
-} from '../../../lib/users';
+} from '@lib/users';
 import type { Role } from '@prisma/client';
-import { withRole } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import {
   AdminUser,
   UserRoleUpdateRequest,

--- a/pages/api/admin/vendor-products.ts
+++ b/pages/api/admin/vendor-products.ts
@@ -3,9 +3,9 @@ import {
   getPendingProducts,
   approveProduct,
   rejectProduct,
-} from '../../../lib/products';
-import { withRole } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+} from '@lib/products';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
 import { PendingProduct, ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -4,8 +4,8 @@ import GoogleProvider from 'next-auth/providers/google';
 import GitHubProvider from 'next-auth/providers/github';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import bcrypt from 'bcryptjs';
-import { findUser, addUser } from '../../../lib/users';
-import type { User as AppUser } from '../../../types/user';
+import { findUser, addUser } from '@lib/users';
+import type { User as AppUser } from '@types/user';
 
 // Extend the User type to include 'role'
 declare module 'next-auth' {

--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrdersForVendorId } from '../../../lib/orders';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getOrdersForVendorId } from '@lib/orders';
+import { handleApiError } from '@utils/handleApiError';
 import type { AnalyticsData, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getCategoriesFlat, createCategory } from '../../../lib/products';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getCategoriesFlat, createCategory } from '@lib/products';
+import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage, Category } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';

--- a/pages/api/brand/earnings.ts
+++ b/pages/api/brand/earnings.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrdersForVendorId } from '../../../lib/orders';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getOrdersForVendorId } from '@lib/orders';
+import { handleApiError } from '@utils/handleApiError';
 import type { EarningsData, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';

--- a/pages/api/brand/low-stock.ts
+++ b/pages/api/brand/low-stock.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { loadAndIndexProducts } from '../../../lib/products';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { loadAndIndexProducts } from '@lib/products';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { Product, ApiMessage } from '../../../types';
 
 export default async function handler(

--- a/pages/api/brand/notifications.ts
+++ b/pages/api/brand/notifications.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { getNotificationsForUser, markNotificationsRead } from '../../../lib/notifications';
-import { findUser } from '../../../lib/users';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getNotificationsForUser, markNotificationsRead } from '@lib/notifications';
+import { findUser } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
 import type { Notification, ApiMessage } from '../../../types';
 
 export default async function handler(

--- a/pages/api/brand/orders.ts
+++ b/pages/api/brand/orders.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrdersForVendorId } from '../../../lib/orders';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getOrdersForVendorId } from '@lib/orders';
+import { handleApiError } from '@utils/handleApiError';
 import type { Order, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -3,11 +3,11 @@ import {
   updateProduct,
   deleteProduct,
   loadAndIndexProducts,
-} from '../../../../lib/products';
-import { getProductByUuid } from '../../../../lib/db';
-import { hasOrdersForProduct } from '../../../../lib/orders';
-import { handleApiError } from '../../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../../lib/utils/getQueryParam';
+} from '@lib/products';
+import { getProductByUuid } from '@lib/db';
+import { hasOrdersForProduct } from '@lib/orders';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage, ProductInput } from '../../../../types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import fs from 'fs';

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -3,17 +3,17 @@ import {
   addProduct,
   loadAndIndexProducts,
   mapDbRowToProduct,
-} from '../../../../lib/products';
-import { handleApiError } from '../../../../lib/utils/handleApiError';
-import { slugify } from '../../../../lib/slugify';
+} from '@lib/products';
+import { handleApiError } from '@utils/handleApiError';
+import { slugify } from '@lib/slugify';
 import type { Product, ProductInput, ApiMessage } from '../../../../types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import fs from 'fs';
 import path from 'path';
-import { withRole, type AuthedNextApiRequest } from '../../../../lib/withRole';
+import { withRole, type AuthedNextApiRequest } from '@lib/withRole';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../../auth/[...nextauth]';
-import { getDb } from '../../../../lib/db';
+import { getDb } from '@lib/db';
 
 export const config = {
   api: {

--- a/pages/api/brand/profile.ts
+++ b/pages/api/brand/profile.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { updateUserProfile, findUser } from '../../../lib/users';
+import { updateUserProfile, findUser } from '@lib/users';
 import type { Vendor, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/brand/stripe-account.ts
+++ b/pages/api/brand/stripe-account.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { stripe } from '../../../lib/stripe';
-import { findUser, updateUserProfile } from '../../../lib/users';
+import { stripe } from '@lib/stripe';
+import { findUser, updateUserProfile } from '@lib/users';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/cart.ts
+++ b/pages/api/cart.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getCart, setCart } from '../../lib/db';
+import { getCart, setCart } from '@lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { CartItem, ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -4,8 +4,8 @@ import {
   getCategoriesPaginated,
   createCategory,
   getCategoriesFlat,
-} from '../../lib/products';
-import { handleApiError } from '../../lib/utils/handleApiError';
+} from '@lib/products';
+import { handleApiError } from '@utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import type {

--- a/pages/api/categories/check-or-create.ts
+++ b/pages/api/categories/check-or-create.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getCategoriesFlat, createCategory } from '../../../lib/products';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getCategoriesFlat, createCategory } from '@lib/products';
+import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage, Category } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';

--- a/pages/api/categories/check.ts
+++ b/pages/api/categories/check.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getCategoriesFlat } from '../../../lib/products';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getCategoriesFlat } from '@lib/products';
+import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage, Category } from '../../../types';
 
 interface CheckResponse {

--- a/pages/api/category-tree.ts
+++ b/pages/api/category-tree.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getCategoryTree } from '../../lib/products';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { getCategoryTree } from '@lib/products';
+import { handleApiError } from '@utils/handleApiError';
 import type { CategoriesResponse, ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/api/change-email.ts
+++ b/pages/api/change-email.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { changeEmail } from '../../lib/users';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { changeEmail } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import type { ApiMessage } from '../../types';

--- a/pages/api/check-email.ts
+++ b/pages/api/check-email.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { findUser } from '../../lib/users';
-import { handleApiError } from '../../lib/utils/handleApiError';
-import { getQueryParam } from '../../lib/utils/getQueryParam';
+import { findUser } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/api/checkout/complete.ts
+++ b/pages/api/checkout/complete.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
-import { addOrder } from '../../../lib/orders';
-import { sendOrderConfirmation } from '../../../lib/email';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { addOrder } from '@lib/orders';
+import { sendOrderConfirmation } from '@lib/email';
+import { handleApiError } from '@utils/handleApiError';
 import type { OrderIdResponse, ApiMessage } from '../../../types';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {

--- a/pages/api/checkout/create-session.ts
+++ b/pages/api/checkout/create-session.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
-import { getProductByUuid } from '../../../lib/db';
-import { findUserById } from '../../../lib/users';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { getProductByUuid } from '@lib/db';
+import { findUserById } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
 import type { CheckoutSessionResponse, ApiMessage } from '../../../types';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {

--- a/pages/api/coupons/[code].ts
+++ b/pages/api/coupons/[code].ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { findCouponByCode } from '../../../lib/coupons';
+import { getQueryParam } from '@utils/getQueryParam';
+import { handleApiError } from '@utils/handleApiError';
+import { findCouponByCode } from '@lib/coupons';
 import type { Coupon, ApiMessage } from '../../../types';
 
 export default async function handler(

--- a/pages/api/dashboard/best-sellers.ts
+++ b/pages/api/dashboard/best-sellers.ts
@@ -1,8 +1,8 @@
 import type { NextApiResponse } from 'next';
-import { getDb } from '../../../lib/db';
-import { withRole, type AuthedNextApiRequest } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getDb } from '@lib/db';
+import { withRole, type AuthedNextApiRequest } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/dashboard/inventory-alerts.ts
+++ b/pages/api/dashboard/inventory-alerts.ts
@@ -1,8 +1,8 @@
 import type { NextApiResponse } from 'next';
-import { getDb } from '../../../lib/db';
-import { withRole, type AuthedNextApiRequest } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getDb } from '@lib/db';
+import { withRole, type AuthedNextApiRequest } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/dashboard/orders-this-month.ts
+++ b/pages/api/dashboard/orders-this-month.ts
@@ -1,9 +1,9 @@
 import type { NextApiResponse } from 'next';
 import dayjs from 'dayjs';
-import { getDb } from '../../../lib/db';
-import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getDb } from '@lib/db';
+import { withRole, AuthedNextApiRequest } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/dashboard/total-products.ts
+++ b/pages/api/dashboard/total-products.ts
@@ -1,8 +1,8 @@
 import type { NextApiResponse } from 'next';
-import { getDb } from '../../../lib/db';
-import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getDb } from '@lib/db';
+import { withRole, AuthedNextApiRequest } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -1,8 +1,8 @@
 import type { NextApiResponse } from 'next';
-import { getDb } from '../../../lib/db';
-import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getDb } from '@lib/db';
+import { withRole, AuthedNextApiRequest } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/dashboard/weekly-summary.ts
+++ b/pages/api/dashboard/weekly-summary.ts
@@ -1,9 +1,9 @@
 import type { NextApiResponse } from 'next';
 import dayjs from 'dayjs';
-import { getDb } from '../../../lib/db';
-import { withRole, AuthedNextApiRequest } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getDb } from '@lib/db';
+import { withRole, AuthedNextApiRequest } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/delivery-estimate.ts
+++ b/pages/api/delivery-estimate.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { estimateDelivery, formatDelivery } from '../../lib/delivery';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { estimateDelivery, formatDelivery } from '@lib/delivery';
+import { handleApiError } from '@utils/handleApiError';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/guest-orders.ts
+++ b/pages/api/guest-orders.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { addGuestOrder, getGuestOrder } from '../../lib/guestOrders';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { addGuestOrder, getGuestOrder } from '@lib/guestOrders';
+import { handleApiError } from '@utils/handleApiError';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { findUser } from '../../lib/users';
+import { findUser } from '@lib/users';
 import bcrypt from 'bcryptjs';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { LoginResponse } from '../../types';
 
 export default async function handler(

--- a/pages/api/messages/[orderId].ts
+++ b/pages/api/messages/[orderId].ts
@@ -1,11 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { createMessage, getMessagesForOrder } from '../../../lib/messages';
-import { getOrderByUuid } from '../../../lib/orders';
-import { findUser } from '../../../lib/users';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { createMessage, getMessagesForOrder } from '@lib/messages';
+import { getOrderByUuid } from '@lib/orders';
+import { findUser } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { Message, ApiMessage } from '../../../types';
 
 export default async function handler(

--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -4,16 +4,16 @@ import {
   getOrdersForUser,
   getAllOrders,
   getOrdersForVendor,
-} from '../../lib/orders';
-import { findUser } from '../../lib/users';
+} from '@lib/orders';
+import { findUser } from '@lib/users';
 import {
   getProductByUuid,
   decreaseProductQuantity,
   clearCart,
-} from '../../lib/db';
-import { withRole } from '../../lib/withRole';
-import { sendOrderConfirmation } from '../../lib/email';
-import { handleApiError } from '../../lib/utils/handleApiError';
+} from '@lib/db';
+import { withRole } from '@lib/withRole';
+import { sendOrderConfirmation } from '@lib/email';
+import { handleApiError } from '@utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import type { Order, OrderPlacedResponse, ApiMessage } from '../../types';

--- a/pages/api/orders/[uuid].ts
+++ b/pages/api/orders/[uuid].ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrderByUuid, updateOrderStatus } from '../../../lib/orders';
-import { sendOrderStatusUpdate } from '../../../lib/email';
-import { withRole } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getOrderByUuid, updateOrderStatus } from '@lib/orders';
+import { sendOrderStatusUpdate } from '@lib/email';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/orders/[uuid]/invoice.ts
+++ b/pages/api/orders/[uuid]/invoice.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrderByUuid } from '../../../../lib/orders';
-import { generateInvoice } from '../../../../lib/invoice';
-import { handleApiError } from '../../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../../lib/utils/getQueryParam';
-import { withRole } from '../../../../lib/withRole';
+import { getOrderByUuid } from '@lib/orders';
+import { generateInvoice } from '@lib/invoice';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
+import { withRole } from '@lib/withRole';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {

--- a/pages/api/payment-methods/[id].ts
+++ b/pages/api/payment-methods/[id].ts
@@ -5,8 +5,8 @@ import {
   setDefaultPaymentMethod,
   deletePaymentMethod,
   getPaymentMethodsForUser,
-} from '../../../lib/paymentMethods';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+} from '@lib/paymentMethods';
+import { handleApiError } from '@utils/handleApiError';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/payment-methods/index.ts
+++ b/pages/api/payment-methods/index.ts
@@ -1,12 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { paymentProvider } from '../../../lib/paymentProvider';
+import { paymentProvider } from '@lib/paymentProvider';
 import {
   addPaymentMethod,
   getPaymentMethodsForUser,
-} from '../../../lib/paymentMethods';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+} from '@lib/paymentMethods';
+import { handleApiError } from '@utils/handleApiError';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/payments/charge.ts
+++ b/pages/api/payments/charge.ts
@@ -1,10 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { paymentProvider } from '../../../lib/paymentProvider';
-import { recordPayment } from '../../../lib/payments';
-import { getDb } from '../../../lib/db';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { paymentProvider } from '@lib/paymentProvider';
+import { recordPayment } from '@lib/payments';
+import { getDb } from '@lib/db';
+import { handleApiError } from '@utils/handleApiError';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/policies.ts
+++ b/pages/api/policies.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getDb } from '../../lib/db';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { getDb } from '@lib/db';
+import { handleApiError } from '@utils/handleApiError';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {

--- a/pages/api/products/[uuid].ts
+++ b/pages/api/products/[uuid].ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getProductByUuid, getAverageRating } from '../../../lib/db';
-import { mapDbRowToProduct } from '../../../lib/products';
-import { Product } from '../../../types/product';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getProductByUuid, getAverageRating } from '@lib/db';
+import { mapDbRowToProduct } from '@lib/products';
+import { Product } from '@types/product';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
 
 export interface ProductParams {

--- a/pages/api/products/[uuid]/reviews.ts
+++ b/pages/api/products/[uuid]/reviews.ts
@@ -4,14 +4,14 @@ import {
   addReview,
   getReviewsForProduct,
   getAverageRating,
-} from '../../../../lib/db';
-import { handleApiError } from '../../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../../lib/utils/getQueryParam';
+} from '@lib/db';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type {
   Review,
   ReviewsResponse,
   ReviewAddedResponse,
-} from '../../../../types/review';
+} from '@types/review';
 import type { ApiMessage } from '../../../../types';
 
 export default async function handler(

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getProductsPaginated } from '../../../lib/products';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
-import type { Product } from '../../../types/product';
+import { getProductsPaginated } from '@lib/products';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
+import type { Product } from '@types/product';
 import type { ApiMessage } from '../../../types';
 
 export interface ProductsQuery {

--- a/pages/api/request-email-change.ts
+++ b/pages/api/request-email-change.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { setResetToken, findUser } from '../../lib/users';
+import { setResetToken, findUser } from '@lib/users';
 import crypto from 'crypto';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { ResetTokenResponse, ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/api/request-reset.ts
+++ b/pages/api/request-reset.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { findUser, setResetToken } from '../../lib/users';
+import { findUser, setResetToken } from '@lib/users';
 import crypto from 'crypto';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { ResetTokenResponse, ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/api/reset-password.ts
+++ b/pages/api/reset-password.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { resetPassword } from '../../lib/users';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { resetPassword } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,13 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getBestSellingProducts } from '../../lib/orders';
-import { getDb } from '../../lib/db';
-import type { Product } from '../../types/product';
+import { getBestSellingProducts } from '@lib/orders';
+import { getDb } from '@lib/db';
+import type { Product } from '@types/product';
 import type { SearchApiResponse, ApiMessage } from '../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
-import client from '../../lib/typesenseClient';
-import { handleApiError } from '../../lib/utils/handleApiError';
-import { getQueryParam } from '../../lib/utils/getQueryParam';
+import client from '@lib/typesenseClient';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 
 interface SearchParams {
   q: string;

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { addUser, findUser } from '../../lib/users';
+import { addUser, findUser } from '@lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { SignupResponse, ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/api/signup/brand.ts
+++ b/pages/api/signup/brand.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { addUser, findUser } from '../../../lib/users';
+import { addUser, findUser } from '@lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { SignupTokenResponse, ApiMessage } from '../../../types';
 
 export default async function handler(

--- a/pages/api/signup/user.ts
+++ b/pages/api/signup/user.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { addUser, findUser } from '../../../lib/users';
+import { addUser, findUser } from '@lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { SignupTokenResponse, ApiMessage } from '../../../types';
 
 export default async function handler(

--- a/pages/api/stripe/webhook.ts
+++ b/pages/api/stripe/webhook.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { stripe } from '../../../lib/stripe';
+import { stripe } from '@lib/stripe';
 
 export const config = {
   api: {

--- a/pages/api/suggest.ts
+++ b/pages/api/suggest.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import client from '../../lib/typesenseClient';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import client from '@lib/typesenseClient';
+import { handleApiError } from '@utils/handleApiError';
 import { ObjectNotFound } from 'typesense/lib/Typesense/Errors';
 import type { SuggestionsResponse, ApiMessage } from '../../types';
 

--- a/pages/api/support.ts
+++ b/pages/api/support.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getDb } from '../../lib/db';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { getDb } from '@lib/db';
+import { handleApiError } from '@utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 

--- a/pages/api/tags.ts
+++ b/pages/api/tags.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getDistinctTags } from '../../lib/products';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { getDistinctTags } from '@lib/products';
+import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/api/trending.ts
+++ b/pages/api/trending.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { TrendingResponse } from '../../types';
 
 const trendingKeywords = [

--- a/pages/api/user/orders.ts
+++ b/pages/api/user/orders.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrdersForUser } from '../../../lib/orders';
+import { getOrdersForUser } from '@lib/orders';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { Order, ApiMessage } from '../../../types';
 
 export default async function handler(

--- a/pages/api/user/orders/[uuid].ts
+++ b/pages/api/user/orders/[uuid].ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { getOrderByUuid } from '../../../../lib/orders';
-import { handleApiError } from '../../../../lib/utils/handleApiError';
+import { getOrderByUuid } from '@lib/orders';
+import { handleApiError } from '@utils/handleApiError';
 import type { Order, ApiMessage } from '../../../../types';
 
 export default async function handler(

--- a/pages/api/user/orders/[uuid]/reorder.ts
+++ b/pages/api/user/orders/[uuid]/reorder.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../../auth/[...nextauth]';
-import { getOrderByUuid } from '../../../../../lib/orders';
-import { getProductByUuid, getCart, setCart } from '../../../../../lib/db';
-import { handleApiError } from '../../../../../lib/utils/handleApiError';
+import { getOrderByUuid } from '@lib/orders';
+import { getProductByUuid, getCart, setCart } from '@lib/db';
+import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage } from '../../../../../types';
 
 export default async function handler(

--- a/pages/api/user/profile.ts
+++ b/pages/api/user/profile.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { updateUserProfile, findUser } from '../../../lib/users';
+import { updateUserProfile, findUser } from '@lib/users';
 import bcrypt from 'bcryptjs';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { User, ApiMessage } from '../../../types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import fs from 'fs';

--- a/pages/api/user/wishlist/[id].ts
+++ b/pages/api/user/wishlist/[id].ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { findUser } from '../../../../lib/users';
-import { removeWishlistItem } from '../../../../lib/wishlist';
-import { handleApiError } from '../../../../lib/utils/handleApiError';
+import { findUser } from '@lib/users';
+import { removeWishlistItem } from '@lib/wishlist';
+import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage } from '../../../../types';
 
 export default async function handler(

--- a/pages/api/user/wishlist/index.ts
+++ b/pages/api/user/wishlist/index.ts
@@ -1,11 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
-import { findUser } from '../../../../lib/users';
+import { findUser } from '@lib/users';
 import {
   addWishlistItem,
   getWishlistForUser,
-} from '../../../../lib/wishlist';
-import { handleApiError } from '../../../../lib/utils/handleApiError';
+} from '@lib/wishlist';
+import { handleApiError } from '@utils/handleApiError';
 import type { WishlistItem, ApiMessage } from '../../../../types';
 import { authOptions } from '../../auth/[...nextauth]';
 

--- a/pages/api/vendor/orders.ts
+++ b/pages/api/vendor/orders.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrdersForVendor } from '../../../lib/orders';
-import { withRole } from '../../../lib/withRole';
-import { handleApiError } from '../../../lib/utils/handleApiError';
-import { getQueryParam } from '../../../lib/utils/getQueryParam';
+import { getOrdersForVendor } from '@lib/orders';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
 
 async function handler(

--- a/pages/api/vendors.ts
+++ b/pages/api/vendors.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getVendors } from '../../lib/users';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { getVendors } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
 import type { Vendor, ApiMessage } from '../../types';
 
 export interface VendorsResponse {

--- a/pages/api/vendors/check-or-create.ts
+++ b/pages/api/vendors/check-or-create.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { findVendorByName, createVendor } from '../../../lib/users';
-import { handleApiError } from '../../../lib/utils/handleApiError';
+import { findVendorByName, createVendor } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
 import type { Vendor, ApiMessage } from '../../../types';
 
 interface CheckCreateResponse {

--- a/pages/api/verify-email.ts
+++ b/pages/api/verify-email.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { verifyUser } from '../../lib/users';
-import { handleApiError } from '../../lib/utils/handleApiError';
-import { getQueryParam } from '../../lib/utils/getQueryParam';
+import { verifyUser } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/api/wishlist.ts
+++ b/pages/api/wishlist.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getWishlist, setWishlist } from '../../lib/db';
+import { getWishlist, setWishlist } from '@lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
-import { handleApiError } from '../../lib/utils/handleApiError';
+import { handleApiError } from '@utils/handleApiError';
 import type { Product, ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/auth/forgot-password.tsx
+++ b/pages/auth/forgot-password.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import { EmailInput } from '../../components/form-fields';
+import { EmailInput } from '@components/form-fields';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
-import PageContainer from '../../components/Layout/PageContainer';
+import { getPageTitle } from '@lib/pageTitle';
+import PageContainer from '@components/Layout/PageContainer';
 
 interface ForgotPasswordForm {
   email: string;

--- a/pages/brand/analytics.tsx
+++ b/pages/brand/analytics.tsx
@@ -1,15 +1,15 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
-import BarChart from '../../components/BarChart';
-import ChartContainer from '../../components/ChartContainer';
-import DashboardCard from '../../components/dashboard/DashboardCard';
-import TotalProductsCard from '../../components/dashboard/TotalProductsCard';
-import TotalSalesCard from '../../components/dashboard/TotalSalesCard';
-import OrdersThisMonthCard from '../../components/dashboard/OrdersThisMonthCard';
-import InventoryAlertsCard from '../../components/dashboard/InventoryAlertsCard';
-import CartIcon from '../../components/icons/CartIcon';
+import { getPageTitle } from '@lib/pageTitle';
+import BarChart from '@components/BarChart';
+import ChartContainer from '@components/ChartContainer';
+import DashboardCard from '@components/dashboard/DashboardCard';
+import TotalProductsCard from '@components/dashboard/TotalProductsCard';
+import TotalSalesCard from '@components/dashboard/TotalSalesCard';
+import OrdersThisMonthCard from '@components/dashboard/OrdersThisMonthCard';
+import InventoryAlertsCard from '@components/dashboard/InventoryAlertsCard';
+import CartIcon from '@components/icons/CartIcon';
 import {
   ResponsiveContainer,
   LineChart,

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -1,15 +1,15 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { AppContext } from '../../contexts/AppContext';
-import type { User } from '../../types/user';
-import ExistingProductsCard from '../../components/dashboard/ExistingProductsCard';
-import TotalProductsCard from '../../components/dashboard/TotalProductsCard';
-import TotalSalesCard from '../../components/dashboard/TotalSalesCard';
-import OrdersThisMonthCard from '../../components/dashboard/OrdersThisMonthCard';
-import BestSellersCard from '../../components/dashboard/BestSellersCard';
-import InventoryAlertsCard from '../../components/dashboard/InventoryAlertsCard';
-import WeeklySummaryCard from '../../components/dashboard/WeeklySummaryCard';
+import { AppContext } from '@contexts/AppContext';
+import type { User } from '@types/user';
+import ExistingProductsCard from '@components/dashboard/ExistingProductsCard';
+import TotalProductsCard from '@components/dashboard/TotalProductsCard';
+import TotalSalesCard from '@components/dashboard/TotalSalesCard';
+import OrdersThisMonthCard from '@components/dashboard/OrdersThisMonthCard';
+import BestSellersCard from '@components/dashboard/BestSellersCard';
+import InventoryAlertsCard from '@components/dashboard/InventoryAlertsCard';
+import WeeklySummaryCard from '@components/dashboard/WeeklySummaryCard';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 import Link from 'next/link';
 
 const BrandDashboard: React.FC = () => {

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -1,9 +1,9 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import { useSession } from 'next-auth/react';
 import { Order } from '../../types';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 const BrandOrders: React.FC = () => {
   const { user } = useContext(AppContext)!;

--- a/pages/brand/products/index.tsx
+++ b/pages/brand/products/index.tsx
@@ -1,10 +1,10 @@
 import React, { useContext, useEffect, useState } from 'react';
 import Link from 'next/link';
 import Head from 'next/head';
-import { AppContext } from '../../../contexts/AppContext';
-import type { User } from '../../../types/user';
-import type { Product } from '../../../types/product';
-import { getPageTitle } from '../../../lib/pageTitle';
+import { AppContext } from '@contexts/AppContext';
+import type { User } from '@types/user';
+import type { Product } from '@types/product';
+import { getPageTitle } from '@lib/pageTitle';
 
 const BrandProductsPage: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };

--- a/pages/brand/products/new.tsx
+++ b/pages/brand/products/new.tsx
@@ -1,13 +1,13 @@
 import React, { useContext, useRef, useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
-import ProductForm from '../../../components/Product/ProductForm';
-import CreateCategoryModal from '../../../components/Category/CreateCategoryModal';
-import { AppContext } from '../../../contexts/AppContext';
-import { NotificationContext } from '../../../contexts/NotificationContext';
-import type { User } from '../../../types/user';
-import { getPageTitle } from '../../../lib/pageTitle';
-import PageContainer from '../../../components/Layout/PageContainer';
+import ProductForm from '@components/Product/ProductForm';
+import CreateCategoryModal from '@components/Category/CreateCategoryModal';
+import { AppContext } from '@contexts/AppContext';
+import { NotificationContext } from '@contexts/NotificationContext';
+import type { User } from '@types/user';
+import { getPageTitle } from '@lib/pageTitle';
+import PageContainer from '@components/Layout/PageContainer';
 
 const NewProductPage: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };

--- a/pages/brand/profile.tsx
+++ b/pages/brand/profile.tsx
@@ -1,12 +1,12 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import type { User, Vendor } from '../../types';
-import { TextInput, Textarea, CountrySelect } from '../../components/form-fields';
+import { TextInput, Textarea, CountrySelect } from '@components/form-fields';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import PageContainer from '../../components/Layout/PageContainer';
+import PageContainer from '@components/Layout/PageContainer';
 
 export const BrandProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
-import { getPageTitle } from '../lib/pageTitle';
-import { AppContext } from '../contexts/AppContext';
+import { getPageTitle } from '@lib/pageTitle';
+import { AppContext } from '@contexts/AppContext';
 import type { AppContextValue } from '../types';
 
 // Define the type for a cart item

--- a/pages/categories/[slug]/index.tsx
+++ b/pages/categories/[slug]/index.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import ProductCard from '../../../components/Product/ProductCard';
+import ProductCard from '@components/Product/ProductCard';
 import Head from 'next/head';
 import React from 'react';
-import { getPageTitle } from '../../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 import { Category, Product } from '../../../types';
 
 const CategoryPage: React.FC = () => {

--- a/pages/categories/[slug]/products.tsx
+++ b/pages/categories/[slug]/products.tsx
@@ -1,15 +1,15 @@
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
-import { getPageTitle } from '../../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import ProductCard from '../../../components/Product/ProductCard';
+import ProductCard from '@components/Product/ProductCard';
 import type { Product, Category } from '../../../types';
 import {
   getCategoryBySlug,
   getProductsByCategorySlug,
-} from '../../../lib/products';
-import { serializeDates } from '../../../lib/utils/serializeDates';
+} from '@lib/products';
+import { serializeDates } from '@utils/serializeDates';
 
 interface CategoryProductsProps {
   products: Product[];

--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
-import CategoryCard from '../../components/Category/CategoryCard';
-import { getPageTitle } from '../../lib/pageTitle';
+import CategoryCard from '@components/Category/CategoryCard';
+import { getPageTitle } from '@lib/pageTitle';
 import { Category } from '../../types';
 
 const Categories: React.FC = () => {

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -2,18 +2,18 @@ import { useContext, useState, useEffect, FormEvent, ChangeEvent } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import Head from 'next/head';
-import { getPageTitle } from '../lib/pageTitle';
-import { AppContext } from '../contexts/AppContext';
+import { getPageTitle } from '@lib/pageTitle';
+import { AppContext } from '@contexts/AppContext';
 import type { AppContextValue } from '../types';
-import type { User } from '../types/user';
+import type { User } from '@types/user';
 import type { Coupon } from '../types';
 import {
   TextInput,
   Textarea,
   CountrySelect,
   AddressAutocomplete,
-} from '../components/form-fields';
-import FileUpload from '../components/form-fields/FileUpload';
+} from '@components/form-fields';
+import FileUpload from '@components/form-fields/FileUpload';
 
 // Types for cart item and user
 type CartItem = {

--- a/pages/checkout/cancel.tsx
+++ b/pages/checkout/cancel.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function Cancel() {
   return (

--- a/pages/checkout/success.tsx
+++ b/pages/checkout/success.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function Success() {
   const router = useRouter();

--- a/pages/confirm/[token].tsx
+++ b/pages/confirm/[token].tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function Confirm() {
   const router = useRouter();

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import { getPageTitle } from '../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 interface ContactForm {
   name: string;

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,13 +1,13 @@
 import React, { useContext } from 'react';
 import Head from 'next/head';
-import { AppContext } from '../contexts/AppContext';
-import { getPageTitle } from '../lib/pageTitle';
-import TotalProductsCard from '../components/dashboard/TotalProductsCard';
-import TotalSalesCard from '../components/dashboard/TotalSalesCard';
-import OrdersThisMonthCard from '../components/dashboard/OrdersThisMonthCard';
-import BestSellersCard from '../components/dashboard/BestSellersCard';
-import InventoryAlertsCard from '../components/dashboard/InventoryAlertsCard';
-import ExistingProductsCard from '../components/dashboard/ExistingProductsCard';
+import { AppContext } from '@contexts/AppContext';
+import { getPageTitle } from '@lib/pageTitle';
+import TotalProductsCard from '@components/dashboard/TotalProductsCard';
+import TotalSalesCard from '@components/dashboard/TotalSalesCard';
+import OrdersThisMonthCard from '@components/dashboard/OrdersThisMonthCard';
+import BestSellersCard from '@components/dashboard/BestSellersCard';
+import InventoryAlertsCard from '@components/dashboard/InventoryAlertsCard';
+import ExistingProductsCard from '@components/dashboard/ExistingProductsCard';
 
 const DashboardPage: React.FC = () => {
   const { user } = useContext(AppContext) as { user: any };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,13 @@
 import Head from 'next/head';
 import { useEffect, useState } from 'react';
-import HomeHero from '../components/HomeHero';
-import FeaturedProducts from '../components/Product/FeaturedProducts';
-import CategoryPromotion from '../components/Category/CategoryPromotion';
-import PromoBanner from '../components/PromoBanner';
-import CategorySlider, { CategoryItem } from '../components/Category/CategorySlider';
-import { getPageTitle } from '../lib/pageTitle';
-import DEFAULT_CATEGORIES from '../lib/defaultCategories';
-import CATEGORY_IMAGES from '../lib/categoryImages';
+import HomeHero from '@components/HomeHero';
+import FeaturedProducts from '@components/Product/FeaturedProducts';
+import CategoryPromotion from '@components/Category/CategoryPromotion';
+import PromoBanner from '@components/PromoBanner';
+import CategorySlider, { CategoryItem } from '@components/Category/CategorySlider';
+import { getPageTitle } from '@lib/pageTitle';
+import DEFAULT_CATEGORIES from '@lib/defaultCategories';
+import CATEGORY_IMAGES from '@lib/categoryImages';
 
 const HomePage: React.FC = () => {
   const [categories, setCategories] = useState<CategoryItem[]>([]);

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,17 +1,17 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { useForm, SubmitHandler, FieldErrors } from 'react-hook-form';
-import { AppContext } from '../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import type { AppContextValue } from '../types';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import Head from 'next/head';
-import { getPageTitle } from '../lib/pageTitle';
-import { EmailInput, PasswordInput } from '../components/form-fields';
-import GoogleIcon from '../components/icons/GoogleIcon';
-import GithubIcon from '../components/icons/GithubIcon';
+import { getPageTitle } from '@lib/pageTitle';
+import { EmailInput, PasswordInput } from '@components/form-fields';
+import GoogleIcon from '@components/icons/GoogleIcon';
+import GithubIcon from '@components/icons/GithubIcon';
 import { User } from '../types';
-import PageContainer from '../components/Layout/PageContainer';
+import PageContainer from '@components/Layout/PageContainer';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 

--- a/pages/messages/[orderId].tsx
+++ b/pages/messages/[orderId].tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import useRequireAuth from '../../hooks/useRequireAuth';
+import useRequireAuth from '@hooks/useRequireAuth';
 import type { Message } from '../../types';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function OrderMessages() {
   const user = useRequireAuth();

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import useRequireAuth from '../hooks/useRequireAuth';
+import useRequireAuth from '@hooks/useRequireAuth';
 import type { Order } from '../types';
 import Head from 'next/head';
-import { getPageTitle } from '../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 type OrdersProps = {};
 

--- a/pages/orders/[uuid].tsx
+++ b/pages/orders/[uuid].tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import type { Order } from '../../types';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function OrderDetail() {
   const router = useRouter();

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -1,8 +1,8 @@
 import Head from 'next/head';
 import ReactMarkdown from 'react-markdown';
 import { useEffect, useState } from 'react';
-import { getPageTitle } from '../lib/pageTitle';
-import { fetchJson } from '../lib/utils/fetchJson';
+import { getPageTitle } from '@lib/pageTitle';
+import { fetchJson } from '@utils/fetchJson';
 
 const PrivacyPolicyPage: React.FC = () => {
   const [content, setContent] = useState('');

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -1,21 +1,21 @@
 import { useContext, useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 import Link from 'next/link';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
-import { AppContext } from '../../contexts/AppContext';
-import ProductImageSlider from '../../components/Product/ProductImageSlider';
-import RecommendedProducts from '../../components/Product/RecommendedProducts';
+import { AppContext } from '@contexts/AppContext';
+import ProductImageSlider from '@components/Product/ProductImageSlider';
+import RecommendedProducts from '@components/Product/RecommendedProducts';
 import {
   getProductBySlug,
   getReviewsForProduct,
   getAverageRating,
-} from '../../lib/db';
-import { mapDbRowToProduct } from '../../lib/products';
+} from '@lib/db';
+import { mapDbRowToProduct } from '@lib/products';
 import { Product, Review } from '../../types';
-import { SelectDropdown, Textarea } from '../../components/form-fields';
-import { serializeDates } from '../../lib/utils/serializeDates';
+import { SelectDropdown, Textarea } from '@components/form-fields';
+import { serializeDates } from '@utils/serializeDates';
 
 type ProductDetailProps = {
   product: Product;

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -1,18 +1,18 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState, useContext, FormEvent, ChangeEvent } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import Link from 'next/link';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
-import ProductImageSlider from '../../components/Product/ProductImageSlider';
+import { getPageTitle } from '@lib/pageTitle';
+import ProductImageSlider from '@components/Product/ProductImageSlider';
 import type { Product } from '../../types';
 import type {
   Review,
   ReviewsResponse,
   ReviewAddedResponse,
-} from '../../types/review';
-import { SelectDropdown, Textarea } from '../../components/form-fields';
-import type { SelectOption } from '../../components/form-fields/SelectDropdown';
+} from '@types/review';
+import { SelectDropdown, Textarea } from '@components/form-fields';
+import type { SelectOption } from '@components/form-fields/SelectDropdown';
 
 interface ProductDetailProps {}
 

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -2,21 +2,21 @@ import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import ProductFilters from '../../components/Product/ProductFilters';
-import ActiveFilters from '../../components/ActiveFilters';
-import ProductGrid from '../../components/Product/ProductGrid';
-import Loader from '../../components/Loader';
-import InfiniteLoader from '../../components/InfiniteLoader';
-import SortMenu, { SortValue } from '../../components/SortMenu';
-import { getPageTitle } from '../../lib/pageTitle';
+import ProductFilters from '@components/Product/ProductFilters';
+import ActiveFilters from '@components/ActiveFilters';
+import ProductGrid from '@components/Product/ProductGrid';
+import Loader from '@components/Loader';
+import InfiniteLoader from '@components/InfiniteLoader';
+import SortMenu, { SortValue } from '@components/SortMenu';
+import { getPageTitle } from '@lib/pageTitle';
 import {
   getProductsPaginated,
   PaginatedResult,
   getCategoriesFlat,
-} from '../../lib/products';
-import type { Product } from '../../types/product';
-import type { Category } from '../../types/category';
-import { serializeDates } from '../../lib/utils/serializeDates';
+} from '@lib/products';
+import type { Product } from '@types/product';
+import type { Category } from '@types/category';
+import { serializeDates } from '@utils/serializeDates';
 
 interface ProductsProps {
   products: Product[];
@@ -51,7 +51,7 @@ export const getServerSideProps: GetServerSideProps<ProductsProps> = async (
     inStock,
     minPrice,
     maxPrice,
-    sort: sort as import('../../lib/products').PaginatedOptions['sort'],
+    sort: sort as import('@lib/products').PaginatedOptions['sort'],
   });
 
   const categories = serializeDates(await getCategoriesFlat());

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 import Head from 'next/head';
 import { useEffect, useState } from 'react';
-import useRequireAuth from '../hooks/useRequireAuth';
-import { getPageTitle } from '../lib/pageTitle';
-import type { User } from '../types/user';
+import useRequireAuth from '@hooks/useRequireAuth';
+import { getPageTitle } from '@lib/pageTitle';
+import type { User } from '@types/user';
 import type { GetServerSideProps } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './api/auth/[...nextauth]';

--- a/pages/profile/edit.tsx
+++ b/pages/profile/edit.tsx
@@ -5,16 +5,16 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
 dayjs.extend(relativeTime);
-import useRequireAuth from '../../hooks/useRequireAuth';
-import { getPageTitle } from '../../lib/pageTitle';
+import useRequireAuth from '@hooks/useRequireAuth';
+import { getPageTitle } from '@lib/pageTitle';
 import {
   EmailInput,
   PasswordInput,
   TextInput,
   CountrySelect,
   FileUpload,
-} from '../../components/form-fields';
-import type { User } from '../../types/user';
+} from '@components/form-fields';
+import type { User } from '@types/user';
 
 interface FormValues {
   firstName: string;

--- a/pages/reset.tsx
+++ b/pages/reset.tsx
@@ -1,9 +1,9 @@
 import { useState, FormEvent, ChangeEvent } from 'react';
 import Link from 'next/link';
-import { TextInput } from '../components/form-fields';
+import { TextInput } from '@components/form-fields';
 import Head from 'next/head';
-import { getPageTitle } from '../lib/pageTitle';
-import PageContainer from '../components/Layout/PageContainer';
+import { getPageTitle } from '@lib/pageTitle';
+import PageContainer from '@components/Layout/PageContainer';
 
 const RequestReset: React.FC = () => {
   const [email, setEmail] = useState<string>('');

--- a/pages/reset/[token].tsx
+++ b/pages/reset/[token].tsx
@@ -2,9 +2,9 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import Link from 'next/link';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import { PasswordInput } from '../../components/form-fields';
+import { PasswordInput } from '@components/form-fields';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 const ResetToken: React.FC = () => {
   const router = useRouter();

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -8,11 +8,11 @@ import React, {
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
-import { getPageTitle } from '../lib/pageTitle';
-import HeroSlider from '../components/HeroSlider';
-import ProductCard from '../components/Product/ProductCard';
-import DEFAULT_CATEGORIES from '../lib/defaultCategories';
-import { Product } from '../types/product';
+import { getPageTitle } from '@lib/pageTitle';
+import HeroSlider from '@components/HeroSlider';
+import ProductCard from '@components/Product/ProductCard';
+import DEFAULT_CATEGORIES from '@lib/defaultCategories';
+import { Product } from '@types/product';
 
 interface SearchResult extends Product {
   highlights?: { field: string; snippet: string }[];

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,15 +1,15 @@
 import { useState, useEffect, useContext } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import Head from 'next/head';
-import { getPageTitle } from '../lib/pageTitle';
-import useRequireAuth from '../hooks/useRequireAuth';
-import { NotificationContext } from '../contexts/NotificationContext';
+import { getPageTitle } from '@lib/pageTitle';
+import useRequireAuth from '@hooks/useRequireAuth';
+import { NotificationContext } from '@contexts/NotificationContext';
 import {
   TextInput,
   EmailInput,
   PasswordInput,
   CountrySelect,
-} from '../components/form-fields';
+} from '@components/form-fields';
 import countries from '../data/countries';
 import type { PaymentMethod } from '../types';
 

--- a/pages/shipping.tsx
+++ b/pages/shipping.tsx
@@ -1,8 +1,8 @@
 import Head from 'next/head';
 import ReactMarkdown from 'react-markdown';
 import { useEffect, useState } from 'react';
-import { getPageTitle } from '../lib/pageTitle';
-import { fetchJson } from '../lib/utils/fetchJson';
+import { getPageTitle } from '@lib/pageTitle';
+import { fetchJson } from '@utils/fetchJson';
 
 const ShippingPage: React.FC = () => {
   const [content, setContent] = useState('');

--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -2,19 +2,19 @@ import { useContext, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import { signIn } from 'next-auth/react';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
-import PageContainer from '../../components/Layout/PageContainer';
-import GoogleIcon from '../../components/icons/GoogleIcon';
-import GithubIcon from '../../components/icons/GithubIcon';
+import { getPageTitle } from '@lib/pageTitle';
+import PageContainer from '@components/Layout/PageContainer';
+import GoogleIcon from '@components/icons/GoogleIcon';
+import GithubIcon from '@components/icons/GithubIcon';
 import {
   EmailInput,
   PasswordInput,
   TextInput,
-} from '../../components/form-fields';
-import useEmailAvailability from '../../hooks/useEmailAvailability';
+} from '@components/form-fields';
+import useEmailAvailability from '@hooks/useEmailAvailability';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
-import PageContainer from '../../components/Layout/PageContainer';
+import { getPageTitle } from '@lib/pageTitle';
+import PageContainer from '@components/Layout/PageContainer';
 
 export default function Signup() {
   return (

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -2,19 +2,19 @@ import { useContext, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import { signIn } from 'next-auth/react';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
-import PageContainer from '../../components/Layout/PageContainer';
-import GoogleIcon from '../../components/icons/GoogleIcon';
-import GithubIcon from '../../components/icons/GithubIcon';
+import { getPageTitle } from '@lib/pageTitle';
+import PageContainer from '@components/Layout/PageContainer';
+import GoogleIcon from '@components/icons/GoogleIcon';
+import GithubIcon from '@components/icons/GithubIcon';
 import {
   EmailInput,
   PasswordInput,
   TextInput,
-} from '../../components/form-fields';
-import useEmailAvailability from '../../hooks/useEmailAvailability';
+} from '@components/form-fields';
+import useEmailAvailability from '@hooks/useEmailAvailability';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;

--- a/pages/support.tsx
+++ b/pages/support.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import Head from 'next/head';
-import { fetchJson } from '../lib/utils/fetchJson';
-import { getPageTitle } from '../lib/pageTitle';
+import { fetchJson } from '@utils/fetchJson';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function SupportPage() {
   const [subject, setSubject] = useState('');

--- a/pages/terms-and-conditions.tsx
+++ b/pages/terms-and-conditions.tsx
@@ -1,8 +1,8 @@
 import Head from 'next/head';
 import ReactMarkdown from 'react-markdown';
 import { useEffect, useState } from 'react';
-import { getPageTitle } from '../lib/pageTitle';
-import { fetchJson } from '../lib/utils/fetchJson';
+import { getPageTitle } from '@lib/pageTitle';
+import { fetchJson } from '@utils/fetchJson';
 
 const TermsPage: React.FC = () => {
   const [content, setContent] = useState('');

--- a/pages/user/orders.tsx
+++ b/pages/user/orders.tsx
@@ -1,8 +1,8 @@
 import { useContext, useEffect, useState } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import type { Order } from '../../types';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 const UserOrders: React.FC = () => {
   const { user } = useContext(AppContext)!;
   const [orders, setOrders] = useState<Order[]>([]);

--- a/pages/user/orders/[uuid].tsx
+++ b/pages/user/orders/[uuid].tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import type { Order } from '../../../types';
 import Head from 'next/head';
-import { getPageTitle } from '../../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function UserOrderDetail() {
   const router = useRouter();

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -1,11 +1,11 @@
 import React, { useContext, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import { CountrySelect } from '../../components/form-fields';
+import { CountrySelect } from '@components/form-fields';
 import { useRouter } from 'next/router';
-import { AppContext } from '../../contexts/AppContext';
-import type { User } from '../../types/user';
+import { AppContext } from '@contexts/AppContext';
+import type { User } from '@types/user';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export const UserProfile: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };

--- a/pages/user/wishlist.tsx
+++ b/pages/user/wishlist.tsx
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import Link from 'next/link';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import type { AppContextValue, WishlistItem } from '../../types';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 const UserWishlist: React.FC = () => {
   const context = useContext<AppContextValue | undefined>(AppContext);

--- a/pages/vendor/index.tsx
+++ b/pages/vendor/index.tsx
@@ -6,11 +6,11 @@ import {
   ChangeEvent,
   FormEvent,
 } from 'react';
-import { AppContext } from '../../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 import type { Product } from '../../types';
-import { TextInput } from '../../components/form-fields';
+import { TextInput } from '@components/form-fields';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function VendorDashboard() {
   const { user } = useContext(AppContext)!;

--- a/pages/vendor/orders.tsx
+++ b/pages/vendor/orders.tsx
@@ -1,9 +1,9 @@
 import { useContext, useEffect, useState, useCallback } from 'react';
-import { AppContext } from '../../contexts/AppContext';
-import { NotificationContext } from '../../contexts/NotificationContext';
+import { AppContext } from '@contexts/AppContext';
+import { NotificationContext } from '@contexts/NotificationContext';
 import type { Order } from '../../types';
 import Head from 'next/head';
-import { getPageTitle } from '../../lib/pageTitle';
+import { getPageTitle } from '@lib/pageTitle';
 
 export default function VendorOrders() {
   const { user } = useContext(AppContext)!;

--- a/scripts/seedProducts.ts
+++ b/scripts/seedProducts.ts
@@ -2,9 +2,9 @@ import { createReadStream, existsSync } from 'fs';
 import path from 'path';
 import csv from 'csv-parser';
 import bcrypt from 'bcryptjs';
-import { prisma } from '../lib/prisma';
-import { slugify } from '../lib/slugify';
-import { loadAndIndexProducts } from '../lib/products';
+import { prisma } from '@lib/prisma';
+import { slugify } from '@lib/slugify';
+import { loadAndIndexProducts } from '@lib/products';
 
 interface CsvRow {
   TITLE?: string;

--- a/scripts/updateQuantities.ts
+++ b/scripts/updateQuantities.ts
@@ -1,5 +1,5 @@
-import { prisma } from '../lib/prisma';
-import { loadAndIndexProducts } from '../lib/products';
+import { prisma } from '@lib/prisma';
+import { loadAndIndexProducts } from '@lib/products';
 
 async function main() {
   const products = await prisma.product.findMany({ select: { id: true } });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -101,7 +101,19 @@
     "incremental": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@lib/*": ["lib/*"],
+      "@utils/*": ["lib/utils/*"],
+      "@hooks/*": ["hooks/*"],
+      "@pages/*": ["pages/*"],
+      "@styles/*": ["styles/*"],
+      "@contexts/*": ["contexts/*"]
+      ,"@types/*": ["types/*"],
+      "@test-utils/*": ["test-utils/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "__tests__"]

--- a/types/context.ts
+++ b/types/context.ts
@@ -1,7 +1,7 @@
 import type { Product } from './product';
 import type { Variant } from './variant';
 import type { ShippingInfo } from './shipping';
-import type { UserInfo } from '../lib/types';
+import type { UserInfo } from '@lib/types';
 import type { WishlistItem } from './wishlist';
 
 export interface AppContextValue {


### PR DESCRIPTION
## Summary
- support absolute imports in TypeScript via tsconfig paths
- add ESLint import resolver
- update imports across the app to use aliases
- add eslint-import-resolver-typescript dev dependency

## Testing
- `npm run lint` *(fails: React Hook rules-of-hooks error)*
- `npm run build` *(fails: React Hook rules-of-hooks error)*

------
https://chatgpt.com/codex/tasks/task_e_685e3a1c56d4832f849b5dd584ec10c0