### PR TITLE
Enhance payment method card input

### DIFF
--- a/components/form-fields/CardNumberInput.tsx
+++ b/components/form-fields/CardNumberInput.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react';
+import {
+  FieldValues,
+  Path,
+  RegisterOptions,
+  UseFormRegister,
+} from 'react-hook-form';
+import CreditCardIcon from '../icons/CreditCardIcon';
+import VisaIcon from '../icons/VisaIcon';
+import MastercardIcon from '../icons/MastercardIcon';
+import AmexIcon from '../icons/AmexIcon';
+import DiscoverIcon from '../icons/DiscoverIcon';
+import {
+  CardBrand,
+  detectCardBrand,
+  formatCardNumber,
+} from '@utils/cardUtils';
+
+export interface CardNumberInputProps<T extends FieldValues>
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  name: Path<T>;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+  register?: UseFormRegister<T>;
+  rules?: RegisterOptions<T, Path<T>>;
+  onCardTypeChange?: (brand: CardBrand) => void;
+}
+
+type BrandMap = { [key in CardBrand]: React.FC<{ size?: number; className?: string }> };
+
+const icons: BrandMap = {
+  visa: VisaIcon,
+  mastercard: MastercardIcon,
+  amex: AmexIcon,
+  discover: DiscoverIcon,
+  unknown: CreditCardIcon,
+};
+
+const CardNumberInput = <T extends FieldValues>(props: CardNumberInputProps<T>) => {
+  const {
+    label,
+    name,
+    value: valueProp,
+    onChange,
+    onBlur,
+    error,
+    required = false,
+    disabled = false,
+    className = '',
+    register,
+    rules,
+    onCardTypeChange,
+    ...rest
+  } = props;
+  const inputId = rest.id || name;
+  const registration = register ? register(name, rules) : {};
+  const [value, setValue] = useState(valueProp || '');
+  const [brand, setBrand] = useState<CardBrand>('unknown');
+
+  useEffect(() => {
+    setValue(valueProp || '');
+    setBrand(detectCardBrand(valueProp || ''));
+  }, [valueProp]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const digits = e.target.value.replace(/\D/g, '');
+    const formatted = formatCardNumber(digits);
+    setValue(formatted);
+    const b = detectCardBrand(digits);
+    setBrand(b);
+    onCardTypeChange?.(b);
+    if (onChange) {
+      onChange({ ...e, target: { ...e.target, value: formatted } });
+    }
+  };
+
+  const Icon = icons[brand];
+
+  return (
+    <div className="mb-4 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {label} {required && <span className="text-red-500">*</span>}
+        </label>
+      )}
+      <div className="relative">
+        <input
+          type="text"
+          id={inputId}
+          name={name}
+          autoComplete="cc-number"
+          inputMode="numeric"
+          aria-label="Card number"
+          placeholder="1234 5678 9012 3456"
+          value={value}
+          onChange={handleChange}
+          onBlur={onBlur}
+          disabled={disabled}
+          required={required}
+          className={`input input-bordered w-full pr-10 ${
+            error ? 'border-red-500' : ''
+          } ${className}`}
+          {...registration}
+          {...rest}
+        />
+        <span className="absolute inset-y-0 right-3 flex items-center pointer-events-none">
+          <Icon size={20} />
+        </span>
+      </div>
+      {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default CardNumberInput;

--- a/components/form-fields/index.ts
+++ b/components/form-fields/index.ts
@@ -10,3 +10,4 @@ export { default as FileUpload } from './FileUpload';
 export { default as CountrySelect } from './CountrySelect';
 export { default as TagInput } from './TagInput';
 export { default as AddressAutocomplete } from './AddressAutocomplete';
+export { default as CardNumberInput } from './CardNumberInput';

--- a/components/icons/AmexIcon.tsx
+++ b/components/icons/AmexIcon.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const AmexIcon: React.FC<IconProps> = ({
+  size = 24,
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <rect x="0" y="4" width="24" height="16" rx="2" fill="#016FD0" />
+    <text
+      x="12"
+      y="16"
+      textAnchor="middle"
+      fontSize="8"
+      fontWeight="bold"
+      fill="white"
+    >
+      AMEX
+    </text>
+  </svg>
+);
+
+export default AmexIcon;

--- a/components/icons/CreditCardIcon.tsx
+++ b/components/icons/CreditCardIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const CreditCardIcon: React.FC<IconProps> = ({
+  size = 24,
+  color = 'currentColor',
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <rect x="2" y="5" width="20" height="14" rx="2" />
+    <path d="M2 10h20" />
+  </svg>
+);
+
+export default CreditCardIcon;

--- a/components/icons/DiscoverIcon.tsx
+++ b/components/icons/DiscoverIcon.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const DiscoverIcon: React.FC<IconProps> = ({
+  size = 24,
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <rect x="0" y="4" width="24" height="16" rx="2" fill="#F47216" />
+    <text
+      x="12"
+      y="16"
+      textAnchor="middle"
+      fontSize="7"
+      fontWeight="bold"
+      fill="white"
+    >
+      DISC
+    </text>
+  </svg>
+);
+
+export default DiscoverIcon;

--- a/lib/utils/cardUtils.ts
+++ b/lib/utils/cardUtils.ts
@@ -1,0 +1,33 @@
+export type CardBrand = 'visa' | 'mastercard' | 'amex' | 'discover' | 'unknown';
+
+export function formatCardNumber(value: string): string {
+  return value
+    .replace(/\D/g, '')
+    .replace(/(.{4})/g, '$1 ')
+    .trim();
+}
+
+export function detectCardBrand(value: string): CardBrand {
+  const digits = value.replace(/\D/g, '');
+  if (/^4/.test(digits)) return 'visa';
+  if (/^(5[1-5]|2[2-7])/.test(digits)) return 'mastercard';
+  if (/^3[47]/.test(digits)) return 'amex';
+  if (/^(6011|65|64[4-9])/.test(digits)) return 'discover';
+  return 'unknown';
+}
+
+export function luhnCheck(value: string): boolean {
+  const digits = value.replace(/\D/g, '');
+  let sum = 0;
+  let shouldDouble = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let digit = parseInt(digits.charAt(i), 10);
+    if (shouldDouble) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+    sum += digit;
+    shouldDouble = !shouldDouble;
+  }
+  return digits.length > 0 && sum % 10 === 0;
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -9,10 +9,12 @@ import {
   EmailInput,
   PasswordInput,
   CountrySelect,
+  CardNumberInput,
 } from '@components/form-fields';
 import PageContainer from '@components/Layout/PageContainer';
 import countries from '../data/countries';
 import type { PaymentMethod } from '../types';
+import { luhnCheck } from '@utils/cardUtils';
 
 interface ProfileFormValues {
   firstName: string;
@@ -56,6 +58,8 @@ const SettingsPage: React.FC = () => {
   const addressForm = useForm<AddressFormValues>();
   const emailForm = useForm<EmailFormValues>();
   const [methods, setMethods] = useState<PaymentMethod[]>([]);
+  const [cardNumber, setCardNumber] = useState('');
+  const [cardError, setCardError] = useState('');
 
   const tabButtonClass = (tab: typeof active) =>
     `w-full text-left px-2 py-2 rounded transition-colors hover:bg-base-200 ${
@@ -396,8 +400,14 @@ const SettingsPage: React.FC = () => {
               onSubmit={(e) => {
                 e.preventDefault();
                 const form = e.currentTarget as HTMLFormElement;
+                const number = cardNumber.replace(/\s+/g, '');
+                if (!luhnCheck(number)) {
+                  setCardError('Invalid card number');
+                  return;
+                }
+                setCardError('');
                 const data = {
-                  number: (form.number as HTMLInputElement).value,
+                  number,
                   expMonth: (form.expMonth as HTMLInputElement).value,
                   expYear: (form.expYear as HTMLInputElement).value,
                   cvc: (form.cvc as HTMLInputElement).value,
@@ -410,16 +420,18 @@ const SettingsPage: React.FC = () => {
                 })
                   .then(() => {
                     form.reset();
+                    setCardNumber('');
                     loadMethods();
                   })
                   .catch(() => {});
               }}
               className="space-y-2"
             >
-              <input
+              <CardNumberInput
                 name="number"
-                className="input input-bordered w-full"
-                placeholder="Card Number"
+                value={cardNumber}
+                onChange={(e) => setCardNumber(e.target.value)}
+                error={cardError}
               />
               <div className="flex gap-2">
                 <input


### PR DESCRIPTION
## Summary
- add utilities for card formatting, brand detection and Luhn check
- create credit card brand icons
- implement `CardNumberInput` component with formatting and icon
- use new card input on the settings page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686030f39a84832fa4eeadafe6441d10