### PR TITLE
Enhance categories menu with nested sub-categories

### DIFF
--- a/__tests__/Header.test.tsx
+++ b/__tests__/Header.test.tsx
@@ -73,7 +73,7 @@ test('renders categories from API', async () => {
     Promise.resolve({
       ok: true,
       json: () =>
-        Promise.resolve([{ name: 'Electronics', subcategories: ['Phones'] }]),
+        Promise.resolve([{ name: 'Electronics', subcategories: [{ name: 'Phones' }] }]),
     })
   );
   renderWithContext(<Header theme="light" setTheme={() => {}} />);

--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -11,6 +11,7 @@ import SunIcon from '../icons/SunIcon';
 import UserIcon from '../icons/UserIcon';
 import MenuIcon from '../icons/MenuIcon';
 import ChevronDownIcon from '../icons/ChevronDownIcon';
+import ChevronRightIcon from '../icons/ChevronRightIcon';
 import ElectronicsIcon from '../icons/ElectronicsIcon';
 import FashionIcon from '../icons/FashionIcon';
 import HomeIcon from '../icons/HomeIcon';
@@ -84,7 +85,13 @@ const Header: FC<HeaderProps> = ({
     fetch('/api/categories')
       .then((res) => res.json())
       .then((data) => {
-        const cats: Category[] = data.categories || data || DEFAULT_CATEGORIES;
+        const catsRaw: Category[] = data.categories || data || DEFAULT_CATEGORIES;
+        const cats = catsRaw.map((c) => ({
+          ...c,
+          subcategories: Array.isArray(c.subcategories)
+            ? c.subcategories.map((s) => (typeof s === 'string' ? { name: s } : s))
+            : undefined,
+        }));
         setCategories(filterCats(cats));
       })
       .catch(() => setCategories(filterCats(DEFAULT_CATEGORIES)));
@@ -192,9 +199,7 @@ const Header: FC<HeaderProps> = ({
                           {iconMap[cat.name] || null}
                           <span>{cat.name}</span>
                           {cat.subcategories?.length ? (
-                            <ChevronDownIcon
-                              className={`w-3 h-3 ml-auto transition-transform ${hoveredCat?.name === cat.name ? 'rotate-180' : ''}`}
-                            />
+                            <ChevronRightIcon className="w-3 h-3 ml-auto" />
                           ) : null}
                         </Link>
                       ))}
@@ -202,25 +207,28 @@ const Header: FC<HeaderProps> = ({
                         <span>No categories found</span>
                       )}
                     </div>
-                    {hoveredCat?.subcategories &&
-                      hoveredCat.subcategories.length > 0 && (
-                        <ul
-                          className="min-w-[200px] pl-4 space-y-1"
-                          role="menu"
-                        >
-                          {hoveredCat.subcategories.map((sub) => (
-                            <li key={sub} className="capitalize" role="none">
-                              <Link
-                                href={`/categories/${encodeURIComponent(hoveredCat.name)}?type=${encodeURIComponent(sub)}`}
-                                role="menuitem"
-                                className="block font-medium text-gray-800 tracking-wide transition-colors transition-transform duration-200 whitespace-nowrap truncate hover:text-primary hover:underline hover:scale-105"
-                              >
-                                {sub}
-                              </Link>
-                            </li>
-                          ))}
-                        </ul>
-                      )}
+                    {hoveredCat?.subcategories && hoveredCat.subcategories.length > 0 ? (
+                      <ul
+                        className="min-w-[200px] pl-4 space-y-1 fade-in"
+                        role="menu"
+                      >
+                        {hoveredCat.subcategories.map((sub) => (
+                          <li key={sub.name} className="capitalize" role="none">
+                            <Link
+                              href={`/categories/${encodeURIComponent(hoveredCat.name)}?type=${encodeURIComponent(sub.name)}`}
+                              role="menuitem"
+                              className="block font-medium text-gray-800 tracking-wide transition-colors transition-transform duration-200 whitespace-nowrap truncate hover:text-primary hover:underline hover:scale-105"
+                            >
+                              {sub.name}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <div className="min-w-[200px] pl-4 flex items-center text-sm text-gray-500">
+                        No sub-categories
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>
@@ -252,12 +260,12 @@ const Header: FC<HeaderProps> = ({
                   {cat.subcategories?.length && (
                     <ul className="pl-4 py-2 space-y-1">
                       {cat.subcategories.map((sub) => (
-                        <li key={sub} className="capitalize">
+                        <li key={sub.name} className="capitalize">
                           <Link
-                            href={`/categories/${encodeURIComponent(cat.name)}?type=${encodeURIComponent(sub)}`}
+                            href={`/categories/${encodeURIComponent(cat.name)}?type=${encodeURIComponent(sub.name)}`}
                             className="block py-1 transition-colors transition-transform duration-200 hover:text-primary hover:underline hover:scale-105"
                           >
-                            {sub}
+                            {sub.name}
                           </Link>
                         </li>
                       ))}

--- a/lib/defaultCategories.ts
+++ b/lib/defaultCategories.ts
@@ -1,23 +1,39 @@
 export const DEFAULT_CATEGORIES = [
   {
     name: 'Electronics',
-    subcategories: ['Phones', 'Computers', 'Cameras'],
+    subcategories: [
+      { name: 'Phones' },
+      { name: 'Computers' },
+      { name: 'Cameras' },
+    ],
   },
   {
     name: 'Fashion',
-    subcategories: ['Men', 'Women', 'Kids'],
+    subcategories: [{ name: 'Men' }, { name: 'Women' }, { name: 'Kids' }],
   },
   {
     name: 'Home',
-    subcategories: ['Furniture', 'Kitchen', 'Decor'],
+    subcategories: [
+      { name: 'Furniture' },
+      { name: 'Kitchen' },
+      { name: 'Decor' },
+    ],
   },
   {
     name: 'Toys',
-    subcategories: ['Games', 'Stuffed Animals', 'Educational'],
+    subcategories: [
+      { name: 'Games' },
+      { name: 'Stuffed Animals' },
+      { name: 'Educational' },
+    ],
   },
   {
     name: 'Sports',
-    subcategories: ['Fitness', 'Outdoor', 'Team Sports'],
+    subcategories: [
+      { name: 'Fitness' },
+      { name: 'Outdoor' },
+      { name: 'Team Sports' },
+    ],
   },
 ];
 export default DEFAULT_CATEGORIES;

--- a/types/category.ts
+++ b/types/category.ts
@@ -5,7 +5,7 @@ export interface Category {
   slug?: string;
   createdAt?: Date;
   updatedAt?: Date;
-  subcategories?: string[];
+  subcategories?: Category[];
 }
 
 export type CategoryInput = {


### PR DESCRIPTION
## Summary
- support nested category objects in `Category` type
- update default categories to use objects
- load/normalize category data on header fetch
- show right-arrow icon for categories with children
- fade in sub-category panel and show placeholder when empty
- update tests for new data shape

## Testing
- `npx jest`
- `npm run lint`
- `npm run type-check` *(fails: Prisma client types missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e7208d650832f8820a87ce708b108