### PR TITLE
Improve cart summary design

### DIFF
--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -46,7 +46,7 @@ const Cart: React.FC = () => {
       </Head>
       <h1 className="text-3xl font-bold mb-4">Summary</h1>
       {cart.length === 0 && <p>Your cart is empty.</p>}
-      <ul className="space-y-2 mb-4">
+      <ul className="space-y-4 mb-6">
         {cart.map((item) => {
           const price = parseFloat(
             typeof item.minPrice === 'number'
@@ -57,32 +57,43 @@ const Cart: React.FC = () => {
           return (
             <li
               key={item.id}
-              className="border p-2 flex justify-between items-center"
+              className="bg-base-100 border p-4 rounded shadow flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
             >
-              <div>
+              <div className="flex-1">
                 <p className="font-medium">{item.title}</p>
-                <p className="text-sm">£{price.toFixed(2)} each</p>
+                <p className="text-sm text-gray-500">
+                  £{price.toFixed(2)} each
+                </p>
               </div>
-              <div className="flex items-center space-x-2">
+              <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-end">
+                <div className="flex items-center gap-2">
+                  <button
+                    className="btn btn-xs"
+                    onClick={() =>
+                      changeQty(item.id as string, -1, item.variant?.id)
+                    }
+                  >
+                    -
+                  </button>
+                  <span>{item.qty}</span>
+                  <button
+                    className="btn btn-xs"
+                    onClick={() =>
+                      changeQty(item.id as string, 1, item.variant?.id)
+                    }
+                  >
+                    +
+                  </button>
+                </div>
+                <span className="font-semibold">£{subtotal.toFixed(2)}</span>
                 <button
-                  className="btn btn-xs"
-                  onClick={() => changeQty(item.id as string, -1, item.variant?.id)}
+                  className="btn btn-ghost btn-xs text-gray-500 hover:bg-red-200"
+                  onClick={() =>
+                    removeFromCart(item.id as string, item.variant?.id)
+                  }
+                  aria-label="Remove"
                 >
-                  -
-                </button>
-                <span>{item.qty}</span>
-                <button
-                  className="btn btn-xs"
-                  onClick={() => changeQty(item.id as string, 1, item.variant?.id)}
-                >
-                  +
-                </button>
-                <span className="ml-2">£{subtotal.toFixed(2)}</span>
-                <button
-                  className="btn btn-xs btn-error"
-                  onClick={() => removeFromCart(item.id as string, item.variant?.id)}
-                >
-                  Remove
+                  🗑️
                 </button>
               </div>
             </li>
@@ -90,21 +101,25 @@ const Cart: React.FC = () => {
         })}
       </ul>
       {cart.length > 0 && (
-        <div className="border-t pt-4 flex justify-between items-center">
+        <div className="border-t pt-4 space-y-2">
           <div>
             <p className="font-semibold">Total Items: {itemCount}</p>
             <p className="font-semibold">Subtotal: £{totalPrice.toFixed(2)}</p>
-            <p className="font-semibold">Estimated Shipping: £{shippingCost.toFixed(2)}</p>
+            <p className="font-semibold">
+              Estimated Shipping: £{shippingCost.toFixed(2)}
+            </p>
             <p className="font-semibold">
               Total: £{(totalPrice + shippingCost).toFixed(2)}
             </p>
           </div>
-          <button
-            className="btn btn-primary"
-            onClick={() => router.push('/checkout')}
-          >
-            Checkout
-          </button>
+          <div className="flex justify-end">
+            <button
+              className="btn btn-primary"
+              onClick={() => router.push('/checkout')}
+            >
+              Checkout
+            </button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- enhance cart item styling with a card-like layout
- align quantity controls and add trash icon for item removal
- place checkout button under order total block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e67976a5c832f8ae157035b35f7be