### PR TITLE
Fix cart badge alignment

### DIFF
--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -269,14 +269,16 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
             <label
               tabIndex={0}
               aria-label="Shopping cart"
-              className="relative p-2 cursor-pointer transition-colors transition-transform duration-200 hover:text-primary hover:scale-105"
+              className="p-2 cursor-pointer transition-colors transition-transform duration-200 hover:text-primary hover:scale-105"
             >
-              <CartIcon className="w-5 h-5" />
-              {itemCount > 0 && (
-                <span className="absolute top-0 right-0 transform translate-x-1/2 -translate-y-1/2 bg-red-500 text-white text-xs rounded-full px-1">
-                  {itemCount}
-                </span>
-              )}
+              <div className="relative flex items-center">
+                <CartIcon className="w-5 h-5" />
+                {itemCount > 0 && (
+                  <span className="absolute -top-2 -right-2 text-xs h-4 w-4 rounded-full flex items-center justify-center bg-red-500 text-white">
+                    {itemCount}
+                  </span>
+                )}
+              </div>
             </label>
             <div
               tabIndex={0}


### PR DESCRIPTION
## Summary
- align cart icon badge within header

## Testing
- `npm test` *(fails: Cannot find module '@components/Layout/Layout', etc.)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5e01479c832fb5c627851910ee58