### PR TITLE
Fix vendor brand and slug mapping

### DIFF
--- a/lib/products.ts
+++ b/lib/products.ts
@@ -20,7 +20,7 @@ interface ProductRow {
   slug?: string | null;
   sku: string;
   title: string;
-  vendor?: Vendor | null;
+  vendor?: (Vendor & { brandName: string | null }) | null;
   description?: string | null;
   productType?: string | null;
   tags?: string | null;
@@ -136,7 +136,9 @@ export function mapDbRowToProduct(row: ProductRow): Product {
 
   return processProductRow({
     ...rest,
-    vendor: row.vendor ?? null,
+    vendor: row.vendor
+      ? { ...row.vendor, brandName: row.vendor.brandName ?? '' }
+      : null,
     category: row.category ?? null,
     images: parseImages(images),
     totalInventory: quantity,
@@ -224,7 +226,7 @@ export async function addProduct(product: ProductInput): Promise<void> {
 
   const data: Prisma.ProductCreateInput = {
     uuid: product.uuid,
-    slug: product.slug?.trim() || slugify(product.title || product.uuid),
+    slug: (product.slug ?? '').trim() || slugify(product.title || product.uuid),
     sku: product.sku,
     title: product.title,
     description: product.description ?? '',


### PR DESCRIPTION
## Summary
- allow nullable brand name when mapping product rows
- handle missing vendor brand during product mapping
- trim slug defensively when creating new products

## Testing
- `npm run build` *(fails: React hook issues in unrelated files)*
- `npm run link:products-brand` *(fails: unable to compile TypeScript due to missing PrismaClient)*

------
https://chatgpt.com/codex/tasks/task_e_685e7b5eb3bc832f946ed91eda76df14