### PR TITLE
Fix CardNumberInput cleave instance assignment

### DIFF
--- a/components/form-fields/CardNumberInput.tsx
+++ b/components/form-fields/CardNumberInput.tsx
@@ -63,7 +63,7 @@ const CardNumberInput = <T extends FieldValues>(
   const registration = register ? register(name, rules) : {};
   const [value, setValue] = useState(valueProp || '');
   const [brand, setBrand] = useState<CardBrand>('unknown');
-  const cleaveRef = useRef<Cleave | null>(null);
+  const cleaveRef = useRef<any>(null);
 
   useEffect(() => {
     const val = valueProp || '';
@@ -124,12 +124,14 @@ const CardNumberInput = <T extends FieldValues>(
             error ? 'border-red-500' : ''
           } ${className}`}
           htmlRef={(ref: any) => {
-            cleaveRef.current = ref;
             if (typeof registration.ref === 'function') registration.ref(ref);
             else if (registration.ref)
               (
                 registration.ref as React.MutableRefObject<HTMLInputElement | null>
               ).current = ref;
+          }}
+          onInit={(cleave) => {
+            cleaveRef.current = cleave;
           }}
           {...rest}
         />


### PR DESCRIPTION
## Summary
- fix incorrect reference to Cleave instance so `setRawValue` works

## Testing
- `npm test` *(fails: TypeError in components unrelated to change)*
- `npm run type-check` *(fails: TS2339: Property 'id' does not exist on type ...)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686038f74ff8832f9753241523355315