### PR TITLE
Fix country select field type

### DIFF
--- a/components/form-fields/CountrySelect.tsx
+++ b/components/form-fields/CountrySelect.tsx
@@ -73,7 +73,14 @@ const CountrySelect = <T extends FieldValues>(props: CountrySelectProps<T>) => {
           name={props.name}
           control={props.control}
           rules={props.rules}
-          render={({ field }) => select(field)}
+          render={({ field }) =>
+            select({
+              ...field,
+              value: countries.find((c) => c.value === field.value),
+              onChange: (option: CountryInfo | null) =>
+                field.onChange(option ? option.value : ''),
+            })
+          }
         />
       ) : (
         select({


### PR DESCRIPTION
## Summary
- keep form state as string for CountrySelect component so Prisma update doesn't fail

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: cannot fetch Prisma binaries)*

------
https://chatgpt.com/codex/tasks/task_e_685e73276834832fb14b37b43066e0b1