### PR TITLE
Improve address field layout

### DIFF
--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -309,6 +309,7 @@ const SettingsPage: React.FC = () => {
                 name="address"
                 rules={{ required: 'Required' }}
                 error={addressForm.formState.errors.address?.message}
+                wrapperClassName="md:col-span-2"
               />
               <TextInput
                 label="City"


### PR DESCRIPTION
## Summary
- expand the address input width on the Manage Address form

## Testing
- `npm test` *(fails: Cannot read properties of undefined)*
- `npm run lint` *(fails with lint errors)*
- `npm run type-check` *(fails with TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_686037e48b08832f89a79fd136a22398