### PR TITLE
Fix layout container width

### DIFF
--- a/components/Layout/BrandHeader.tsx
+++ b/components/Layout/BrandHeader.tsx
@@ -14,9 +14,14 @@ import type { User } from '@types/user';
 interface HeaderProps {
   theme?: string;
   setTheme?: React.Dispatch<React.SetStateAction<string>>;
+  maxWidthClass?: string;
 }
 
-const BrandHeader: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
+const BrandHeader: FC<HeaderProps> = ({
+  theme = 'light',
+  setTheme,
+  maxWidthClass,
+}) => {
   const router = useRouter();
   const { data: session } = useSession();
   const appContext = useContext(AppContext);
@@ -33,7 +38,11 @@ const BrandHeader: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
 
   return (
     <header className="relative bg-base-300 mb-6 py-4">
-      <div className="w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-6 gap-y-2">
+      <div
+        className={`w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-6 gap-y-2 mx-auto ${
+          maxWidthClass ?? 'max-w-[95%] 2xl:max-w-[1440px]'
+        }`}
+      >
         <Link
           href="/"
           className="p-0 flex items-center cursor-pointer transition-transform duration-300 ease-out hover:scale-110 hover:-translate-y-1 hover:shadow-xl"
@@ -154,7 +163,11 @@ const BrandHeader: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
           ) : (
             !isAuthRoute && (
               <>
-                <Link href="/login" aria-label="Login" className="btn btn-ghost">
+                <Link
+                  href="/login"
+                  aria-label="Login"
+                  className="btn btn-ghost"
+                >
                   Login
                 </Link>
                 <Link

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -7,9 +7,14 @@ import BrandHeader from './BrandHeader';
 interface HeaderProps {
   theme?: string;
   setTheme?: React.Dispatch<React.SetStateAction<string>>;
+  maxWidthClass?: string;
 }
 
-const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
+const Header: FC<HeaderProps> = ({
+  theme = 'light',
+  setTheme,
+  maxWidthClass,
+}) => {
   const app = useContext(AppContext);
   const { data: session } = useSession();
   const role =
@@ -18,9 +23,21 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
       (session?.user as { role?: string } | undefined)?.role || ''
     ).toLowerCase();
   if (role === 'brand') {
-    return <BrandHeader theme={theme} setTheme={setTheme} />;
+    return (
+      <BrandHeader
+        theme={theme}
+        setTheme={setTheme}
+        maxWidthClass={maxWidthClass}
+      />
+    );
   }
-  return <UserHeader theme={theme} setTheme={setTheme} />;
+  return (
+    <UserHeader
+      theme={theme}
+      setTheme={setTheme}
+      maxWidthClass={maxWidthClass}
+    />
+  );
 };
 
 export default Header;

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -9,18 +9,28 @@ interface LayoutProps {
   maxWidthClass?: string;
 }
 
-const Layout: FC<LayoutProps> = ({ children, heroSecond }) => {
+const Layout: FC<LayoutProps> = ({ children, heroSecond, maxWidthClass }) => {
   // If useTheme returns [Theme, Dispatch<SetStateAction<Theme>>]
   const [theme, setTheme] = useTheme() as [
     string | Theme,
     Dispatch<SetStateAction<string | Theme>>,
   ];
 
+  const containerWidth = maxWidthClass ?? 'max-w-[95%] 2xl:max-w-[1440px]';
+
   return (
     <div className="flex flex-col min-h-screen overflow-x-hidden">
-      <Header theme={theme} setTheme={setTheme} />
-      {heroSecond && <div className="w-full">{heroSecond}</div>}
-      <main className={`w-full mx-auto flex-1 px-4 sm:px-6 lg:px-8 py-6 `}>
+      <Header
+        theme={theme}
+        setTheme={setTheme}
+        maxWidthClass={containerWidth}
+      />
+      {heroSecond && (
+        <div className={`w-full mx-auto ${containerWidth}`}>{heroSecond}</div>
+      )}
+      <main
+        className={`w-full mx-auto flex-1 px-4 sm:px-6 lg:px-8 py-6 ${containerWidth}`}
+      >
         {children}
       </main>
       <Footer />

--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -26,9 +26,14 @@ import type { User } from '@types/user';
 interface HeaderProps {
   theme?: string;
   setTheme?: React.Dispatch<React.SetStateAction<string>>;
+  maxWidthClass?: string;
 }
 
-const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
+const Header: FC<HeaderProps> = ({
+  theme = 'light',
+  setTheme,
+  maxWidthClass,
+}) => {
   const router = useRouter();
   const { data: session } = useSession();
   const appContext = useContext(AppContext);
@@ -112,7 +117,11 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
 
   return (
     <header className="relative bg-base-300 mb-6 py-4">
-      <div className="w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-6 gap-y-2">
+      <div
+        className={`w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-6 gap-y-2 mx-auto ${
+          maxWidthClass ?? 'max-w-[95%] 2xl:max-w-[1440px]'
+        }`}
+      >
         <Link
           href="/"
           className="p-0 flex items-center cursor-pointer transition-transform duration-300 ease-out hover:scale-110 hover:-translate-y-1 hover:shadow-xl"
@@ -128,7 +137,7 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
         </Link>
 
         <div className="flex-1 flex items-center gap-x-6 relative">
-        <button
+          <button
             type="button"
             aria-label="Toggle categories"
             className="md:hidden btn btn-ghost"
@@ -189,7 +198,9 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                           ) : null}
                         </Link>
                       ))}
-                      {categories.length === 0 && <span>No categories found</span>}
+                      {categories.length === 0 && (
+                        <span>No categories found</span>
+                      )}
                     </div>
                     {hoveredCat?.subcategories &&
                       hoveredCat.subcategories.length > 0 && (
@@ -316,21 +327,34 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                             : item.minPrice || '0'
                         );
                         return (
-                          <li key={item.id} className="flex items-center gap-2 py-2">
+                          <li
+                            key={item.id}
+                            className="flex items-center gap-2 py-2"
+                          >
                             <img
-                              src={item.featuredImage?.url || '/placeholder.png'}
+                              src={
+                                item.featuredImage?.url || '/placeholder.png'
+                              }
                               alt={item.title}
                               className="w-12 h-12 object-cover rounded"
                             />
                             <div className="flex flex-col flex-1">
-                              <p className="font-medium truncate">{item.title}</p>
+                              <p className="font-medium truncate">
+                                {item.title}
+                              </p>
                               <p className="text-xs">£{price.toFixed(2)}</p>
                             </div>
                             <div className="flex items-center gap-1">
                               <button
                                 type="button"
                                 className="btn btn-xs"
-                                onClick={() => changeQty(item.id as string, -1, item.variant?.id)}
+                                onClick={() =>
+                                  changeQty(
+                                    item.id as string,
+                                    -1,
+                                    item.variant?.id
+                                  )
+                                }
                               >
                                 -
                               </button>
@@ -338,7 +362,13 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                               <button
                                 type="button"
                                 className="btn btn-xs"
-                                onClick={() => changeQty(item.id as string, 1, item.variant?.id)}
+                                onClick={() =>
+                                  changeQty(
+                                    item.id as string,
+                                    1,
+                                    item.variant?.id
+                                  )
+                                }
                               >
                                 +
                               </button>
@@ -346,7 +376,12 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                             <button
                               type="button"
                               className="btn btn-ghost btn-xs text-error hover:text-red-600"
-                              onClick={() => removeFromCart(item.id as string, item.variant?.id)}
+                              onClick={() =>
+                                removeFromCart(
+                                  item.id as string,
+                                  item.variant?.id
+                                )
+                              }
                             >
                               <TrashIcon className="w-4 h-4" />
                               <span className="sr-only">Remove</span>
@@ -357,9 +392,25 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
                     </ul>
                     <div className="pt-2 mt-2 border-t">
                       <p className="font-semibold">
-                        Total: £{cart.reduce((s, i) => s + i.qty * parseFloat(typeof i.minPrice === 'number' ? i.minPrice.toString() : i.minPrice || '0'), 0).toFixed(2)}
+                        Total: £
+                        {cart
+                          .reduce(
+                            (s, i) =>
+                              s +
+                              i.qty *
+                                parseFloat(
+                                  typeof i.minPrice === 'number'
+                                    ? i.minPrice.toString()
+                                    : i.minPrice || '0'
+                                ),
+                            0
+                          )
+                          .toFixed(2)}
                       </p>
-                      <Link href="/cart" className="btn btn-primary btn-sm w-full mt-2">
+                      <Link
+                        href="/cart"
+                        className="btn btn-primary btn-sm w-full mt-2"
+                      >
                         View Cart
                       </Link>
                     </div>
@@ -406,7 +457,11 @@ const Header: FC<HeaderProps> = ({ theme = 'light', setTheme }) => {
           ) : (
             !isAuthRoute && (
               <>
-                <Link href="/login" aria-label="Login" className="btn btn-ghost">
+                <Link
+                  href="/login"
+                  aria-label="Login"
+                  className="btn btn-ghost"
+                >
                   Login
                 </Link>
                 <Link


### PR DESCRIPTION
## Summary
- pass width class through Layout -> Header
- apply max width container to Header, BrandHeader, UserHeader
- contain main layout to 1440px by default

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6613b6cc832f8a700f8b41a9465f