### PR TITLE
Fix Clear All resets sort option

### DIFF
--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, useContext } from 'react';
 import ProductFilters from '../../components/Product/ProductFilters';
 import ActiveFilters from '../../components/ActiveFilters';
 import ProductGrid from '../../components/Product/ProductGrid';
@@ -17,6 +17,7 @@ import {
 import type { Product } from '../../types/product';
 import type { Category } from '../../types/category';
 import { serializeDates } from '../../lib/utils/serializeDates';
+import { NotificationContext } from '../../contexts/NotificationContext';
 
 interface ProductsProps {
   products: Product[];
@@ -65,6 +66,7 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
   categories,
 }) => {
   const router = useRouter();
+  const { addNotification } = useContext(NotificationContext);
   const [keyword, setKeyword] = useState(
     typeof router.query.q === 'string' ? router.query.q : ''
   );
@@ -268,10 +270,12 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
     setMinPrice('');
     setMaxPrice('');
     setInStock(false);
+    setSort('newest');
     router.replace({ pathname: router.pathname, query: {} }, undefined, {
       shallow: true,
     });
-  }, [router]);
+    addNotification('Filters cleared', 'success');
+  }, [router, addNotification]);
 
   return (
     <div className="min-h-screen bg-base-200 py-10">
@@ -298,9 +302,9 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
             />
           </aside>
           <div className="flex-1">
-          <ActiveFilters filters={activeFilters} clearAll={clearAll} />
-          <SortMenu value={sort} onChange={(v) => setSort(v)} />
-          <div className="relative">
+            <ActiveFilters filters={activeFilters} clearAll={clearAll} />
+            <SortMenu value={sort} onChange={(v) => setSort(v)} />
+            <div className="relative">
               <ProductGrid products={items} />
               {loading && (
                 <Loader className="absolute inset-0 bg-base-200/70" />


### PR DESCRIPTION
## Summary
- reset sort parameter when clearing filters on Products page
- show toast notification for confirmation

## Testing
- `npx prettier --write pages/products/index.tsx`
- `npm install` *(fails: binaries.prisma.sh blocked)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3bc800e0832f8a705dc07db082a6