### PR TITLE
Improve Login UI and Cart Badge

### DIFF
--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -273,7 +273,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
             >
               <CartIcon className="w-5 h-5" />
               {itemCount > 0 && (
-                <span className="absolute top-0 right-0 transform translate-x-1/2 -translate-y-1/2 bg-red-500 text-white text-xs rounded-full px-1">
+                <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full px-1">
                   {itemCount}
                 </span>
               )}

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -69,13 +69,13 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center overflow-auto px-4 py-6 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
       <Head>
         <title>{getPageTitle('Login')}</title>
       </Head>
-      <PageContainer className="space-y-4 max-w-sm -mt-8">
+      <PageContainer className="space-y-4 max-w-sm">
         <h1 className="text-2xl font-bold mb-4 text-center">Login</h1>
-        <div className="flex flex-col gap-4 mb-4">
+        <div className="flex flex-col gap-4 mb-6">
           <button
             type="button"
             className="btn w-full hover:bg-red-600 hover:text-white flex items-center justify-center gap-2"
@@ -100,6 +100,7 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
             placeholder="Email"
             required
             register={register}
+            className="bg-base-200 border-base-300"
             rules={{
               required: 'Email is required',
               pattern: { value: emailRegex, message: 'Invalid email format' },
@@ -111,10 +112,11 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
             placeholder="Password"
             required
             register={register}
+            className="bg-base-200 border-base-300"
             rules={{ required: 'Password is required' }}
             error={errors.password?.message as string}
           />
-          <div className="text-right -mt-2 mb-2">
+          <div className="text-right mt-1">
             <Link href="/auth/forgot-password" className="link text-sm">
               Forgot Password?
             </Link>


### PR DESCRIPTION
## Summary
- tweak login page styles for better alignment
- soften input appearance and reposition forgot password link
- fix cart badge alignment in header

## Testing
- `npx jest` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e5e88304c832f83f6a6712a57415b