### PR TITLE
Add current password verification

### DIFF
--- a/components/Settings/ChangePasswordSection.tsx
+++ b/components/Settings/ChangePasswordSection.tsx
@@ -4,6 +4,7 @@ import { PasswordInput } from '@components/form-fields';
 import { NotificationContext } from '@contexts/NotificationContext';
 
 interface PasswordFormValues {
+  current: string;
   password: string;
   confirm: string;
 }
@@ -14,20 +15,37 @@ const ChangePasswordSection: React.FC = () => {
   const passwordForm = useForm<PasswordFormValues>();
   const { addNotification } = useContext(NotificationContext);
 
-  const submitPassword: SubmitHandler<PasswordFormValues> = async ({ password }) => {
-    const res = await fetch('/api/user/profile', {
-      method: 'PUT',
+  const submitPassword: SubmitHandler<PasswordFormValues> = async ({
+    current,
+    password,
+  }) => {
+    const res = await fetch('/api/change-password', {
+      method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password }),
+      body: JSON.stringify({ currentPassword: current, newPassword: password }),
     });
+    let message = 'Change failed';
+    try {
+      const data = await res.json();
+      if (data?.message) message = data.message;
+    } catch {
+      // ignore
+    }
     if (res.ok) addNotification('Password changed', 'success');
-    else addNotification('Change failed', 'error');
+    else addNotification(message, 'error');
     passwordForm.reset();
   };
 
   return (
     <form onSubmit={passwordForm.handleSubmit(submitPassword)} className="space-y-2 max-w-md mx-auto">
       <h2 className="text-xl font-bold mb-2">Change Password</h2>
+      <PasswordInput
+        label="Current Password"
+        register={passwordForm.register}
+        name="current"
+        rules={{ required: 'Required' }}
+        error={passwordForm.formState.errors.current?.message}
+      />
       <PasswordInput
         label="New Password"
         register={passwordForm.register}

--- a/pages/api/change-password.ts
+++ b/pages/api/change-password.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import bcrypt from 'bcryptjs';
+import { authOptions } from './auth/[...nextauth]';
+import { findUser, updateUserProfile } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
+import type { ApiMessage } from '../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'POST')
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user)
+      return res.status(401).json({ message: 'Unauthorized' });
+
+    const { currentPassword, newPassword } = req.body as {
+      currentPassword?: string;
+      newPassword?: string;
+    };
+    if (!currentPassword || !newPassword)
+      return res
+        .status(400)
+        .json({ message: 'currentPassword and newPassword required' });
+
+    const user = await findUser(session.user.email);
+    if (!user || !(await bcrypt.compare(currentPassword, user.password))) {
+      return res.status(400).json({ message: 'Incorrect current password' });
+    }
+
+    const hashed = await bcrypt.hash(newPassword, 10);
+    await updateUserProfile(session.user.email, { password: hashed });
+    return res.status(200).json({ message: 'Password updated' });
+  } catch (e) {
+    return handleApiError(res, e, 'Failed to update password');
+  }
+}


### PR DESCRIPTION
## Summary
- add API endpoint to change password with verification
- require current password in ChangePasswordSection

## Testing
- `npm install` *(fails: prisma binary download blocked)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603cff14c0832f96eed1bc80f1bf88