### PR TITLE
Refine signup page layout

### DIFF
--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -99,9 +99,9 @@ export default function BrandSignup() {
       <Head>
         <title>{getPageTitle('Brand Signup')}</title>
       </Head>
-      <PageContainer className="max-w-sm -mt-8">
+      <PageContainer className="max-w-xs -mt-12">
         <h1 className="text-2xl font-bold mb-4 text-center">Brand Sign Up</h1>
-        <div className="flex flex-col gap-4 mb-4">
+        <div className="flex flex-col gap-4 mb-6">
           <button
             type="button"
             className="btn btn-lg px-6 w-full sm:w-auto flex items-center justify-center gap-2 hover:bg-red-600 hover:text-white"
@@ -181,13 +181,13 @@ export default function BrandSignup() {
             Sign Up
           </button>
         </form>
-        <p className="text-center mt-4">
+        <p className="text-center mt-6">
           Already have an account?{' '}
           <Link href="/login" className="link">
             Login
           </Link>
         </p>
-        <p className="text-sm text-center mt-4 text-gray-600">
+        <p className="text-sm text-center mt-2 text-gray-600">
           Not a brand?{' '}
           <Link href="/signup/user" className="text-blue-600 hover:underline">
             Sign up as a user instead

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -99,9 +99,9 @@ export default function UserSignup() {
       <Head>
         <title>{getPageTitle('User Signup')}</title>
       </Head>
-      <PageContainer className="max-w-sm -mt-8">
+      <PageContainer className="max-w-xs -mt-12">
         <h1 className="text-2xl font-bold mb-4 text-center">User Sign Up</h1>
-        <div className="flex flex-col gap-4 mb-4">
+        <div className="flex flex-col gap-4 mb-6">
           <button
             type="button"
             className="btn btn-lg px-6 w-full sm:w-auto flex items-center justify-center gap-2 hover:bg-red-600 hover:text-white"
@@ -181,13 +181,13 @@ export default function UserSignup() {
             Sign Up
           </button>
         </form>
-        <p className="text-center mt-4">
+        <p className="text-center mt-6">
           Already have an account?{' '}
           <Link href="/login" className="link">
             Login
           </Link>
         </p>
-        <p className="text-sm text-center mt-4 text-gray-600">
+        <p className="text-sm text-center mt-2 text-gray-600">
           Want to sign up as a brand instead?{' '}
           <Link href="/signup/brand" className="text-blue-600 hover:underline">
             Sign up as a brand instead


### PR DESCRIPTION
## Summary
- reduce width of signup forms and adjust vertical offset
- add clearer spacing between social logins and input fields
- tweak spacing of login/alternate signup links

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5f1aaa2c832f859f3a20a5108833