### PR TITLE
Integrate Sonner for toast notifications

### DIFF
--- a/components/UI/index.ts
+++ b/components/UI/index.ts
@@ -1,4 +1,3 @@
 export { default as InputField } from './InputField';
 export { default as GenericInput } from './GenericInput';
 export { default as GenericModal } from '../Modals/GenericModal';
-export { default as Toast } from './Toast';

--- a/contexts/NotificationContext.d.ts
+++ b/contexts/NotificationContext.d.ts
@@ -1,6 +1,9 @@
 import React from 'react';
 export interface NotificationContextValue {
-  addNotification: (msg: string, type?: string, position?: string) => void;
+  addNotification: (
+    msg: string,
+    type?: 'info' | 'success' | 'warning' | 'error'
+  ) => void;
 }
 
 export const NotificationContext: React.Context<NotificationContextValue>;

--- a/contexts/NotificationContext.tsx
+++ b/contexts/NotificationContext.tsx
@@ -1,25 +1,10 @@
-import React, { createContext, useState, useCallback, ReactNode } from 'react';
-// Update the import path below to the actual location of your Toast component.
-// For example, if Toast is in components/UI/Toast.tsx, use:
-import Toast from '@components/UI/Toast';
-// Or adjust the path as needed for your project structure.
+import React, { createContext, ReactNode } from 'react';
+import { toast } from 'sonner';
 
 type NotificationType = 'info' | 'success' | 'warning' | 'error';
-type NotificationPosition = 'center' | 'top-right' | 'top-left' | 'end' | string;
-
-interface Notification {
-  id: number;
-  message: string;
-  type: NotificationType;
-  position: NotificationPosition;
-}
 
 interface NotificationContextType {
-  addNotification: (
-    message: string,
-    type?: NotificationType,
-    position?: NotificationPosition
-  ) => void;
+  addNotification: (message: string, type?: NotificationType) => void;
 }
 
 export const NotificationContext = createContext<NotificationContextType>({
@@ -31,85 +16,28 @@ interface NotificationProviderProps {
 }
 
 export function NotificationProvider({ children }: NotificationProviderProps) {
-  const [notifs, setNotifs] = useState<Notification[]>([]);
-
-  const addNotification = useCallback(
-    (
-      message: string,
-      type: NotificationType = 'info',
-      position: NotificationPosition = 'top-right'
-    ) => {
-      const id = Date.now() + Math.random();
-      setNotifs((prev) => [...prev, { id, message, type, position }]);
-      setTimeout(() => {
-        setNotifs((prev) => prev.filter((n) => n.id !== id));
-      }, 5000);
-    },
-    []
-  );
-
-  const removeNotification = useCallback((id: number) => {
-    setNotifs((prev) => prev.filter((n) => n.id !== id));
-  }, []);
+  const addNotification = (
+    message: string,
+    type: NotificationType = 'info'
+  ) => {
+    switch (type) {
+      case 'success':
+        toast.success(message);
+        break;
+      case 'error':
+        toast.error(message);
+        break;
+      case 'warning':
+        toast.warning(message);
+        break;
+      default:
+        toast(message);
+    }
+  };
 
   return (
     <NotificationContext.Provider value={{ addNotification }}>
       {children}
-      <div className="fixed inset-0 pointer-events-none z-50">
-        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 space-y-2">
-          {notifs
-            .filter((n) => n.position === 'center')
-            .map((n) => (
-              <Toast
-                key={n.id}
-                message={n.message}
-                type={n.type}
-                onClose={() => removeNotification(n.id)}
-              />
-            ))}
-        </div>
-        <div className="absolute right-5 top-5 space-y-2">
-          {notifs
-            .filter((n) => n.position === 'top-right')
-            .map((n) => (
-              <Toast
-                key={n.id}
-                message={n.message}
-                type={n.type}
-                onClose={() => removeNotification(n.id)}
-              />
-            ))}
-        </div>
-        <div className="absolute left-5 top-5 space-y-2">
-          {notifs
-            .filter((n) => n.position === 'top-left')
-            .map((n) => (
-              <Toast
-                key={n.id}
-                message={n.message}
-                type={n.type}
-                onClose={() => removeNotification(n.id)}
-              />
-            ))}
-        </div>
-        <div className="absolute right-5 bottom-5 space-y-2">
-          {notifs
-            .filter(
-              (n) =>
-                n.position !== 'center' &&
-                n.position !== 'top-right' &&
-                n.position !== 'top-left'
-            )
-            .map((n) => (
-              <Toast
-                key={n.id}
-                message={n.message}
-                type={n.type}
-                onClose={() => removeNotification(n.id)}
-              />
-            ))}
-        </div>
-      </div>
     </NotificationContext.Provider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-select-country-list": "^2.2.3",
         "react-world-flags": "^1.6.0",
         "recharts": "^2.9.0",
+        "sonner": "^2.0.5",
         "stripe": "^12.18.0",
         "swiper": "^11.2.8",
         "typesense": "^2.0.3",
@@ -13793,6 +13794,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.5.tgz",
+      "integrity": "sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-select-country-list": "^2.2.3",
     "react-world-flags": "^1.6.0",
     "recharts": "^2.9.0",
+    "sonner": "^2.0.5",
     "stripe": "^12.18.0",
     "swiper": "^11.2.8",
     "typesense": "^2.0.3",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,7 @@ import { AppProvider } from '@contexts/AppContext';
 import Layout from '@components/Layout/Layout';
 import { SessionProvider } from 'next-auth/react';
 import { NotificationProvider } from '@contexts/NotificationContext';
+import { Toaster } from 'sonner';
 
 import type { AppProps } from 'next/app';
 
@@ -16,6 +17,7 @@ export default function App({
     <SessionProvider session={session}>
       <NotificationProvider>
         <AppProvider>
+          <Toaster position="top-right" richColors />
           <Layout
             heroSecond={HeroSecond ? <HeroSecond /> : null}
             maxWidthClass={maxWidthClass}


### PR DESCRIPTION
## Summary
- install **sonner** and remove old toast export
- simplify `NotificationContext` to use `sonner`
- add `<Toaster/>` globally in `_app.tsx`

## Testing
- `npm test` *(fails: Cannot find module '@pages/api/auth/[...nextauth]')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e44828178832fbdf30c1c3db4385a