### PR TITLE
Add reusable dropdown menu

### DIFF
--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -19,6 +19,7 @@ import SportsIcon from '../icons/SportsIcon';
 import DEFAULT_CATEGORIES from '@lib/defaultCategories';
 import TrashIcon from '../icons/TrashIcon';
 import SearchBar from './SearchBar';
+import DropdownMenu from '@components/common/DropdownMenu';
 import type { Category } from '@types/category';
 import type { User } from '@types/user';
 
@@ -75,6 +76,14 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
 
   const itemCount = cart.reduce((sum, item) => sum + (item.qty || 0), 0);
   const logout = () => signOut({ callbackUrl: '/', redirect: true });
+
+  const menuItems = [
+    { label: 'My Orders', href: '/orders' },
+    { label: 'Profile', href: '/profile' },
+    { label: 'Update Profile', href: '/profile/edit' },
+    { label: 'Settings', href: '/settings' },
+    { label: 'Logout', onClick: logout, isButton: true },
+  ];
 
   const iconMap: Record<string, JSX.Element> = {
     Electronics: <ElectronicsIcon className="h-5 w-5 mr-1" />,
@@ -361,51 +370,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                     : user.email}
                 </span>
               </label>
-              <ul
-                tabIndex={0}
-                className="dropdown-content z-50 menu p-2 shadow bg-base-100 rounded w-40"
-              >
-                <li>
-                  <Link
-                    href="/orders"
-                    className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
-                  >
-                    My Orders
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    href="/profile"
-                    className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
-                  >
-                    Profile
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    href="/profile/edit"
-                    className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
-                  >
-                    Update Profile
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    href="/settings"
-                    className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
-                  >
-                    Settings
-                  </Link>
-                </li>
-                <li>
-                  <button
-                    onClick={logout}
-                    className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
-                  >
-                    Logout
-                  </button>
-                </li>
-              </ul>
+              <DropdownMenu items={menuItems} />
             </div>
           ) : (
             !isAuthRoute && (

--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import type { FC } from 'react';
+
+type DropdownItem = {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  isButton?: boolean;
+};
+
+interface DropdownMenuProps {
+  items: DropdownItem[];
+}
+
+const DropdownMenu: FC<DropdownMenuProps> = ({ items }) => (
+  <ul
+    tabIndex={0}
+    className="dropdown-content z-50 menu p-2 shadow bg-base-100 rounded w-40"
+  >
+    {items.map((item, index) =>
+      item.isButton ? (
+        <li key={index}>
+          <button
+            onClick={item.onClick}
+            className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
+          >
+            {item.label}
+          </button>
+        </li>
+      ) : (
+        <li key={index}>
+          <Link
+            href={item.href || '#'}
+            className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
+          >
+            {item.label}
+          </Link>
+        </li>
+      )
+    )}
+  </ul>
+);
+
+export default DropdownMenu;


### PR DESCRIPTION
## Summary
- add new `DropdownMenu` component for dropdown lists
- use `DropdownMenu` in `UserHeader`

## Testing
- `npm test` *(fails: Cannot find module '@hooks/useRequireAuth' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_685e3cee85a4832f8edeed385834ce91