### PR TITLE
Fix imports referencing '@types' alias

### DIFF
--- a/components/ActiveFilters.tsx
+++ b/components/ActiveFilters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ActiveFilter } from '@types/shared';
+import type { ActiveFilter } from '@/types/shared';
 
 interface ActiveFiltersProps {
   filters: ActiveFilter[];

--- a/components/InfiniteLoader.tsx
+++ b/components/InfiniteLoader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import type { InfiniteLoaderProps } from '@types/shared';
+import type { InfiniteLoaderProps } from '@/types/shared';
 
 const InfiniteLoader: React.FC<InfiniteLoaderProps> = ({
   onLoadMore,

--- a/components/Layout/BrandHeader.tsx
+++ b/components/Layout/BrandHeader.tsx
@@ -9,7 +9,7 @@ import MoonIcon from '../icons/MoonIcon';
 import SunIcon from '../icons/SunIcon';
 import UserIcon from '../icons/UserIcon';
 import NotificationBell from './NotificationBell';
-import type { User } from '@types/user';
+import type { User } from '@/types/user';
 
 interface HeaderProps {
   theme?: string;

--- a/components/Layout/SearchBar.tsx
+++ b/components/Layout/SearchBar.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
 import SearchIcon from '../icons/SearchIcon';
-import type { TrendingResponse, SuggestionsResponse } from '@types/api';
+import type { TrendingResponse, SuggestionsResponse } from '@/types/api';
 
 interface SearchBarProps {
   placeholder?: string;

--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -20,8 +20,8 @@ import DEFAULT_CATEGORIES from '@lib/defaultCategories';
 import TrashIcon from '../icons/TrashIcon';
 import SearchBar from './SearchBar';
 import DropdownMenu from '@components/common/DropdownMenu';
-import type { Category } from '@types/category';
-import type { User } from '@types/user';
+import type { Category } from '@/types/category';
+import type { User } from '@/types/user';
 
 interface HeaderProps {
   theme?: string;

--- a/components/Product/FeaturedProducts.tsx
+++ b/components/Product/FeaturedProducts.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import ProductCard from './ProductCard';
-import type { Product } from '@types/product';
+import type { Product } from '@/types/product';
 
 const FeaturedProducts: React.FC = () => {
   const [products, setProducts] = useState<Product[]>([]);

--- a/components/Product/ProductCard.tsx
+++ b/components/Product/ProductCard.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import ProductImageSlider from './ProductImageSlider';
 import { AppContext } from '@contexts/AppContext';
 import type { AppContextValue } from '../../types';
-import type { Product } from '@types/product';
+import type { Product } from '@/types/product';
 import { formatCurrency } from '@utils/formatCurrency';
 
 interface ProductCardProps {

--- a/components/Product/ProductFilters.tsx
+++ b/components/Product/ProductFilters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Category } from '@types/category';
+import type { Category } from '@/types/category';
 import InputField from '../UI/InputField';
 import { Checkbox } from '../form-fields';
 

--- a/components/Product/ProductGrid.tsx
+++ b/components/Product/ProductGrid.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ProductCard from './ProductCard';
 import ProductCardSkeleton from './ProductCardSkeleton';
-import type { Product } from '@types/product';
+import type { Product } from '@/types/product';
 
 interface ProductGridProps {
   products: Product[];

--- a/components/Product/ProductImageSlider.tsx
+++ b/components/Product/ProductImageSlider.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
-import type { Image as ProductImage } from '@types/image';
+import type { Image as ProductImage } from '@/types/image';
 import ChevronLeftIcon from '../icons/ChevronLeftIcon';
 import ChevronRightIcon from '../icons/ChevronRightIcon';
 

--- a/components/Product/RecommendedProducts.tsx
+++ b/components/Product/RecommendedProducts.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ProductCard from './ProductCard';
-import { Product } from '@types/product';
-import type { SearchResults } from '@types/api';
+import { Product } from '@/types/product';
+import type { SearchResults } from '@/types/api';
 
 interface RecommendedProductsProps {
   category?: string;

--- a/components/dashboard/ExistingProductsCard.tsx
+++ b/components/dashboard/ExistingProductsCard.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import DashboardCard from './DashboardCard';
 import BoxIcon from '../icons/BoxIcon';
-import type { Product } from '@types/product';
+import type { Product } from '@/types/product';
 
 interface Props {
   previewCount?: number;

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -8,10 +8,10 @@ import { NotificationContext } from './NotificationContext';
 
 import type { UserInfo } from '@lib/types';
 import type { AppContextValue } from '../types';
-import { Product } from '@types/product';
-import { Variant } from '@types/variant';
-import type { ShippingInfo } from '@types/shipping';
-import type { WishlistItem } from '@types/wishlist';
+import { Product } from '@/types/product';
+import { Variant } from '@/types/variant';
+import type { ShippingInfo } from '@/types/shipping';
+import type { WishlistItem } from '@/types/wishlist';
 
 export const AppContext = createContext<AppContextValue | undefined>(undefined);
 

--- a/hooks/useRequireAuth.ts
+++ b/hooks/useRequireAuth.ts
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import { useContext, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { AppContext } from '@contexts/AppContext';
-import type { User } from '@types/user';
+import type { User } from '@/types/user';
 
 export default function useRequireAuth() {
   const { user } = useContext(AppContext) as { user: User | null };

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
     '^@pages/(.*)$': '<rootDir>/pages/$1',
     '^@styles/(.*)$': '<rootDir>/styles/$1',
     '^@contexts/(.*)$': '<rootDir>/contexts/$1',
-    '^@types/(.*)$': '<rootDir>/types/$1',
+    '^@/types/(.*)$': '<rootDir>/types/$1',
     '^@test-utils/(.*)$': '<rootDir>/test-utils/$1',
   },
   transform: {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,6 +1,6 @@
 import { prisma } from './prisma';
-import type { Product } from '@types/product';
-import type { Review } from '@types/review';
+import type { Product } from '@/types/product';
+import type { Review } from '@/types/review';
 
 const cartStore = new Map<string, (Product & { qty: number })[]>();
 const wishlistStore = new Map<string, Product[]>();

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,10 +1,10 @@
 import { JSDOM } from 'jsdom';
 import { getDb } from './db';
-import type { Product, ProductInput } from '@types/product';
-import type { Variant } from '@types/variant';
+import type { Product, ProductInput } from '@/types/product';
+import type { Variant } from '@/types/variant';
 import { parseImages } from './utils/parseImages';
-import type { Category } from '@types/category';
-import type { Vendor } from '@types/vendor';
+import type { Category } from '@/types/category';
+import type { Vendor } from '@/types/vendor';
 import { Prisma } from '@prisma/client';
 import client from './typesenseClient';
 import { getBestSellingProducts } from './orders';

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,6 +1,6 @@
 import { getDb } from './db';
 import type { Prisma, Role } from '@prisma/client';
-import type { UserInput } from '@types/user';
+import type { UserInput } from '@/types/user';
 import bcrypt from 'bcryptjs';
 import { slugify } from './slugify';
 

--- a/lib/wishlist.ts
+++ b/lib/wishlist.ts
@@ -1,5 +1,5 @@
 import { prisma } from './prisma';
-import type { WishlistItem } from '@types/wishlist';
+import type { WishlistItem } from '@/types/wishlist';
 
 export async function addWishlistItem(params: {
   userId: number;

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -5,7 +5,7 @@ import GitHubProvider from 'next-auth/providers/github';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import bcrypt from 'bcryptjs';
 import { findUser, addUser } from '@lib/users';
-import type { User as AppUser } from '@types/user';
+import type { User as AppUser } from '@/types/user';
 
 // Extend the User type to include 'role'
 declare module 'next-auth' {

--- a/pages/api/products/[uuid].ts
+++ b/pages/api/products/[uuid].ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getProductByUuid, getAverageRating } from '@lib/db';
 import { mapDbRowToProduct } from '@lib/products';
-import { Product } from '@types/product';
+import { Product } from '@/types/product';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';

--- a/pages/api/products/[uuid]/reviews.ts
+++ b/pages/api/products/[uuid]/reviews.ts
@@ -11,7 +11,7 @@ import type {
   Review,
   ReviewsResponse,
   ReviewAddedResponse,
-} from '@types/review';
+} from '@/types/review';
 import type { ApiMessage } from '../../../../types';
 
 export default async function handler(

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getProductsPaginated } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { Product } from '@types/product';
+import type { Product } from '@/types/product';
 import type { ApiMessage } from '../../../types';
 
 export interface ProductsQuery {

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getBestSellingProducts } from '@lib/orders';
 import { getDb } from '@lib/db';
-import type { Product } from '@types/product';
+import type { Product } from '@/types/product';
 import type { SearchApiResponse, ApiMessage } from '../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { AppContext } from '@contexts/AppContext';
-import type { User } from '@types/user';
+import type { User } from '@/types/user';
 import ExistingProductsCard from '@components/dashboard/ExistingProductsCard';
 import TotalProductsCard from '@components/dashboard/TotalProductsCard';
 import TotalSalesCard from '@components/dashboard/TotalSalesCard';

--- a/pages/brand/products/index.tsx
+++ b/pages/brand/products/index.tsx
@@ -2,8 +2,8 @@ import React, { useContext, useEffect, useState } from 'react';
 import Link from 'next/link';
 import Head from 'next/head';
 import { AppContext } from '@contexts/AppContext';
-import type { User } from '@types/user';
-import type { Product } from '@types/product';
+import type { User } from '@/types/user';
+import type { Product } from '@/types/product';
 import { getPageTitle } from '@lib/pageTitle';
 
 const BrandProductsPage: React.FC = () => {

--- a/pages/brand/products/new.tsx
+++ b/pages/brand/products/new.tsx
@@ -5,7 +5,7 @@ import ProductForm from '@components/Product/ProductForm';
 import CreateCategoryModal from '@components/Category/CreateCategoryModal';
 import { AppContext } from '@contexts/AppContext';
 import { NotificationContext } from '@contexts/NotificationContext';
-import type { User } from '@types/user';
+import type { User } from '@/types/user';
 import { getPageTitle } from '@lib/pageTitle';
 import PageContainer from '@components/Layout/PageContainer';
 

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -5,7 +5,7 @@ import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
 import { AppContext } from '@contexts/AppContext';
 import type { AppContextValue } from '../types';
-import type { User } from '@types/user';
+import type { User } from '@/types/user';
 import type { Coupon } from '../types';
 import {
   TextInput,

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -10,7 +10,7 @@ import type {
   Review,
   ReviewsResponse,
   ReviewAddedResponse,
-} from '@types/review';
+} from '@/types/review';
 import { SelectDropdown, Textarea } from '@components/form-fields';
 import type { SelectOption } from '@components/form-fields/SelectDropdown';
 

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -14,8 +14,8 @@ import {
   PaginatedResult,
   getCategoriesFlat,
 } from '@lib/products';
-import type { Product } from '@types/product';
-import type { Category } from '@types/category';
+import type { Product } from '@/types/product';
+import type { Category } from '@/types/category';
 import { serializeDates } from '@utils/serializeDates';
 import { NotificationContext } from '../../contexts/NotificationContext';
 

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import useRequireAuth from '@hooks/useRequireAuth';
 import { getPageTitle } from '@lib/pageTitle';
-import type { User } from '@types/user';
+import type { User } from '@/types/user';
 import type { GetServerSideProps } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './api/auth/[...nextauth]';

--- a/pages/profile/edit.tsx
+++ b/pages/profile/edit.tsx
@@ -14,7 +14,7 @@ import {
   CountrySelect,
   FileUpload,
 } from '@components/form-fields';
-import type { User } from '@types/user';
+import type { User } from '@/types/user';
 
 interface FormValues {
   firstName: string;

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -12,7 +12,7 @@ import { getPageTitle } from '@lib/pageTitle';
 import HeroSlider from '@components/HeroSlider';
 import ProductCard from '@components/Product/ProductCard';
 import DEFAULT_CATEGORIES from '@lib/defaultCategories';
-import { Product } from '@types/product';
+import { Product } from '@/types/product';
 
 interface SearchResult extends Product {
   highlights?: { field: string; snippet: string }[];

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -3,7 +3,7 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 import { CountrySelect } from '@components/form-fields';
 import { useRouter } from 'next/router';
 import { AppContext } from '@contexts/AppContext';
-import type { User } from '@types/user';
+import type { User } from '@/types/user';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -110,8 +110,8 @@
       "@hooks/*": ["hooks/*"],
       "@pages/*": ["pages/*"],
       "@styles/*": ["styles/*"],
-      "@contexts/*": ["contexts/*"]
-      ,"@types/*": ["types/*"],
+      "@contexts/*": ["contexts/*"],
+      "@/types/*": ["types/*"],
       "@test-utils/*": ["test-utils/*"]
     }
   },


### PR DESCRIPTION
## Summary
- replace `@types` alias usage with `@/types`
- update tsconfig and jest path aliases

## Testing
- `npx jest` *(fails: Error: canceled)*
- `npm run type-check` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685e717bdff0832f9367419260fb7497