### PR TITLE
Fix vendor brandName type

### DIFF
--- a/types/vendor.ts
+++ b/types/vendor.ts
@@ -2,7 +2,7 @@ export interface Vendor {
   id?: number | string;
   uuid?: string;
   /** Display name used for the brand */
-  brandName: string;
+  brandName: string | null;
   email: string;
   phoneNumber?: string;
   address?: string;


### PR DESCRIPTION
## Summary
- allow null `vendor.brandName` in the Vendor type to match DB

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: JSX closing tag error)*

------
https://chatgpt.com/codex/tasks/task_e_685e94816698832f89370e4d027e890f