### PR TITLE
Fix change email layout

### DIFF
--- a/components/form-fields/TextInput.tsx
+++ b/components/form-fields/TextInput.tsx
@@ -22,6 +22,7 @@ export interface TextInputProps<T extends FieldValues>
   rightAddon?: React.ReactNode;
   register?: UseFormRegister<T>;
   rules?: RegisterOptions<T, Path<T>>;
+  wrapperClassName?: string;
 }
 
 const TextInput = <T extends FieldValues>(props: TextInputProps<T>) => {
@@ -40,13 +41,14 @@ const TextInput = <T extends FieldValues>(props: TextInputProps<T>) => {
     rightAddon,
     register,
     rules,
+    wrapperClassName = '',
     ...rest
   } = props;
   const inputId = rest.id || name;
   const registration = register ? register(name, rules) : {};
 
   return (
-    <div className="mb-4 w-full">
+    <div className={`mb-4 w-full ${wrapperClassName}`}>
       {label && (
         <label
           htmlFor={inputId}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -333,14 +333,21 @@ const SettingsPage: React.FC = () => {
               rules={{ required: 'Required' }}
               error={emailForm.formState.errors.email?.message}
             />
-            <div className="flex items-end gap-2">
-              <TextInput
-                label="Verification Code"
-                register={emailForm.register}
-                name="token"
-                error={emailForm.formState.errors.token?.message}
-              />
-              <button type="button" className="btn" onClick={sendCode}>
+            <div className="flex flex-col sm:flex-row sm:items-end gap-2">
+              <div className="flex-1">
+                <TextInput
+                  label="Verification Code"
+                  register={emailForm.register}
+                  name="token"
+                  error={emailForm.formState.errors.token?.message}
+                  wrapperClassName="mb-0"
+                />
+              </div>
+              <button
+                type="button"
+                className="btn w-full sm:w-auto"
+                onClick={sendCode}
+              >
                 Send Code
               </button>
             </div>


### PR DESCRIPTION
## Summary
- allow custom wrapper classes for `TextInput`
- align `Send Code` with the verification input

## Testing
- `npm run type-check` *(fails: JSX element 'div' has no corresponding closing tag)*

------
https://chatgpt.com/codex/tasks/task_e_686031397894832fa230b01e8da2d2ee