### PR TITLE
Add placeholder footer content

### DIFF
--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -5,7 +5,7 @@ import { getPageTitle } from '@lib/pageTitle';
 import { fetchJson } from '@utils/fetchJson';
 
 const PrivacyPolicyPage: React.FC = () => {
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState<string | null>(null);
 
   useEffect(() => {
     fetchJson<{ content: string }>(`/api/policies?type=privacy`)
@@ -24,7 +24,29 @@ const PrivacyPolicyPage: React.FC = () => {
           <ReactMarkdown>{content}</ReactMarkdown>
         </div>
       ) : (
-        <p>Loading...</p>
+        <div className="space-y-4">
+          <section className="space-y-2">
+            <h2 className="text-xl font-semibold">Data Collection</h2>
+            <p>
+              We only collect the information necessary to process your orders
+              and improve your shopping experience.
+            </p>
+          </section>
+          <section className="space-y-2">
+            <h2 className="text-xl font-semibold">Usage</h2>
+            <p>
+              Your details are used solely to provide our services and are not
+              sold or shared for advertising purposes.
+            </p>
+          </section>
+          <section className="space-y-2">
+            <h2 className="text-xl font-semibold">Third-Party Access</h2>
+            <p>
+              Access to your data is limited to trusted partners like payment
+              processors and shipping carriers.
+            </p>
+          </section>
+        </div>
       )}
     </div>
   );

--- a/pages/shipping.tsx
+++ b/pages/shipping.tsx
@@ -5,7 +5,7 @@ import { getPageTitle } from '@lib/pageTitle';
 import { fetchJson } from '@utils/fetchJson';
 
 const ShippingPage: React.FC = () => {
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState<string | null>(null);
 
   useEffect(() => {
     fetchJson<{ content: string }>(`/api/policies?type=shipping`)
@@ -16,15 +16,30 @@ const ShippingPage: React.FC = () => {
   return (
     <div className="max-w-3xl mx-auto space-y-4">
       <Head>
-        <title>{getPageTitle('Shipping')}</title>
+        <title>{getPageTitle('Shipping Information')}</title>
       </Head>
-      <h1 className="text-2xl font-bold mb-4">Shipping</h1>
+      <h1 className="text-2xl font-bold mb-4">Shipping Information</h1>
       {content ? (
         <div className="prose">
           <ReactMarkdown>{content}</ReactMarkdown>
         </div>
       ) : (
-        <p>Loading...</p>
+        <div className="space-y-2">
+          <p>
+            Orders are typically processed within 1-2 business days. Delivery
+            times vary by destination but average 3-5 business days for
+            domestic shipments.
+          </p>
+          <p>
+            We currently ship to most regions across the UK and Europe. Please
+            contact us if you need details about a specific location.
+          </p>
+          <p>
+            All parcels are dispatched via leading carriers such as Royal Mail
+            and DHL. Tracking details will be provided once your order leaves
+            our warehouse.
+          </p>
+        </div>
       )}
     </div>
   );

--- a/pages/terms-and-conditions.tsx
+++ b/pages/terms-and-conditions.tsx
@@ -5,7 +5,7 @@ import { getPageTitle } from '@lib/pageTitle';
 import { fetchJson } from '@utils/fetchJson';
 
 const TermsPage: React.FC = () => {
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState<string | null>(null);
 
   useEffect(() => {
     fetchJson<{ content: string }>(`/api/policies?type=terms`)
@@ -24,7 +24,29 @@ const TermsPage: React.FC = () => {
           <ReactMarkdown>{content}</ReactMarkdown>
         </div>
       ) : (
-        <p>Loading...</p>
+        <div className="space-y-4">
+          <section className="space-y-2">
+            <h2 className="text-xl font-semibold">User Responsibilities</h2>
+            <p>
+              By using this site you agree to act responsibly and comply with
+              all local laws and regulations.
+            </p>
+          </section>
+          <section className="space-y-2">
+            <h2 className="text-xl font-semibold">Refunds</h2>
+            <p>
+              Refunds are issued in accordance with our returns policy. Please
+              contact support within 30 days of receipt if you have any issues.
+            </p>
+          </section>
+          <section className="space-y-2">
+            <h2 className="text-xl font-semibold">Dispute Resolution</h2>
+            <p>
+              Any disputes will be handled in good faith and resolved through
+              our customer service team before seeking further action.
+            </p>
+          </section>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add simple placeholders to Shipping, Privacy, and Terms pages

## Testing
- `npm test` *(fails: Cannot find modules for tests)*

------
https://chatgpt.com/codex/tasks/task_e_685e5bf17744832fb7c6ed5eb3bb27e7