### PR TITLE
Fix order grouping and user name display

### DIFF
--- a/components/Layout/BrandHeader.tsx
+++ b/components/Layout/BrandHeader.tsx
@@ -133,9 +133,10 @@ const BrandHeader: FC<HeaderProps> = ({
                   <UserIcon className="w-5 h-5" />
                 )}
                 <span>
-                  {user.firstName || user.lastName
-                    ? `${user.firstName || ''} ${user.lastName || ''}`.trim()
-                    : user.email}
+                  {user.name?.trim() ||
+                    (user.firstName || user.lastName
+                      ? `${user.firstName || ''} ${user.lastName || ''}`.trim()
+                      : user.email)}
                 </span>
               </label>
               <ul

--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -85,11 +85,14 @@ const Header: FC<HeaderProps> = ({
     fetch('/api/categories')
       .then((res) => res.json())
       .then((data) => {
-        const catsRaw: Category[] = data.categories || data || DEFAULT_CATEGORIES;
+        const catsRaw: Category[] =
+          data.categories || data || DEFAULT_CATEGORIES;
         const cats = catsRaw.map((c) => ({
           ...c,
           subcategories: Array.isArray(c.subcategories)
-            ? c.subcategories.map((s) => (typeof s === 'string' ? { name: s } : s))
+            ? c.subcategories.map((s) =>
+                typeof s === 'string' ? { name: s } : s
+              )
             : undefined,
         }));
         setCategories(filterCats(cats));
@@ -207,7 +210,8 @@ const Header: FC<HeaderProps> = ({
                         <span>No categories found</span>
                       )}
                     </div>
-                    {hoveredCat?.subcategories && hoveredCat.subcategories.length > 0 ? (
+                    {hoveredCat?.subcategories &&
+                    hoveredCat.subcategories.length > 0 ? (
                       <ul
                         className="min-w-[200px] pl-4 space-y-1 fade-in"
                         role="menu"
@@ -347,10 +351,15 @@ const Header: FC<HeaderProps> = ({
                               className="w-12 h-12 object-cover rounded"
                             />
                             <div className="flex flex-col flex-1 min-w-0">
-                              <p className="font-medium text-sm line-clamp-2 break-words" title={item.title}>
+                              <p
+                                className="font-medium text-sm line-clamp-2 break-words"
+                                title={item.title}
+                              >
                                 {item.title}
                               </p>
-                              <p className="text-xs mt-0.5">£{price.toFixed(2)}</p>
+                              <p className="text-xs mt-0.5">
+                                £{price.toFixed(2)}
+                              </p>
                             </div>
                             <div className="flex items-center gap-1 min-w-[80px] justify-center">
                               <button
@@ -455,9 +464,10 @@ const Header: FC<HeaderProps> = ({
                   <UserIcon className="w-5 h-5" />
                 )}
                 <span>
-                  {user.firstName || user.lastName
-                    ? `${user.firstName || ''} ${user.lastName || ''}`.trim()
-                    : user.email}
+                  {user.name?.trim() ||
+                    (user.firstName || user.lastName
+                      ? `${user.firstName || ''} ${user.lastName || ''}`.trim()
+                      : user.email)}
                 </span>
               </label>
               <DropdownMenu items={menuItems} />

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo, Fragment } from 'react';
 import useRequireAuth from '@hooks/useRequireAuth';
 import type { Order } from '../types';
 import Head from 'next/head';
@@ -11,6 +11,22 @@ const Orders: React.FC<OrdersProps> = (_props) => {
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const groupedOrders = useMemo(() => {
+    const map = new Map<string, { order: Order; items: Order[] }>();
+    for (const o of orders) {
+      const key =
+        o.paymentReference || new Date(o.createdAt).toISOString().split('.')[0];
+      const existing = map.get(key);
+      if (existing) {
+        existing.items.push(o);
+      } else {
+        map.set(key, { order: o, items: [o] });
+      }
+    }
+    return Array.from(map.values());
+  }, [orders]);
 
   useEffect(() => {
     if (!user) return;
@@ -64,56 +80,82 @@ const Orders: React.FC<OrdersProps> = (_props) => {
               </tr>
             </thead>
             <tbody>
-              {orders.map((o) => (
-                <tr key={o.id} className="hover">
-                  <td>{o.id}</td>
-                  <td>
-                    <div className="flex items-center gap-2">
-                      <img
-                        src={
-                          o.product.featuredImage?.url ||
-                          `https://picsum.photos/seed/${o.product.id}/40/40`
-                        }
-                        alt={o.product.title}
-                        className="w-10 h-10 object-cover rounded"
-                      />
-                      <span className="whitespace-nowrap">
-                        {o.product.title}
+              {groupedOrders.map((group, idx) => (
+                <Fragment key={group.order.id}>
+                  <tr
+                    className="hover cursor-pointer"
+                    onClick={() => setExpanded(expanded === idx ? null : idx)}
+                  >
+                    <td>{group.order.id}</td>
+                    <td>{group.items.length}</td>
+                    <td>
+                      {group.order.user
+                        ? `${group.order.user.firstName || ''} ${
+                            group.order.user.lastName || ''
+                          }`.trim() || group.order.user.email
+                        : '-'}
+                    </td>
+                    <td>
+                      <span
+                        className={`badge ${
+                          group.order.status === 'processing'
+                            ? 'badge-warning'
+                            : group.order.status === 'shipped'
+                              ? 'badge-info'
+                              : group.order.status === 'delivered'
+                                ? 'badge-success'
+                                : 'badge-error'
+                        }`}
+                      >
+                        {group.order.status}
                       </span>
-                    </div>
-                  </td>
-                  <td>
-                    {o.user
-                      ? `${o.user.firstName || ''} ${o.user.lastName || ''}`.trim() ||
-                        o.user.email
-                      : '-'}
-                  </td>
-                  <td>
-                    <span
-                      className={`badge ${
-                        o.status === 'processing'
-                          ? 'badge-warning'
-                          : o.status === 'shipped'
-                          ? 'badge-info'
-                          : o.status === 'delivered'
-                          ? 'badge-success'
-                          : 'badge-error'
-                      }`}
-                    >
-                      {o.status}
-                    </span>
-                  </td>
-                  <td>£{o.total}</td>
-                  <td>{new Date(o.createdAt).toLocaleDateString()}</td>
-                  <td className="space-x-2">
-                    <a className="btn btn-sm" href={`/orders/${o.uuid}`}>
-                      View
-                    </a>
-                    <a className="link" href={`/api/orders/${o.uuid}/invoice`}>
-                      PDF
-                    </a>
-                  </td>
-                </tr>
+                    </td>
+                    <td>£{group.order.total}</td>
+                    <td>
+                      {new Date(group.order.createdAt).toLocaleDateString()}
+                    </td>
+                    <td className="space-x-2">
+                      <a
+                        className="btn btn-sm"
+                        href={`/orders/${group.order.uuid}`}
+                      >
+                        View
+                      </a>
+                      <a
+                        className="link"
+                        href={`/api/orders/${group.order.uuid}/invoice`}
+                      >
+                        PDF
+                      </a>
+                    </td>
+                  </tr>
+                  {expanded === idx && (
+                    <tr className="bg-base-200">
+                      <td colSpan={7} className="p-2">
+                        <ul className="space-y-1">
+                          {group.items.map((item) => (
+                            <li
+                              key={item.uuid}
+                              className="flex items-center gap-2"
+                            >
+                              <img
+                                src={
+                                  item.product.featuredImage?.url ||
+                                  `https://picsum.photos/seed/${item.product.id}/40/40`
+                                }
+                                alt={item.product.title}
+                                className="w-10 h-10 object-cover rounded"
+                              />
+                              <span className="flex-1 whitespace-nowrap">
+                                {item.product.title} x {item.quantity}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
               ))}
             </tbody>
           </table>


### PR DESCRIPTION
## Summary
- group order rows by payment reference or timestamp
- show grouped orders with expandable item list
- display user full name in brand and user headers

## Testing
- `npx jest --runInBand` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_685e765c61dc832f814247e59b260e99