### PR TITLE
Fix toast position and header hover contrast

### DIFF
--- a/components/Layout/BrandHeader.tsx
+++ b/components/Layout/BrandHeader.tsx
@@ -52,19 +52,19 @@ const BrandHeader: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
             <>
               <Link
                 href="/brand/dashboard"
-                className={`transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105 ${pathname === '/brand/dashboard' ? 'text-primary underline font-semibold' : ''}`}
+                className={`transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105 ${pathname === '/brand/dashboard' ? 'text-primary underline font-semibold' : ''}`}
               >
                 Dashboard
               </Link>
               <Link
                 href="/brand/orders"
-                className={`transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105 ${pathname === '/brand/orders' ? 'text-primary underline font-semibold' : ''}`}
+                className={`transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105 ${pathname === '/brand/orders' ? 'text-primary underline font-semibold' : ''}`}
               >
                 Orders
               </Link>
               <Link
                 href="/brand/analytics"
-                className={`transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105 ${pathname === '/brand/analytics' ? 'text-primary underline font-semibold' : ''}`}
+                className={`transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105 ${pathname === '/brand/analytics' ? 'text-primary underline font-semibold' : ''}`}
               >
                 Analytics
               </Link>
@@ -136,7 +136,7 @@ const BrandHeader: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                 <li>
                   <Link
                     href="/brand/profile"
-                    className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
+                    className="transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105"
                   >
                     Profile
                   </Link>
@@ -144,7 +144,7 @@ const BrandHeader: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                 <li>
                   <button
                     onClick={logout}
-                    className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
+                    className="transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105"
                   >
                     Logout
                   </button>

--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -157,7 +157,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                           aria-expanded={hoveredCat?.name === cat.name}
                           onFocus={() => setHoveredCat(cat)}
                           onMouseEnter={() => setHoveredCat(cat)}
-                          className="w-full flex items-center gap-1 text-left font-medium text-gray-800 tracking-wide transition-colors transition-transform duration-200 focus:outline-none capitalize whitespace-nowrap truncate hover:text-white hover:underline hover:scale-105"
+                          className="w-full flex items-center gap-1 text-left font-medium text-gray-800 tracking-wide transition-colors transition-transform duration-200 focus:outline-none capitalize whitespace-nowrap truncate hover:text-primary hover:underline hover:scale-105"
                         >
                           {iconMap[cat.name] || null}
                           {cat.name}
@@ -183,7 +183,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                               <Link
                                 href={`/categories/${encodeURIComponent(hoveredCat.name)}?type=${encodeURIComponent(sub)}`}
                                 role="menuitem"
-                                className="block font-medium text-gray-800 tracking-wide transition-colors transition-transform duration-200 whitespace-nowrap truncate hover:text-white hover:underline hover:scale-105"
+                                className="block font-medium text-gray-800 tracking-wide transition-colors transition-transform duration-200 whitespace-nowrap truncate hover:text-primary hover:underline hover:scale-105"
                               >
                                 {sub}
                               </Link>
@@ -206,7 +206,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                   key={cat.name}
                   className="border-b border-base-200 last:border-none"
                 >
-                  <summary className="flex items-center gap-2 py-2 cursor-pointer list-none transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105">
+                  <summary className="flex items-center gap-2 py-2 cursor-pointer list-none transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105">
                     {iconMap[cat.name] || null}
                     <span className="capitalize">{cat.name}</span>
                   </summary>
@@ -216,7 +216,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                         <li key={sub} className="capitalize">
                           <Link
                             href={`/categories/${encodeURIComponent(cat.name)}?type=${encodeURIComponent(sub)}`}
-                            className="block py-1 transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
+                            className="block py-1 transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105"
                           >
                             {sub}
                           </Link>
@@ -236,19 +236,19 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
           <nav className="hidden lg:flex gap-4 ml-4">
             <Link
               href="/products"
-              className={`transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105 ${pathname.startsWith('/products') ? 'text-primary underline font-semibold' : ''}`}
+              className={`transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105 ${pathname.startsWith('/products') ? 'text-primary underline font-semibold' : ''}`}
             >
               Shop
             </Link>
             <Link
               href="/about"
-              className={`transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105 ${pathname === '/about' ? 'text-primary underline font-semibold' : ''}`}
+              className={`transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105 ${pathname === '/about' ? 'text-primary underline font-semibold' : ''}`}
             >
               About
             </Link>
             <Link
               href="/contact"
-              className={`transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105 ${pathname === '/contact' ? 'text-primary underline font-semibold' : ''}`}
+              className={`transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105 ${pathname === '/contact' ? 'text-primary underline font-semibold' : ''}`}
             >
               Contact
             </Link>
@@ -259,7 +259,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
           <div className="dropdown dropdown-end dropdown-hover">
             <label
               tabIndex={0}
-              className="relative p-2 cursor-pointer transition-colors transition-transform duration-200 hover:text-white hover:scale-105"
+              className="relative p-2 cursor-pointer transition-colors transition-transform duration-200 hover:text-primary hover:scale-105"
             >
               <CartIcon className="w-5 h-5" />
               {itemCount > 0 && (

--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -22,7 +22,7 @@ const DropdownMenu: FC<DropdownMenuProps> = ({ items }) => (
         <li key={index}>
           <button
             onClick={item.onClick}
-            className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
+            className="transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105"
           >
             {item.label}
           </button>
@@ -31,7 +31,7 @@ const DropdownMenu: FC<DropdownMenuProps> = ({ items }) => (
         <li key={index}>
           <Link
             href={item.href || '#'}
-            className="transition-colors transition-transform duration-200 hover:text-white hover:underline hover:scale-105"
+            className="transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105"
           >
             {item.label}
           </Link>

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -166,11 +166,7 @@ export function AppProvider({ children }: AppProviderProps) {
       }
       return [...prev, { ...product, qty, variant }];
     });
-    addNotification(
-      `✅ ${product.title} added to cart!`,
-      'success',
-      'top-right'
-    );
+    addNotification(`✅ ${product.title} added to cart!`, 'success');
   };
 
   const changeQty = (id: string, delta: number, variantId?: number) => {
@@ -183,7 +179,7 @@ export function AppProvider({ children }: AppProviderProps) {
         )
         .filter((item) => item.qty > 0);
     });
-    addNotification('✅ Quantity updated', 'success', 'top-left');
+    addNotification('✅ Quantity updated', 'success');
   };
 
   const removeFromCart = (id: string, variantId?: number) => {
@@ -193,7 +189,7 @@ export function AppProvider({ children }: AppProviderProps) {
           !(item.id === id && (!variantId || item.variant?.id === variantId))
       )
     );
-    addNotification('❌ Product removed from cart', 'error', 'top-left');
+    addNotification('❌ Product removed from cart', 'error');
   };
 
   const addToWishlist = (product: Product, notifyOnStock = false) => {

--- a/contexts/NotificationContext.tsx
+++ b/contexts/NotificationContext.tsx
@@ -37,7 +37,7 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
     (
       message: string,
       type: NotificationType = 'info',
-      position: NotificationPosition = 'end'
+      position: NotificationPosition = 'top-right'
     ) => {
       const id = Date.now() + Math.random();
       setNotifs((prev) => [...prev, { id, message, type, position }]);


### PR DESCRIPTION
## Summary
- default all toasts to top-right
- drop toast position overrides in context
- use primary color on header hover menus

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e41e39444832fb850393bc55cbfa1