### PR TITLE
Restrict direct email edits and add verification

### DIFF
--- a/components/Settings/ChangeEmailSection.tsx
+++ b/components/Settings/ChangeEmailSection.tsx
@@ -5,15 +5,16 @@ import { NotificationContext } from '@contexts/NotificationContext';
 
 interface EmailFormValues {
   email: string;
-  token: string;
+  oldToken: string;
+  newToken: string;
 }
 
 const ChangeEmailSection: React.FC = () => {
   const emailForm = useForm<EmailFormValues>();
-  const [codeSent, setCodeSent] = useState(false);
+  const [codesSent, setCodesSent] = useState(false);
   const { addNotification } = useContext(NotificationContext);
 
-  const sendCode = async () => {
+  const sendCodes = async () => {
     const email = emailForm.getValues('email');
     if (!email) return;
     const res = await fetch('/api/request-email-change', {
@@ -22,8 +23,8 @@ const ChangeEmailSection: React.FC = () => {
       body: JSON.stringify({ email }),
     });
     if (res.ok) {
-      setCodeSent(true);
-      addNotification('Verification code sent', 'success');
+      setCodesSent(true);
+      addNotification('Verification codes sent', 'success');
     } else {
       addNotification('Send failed', 'error');
     }
@@ -33,11 +34,15 @@ const ChangeEmailSection: React.FC = () => {
     const res = await fetch('/api/change-email', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(values),
+      body: JSON.stringify({
+        email: values.email,
+        oldToken: values.oldToken,
+        newToken: values.newToken,
+      }),
     });
     if (res.ok) {
       addNotification('Email updated', 'success');
-      setCodeSent(false);
+      setCodesSent(false);
       emailForm.reset();
     } else {
       addNotification('Update failed', 'error');
@@ -45,7 +50,10 @@ const ChangeEmailSection: React.FC = () => {
   };
 
   return (
-    <form onSubmit={emailForm.handleSubmit(submitEmailChange)} className="space-y-2 max-w-md mx-auto">
+    <form
+      onSubmit={emailForm.handleSubmit(submitEmailChange)}
+      className="space-y-2 max-w-md mx-auto"
+    >
       <h2 className="text-xl font-bold mb-2">Change Email</h2>
       <EmailInput
         label="New Email"
@@ -57,18 +65,32 @@ const ChangeEmailSection: React.FC = () => {
       <div className="flex flex-col sm:flex-row sm:items-end gap-2">
         <div className="flex-1">
           <TextInput
-            label="Verification Code"
+            label="Code from Old Email"
             register={emailForm.register}
-            name="token"
-            error={emailForm.formState.errors.token?.message}
+            name="oldToken"
+            error={emailForm.formState.errors.oldToken?.message}
             wrapperClassName="mb-0"
           />
         </div>
-        <button type="button" className="btn w-full sm:w-auto" onClick={sendCode}>
-          Send Code
+        <button
+          type="button"
+          className="btn w-full sm:w-auto"
+          onClick={sendCodes}
+        >
+          Send Codes
         </button>
       </div>
-      <button type="submit" className="btn btn-primary w-full" disabled={!codeSent}>
+      <TextInput
+        label="Code from New Email"
+        register={emailForm.register}
+        name="newToken"
+        error={emailForm.formState.errors.newToken?.message}
+      />
+      <button
+        type="submit"
+        className="btn btn-primary w-full"
+        disabled={!codesSent}
+      >
         Confirm
       </button>
     </form>

--- a/components/Settings/UpdateProfileSection.tsx
+++ b/components/Settings/UpdateProfileSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useContext } from 'react';
+import Link from 'next/link';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { TextInput, EmailInput } from '@components/form-fields';
 import { NotificationContext } from '@contexts/NotificationContext';
@@ -40,7 +41,10 @@ const UpdateProfileSection: React.FC = () => {
   };
 
   return (
-    <form onSubmit={profileForm.handleSubmit(submitProfile)} className="space-y-2 max-w-md mx-auto">
+    <form
+      onSubmit={profileForm.handleSubmit(submitProfile)}
+      className="space-y-2 max-w-md mx-auto"
+    >
       <h2 className="text-xl font-bold mb-2">Update Profile</h2>
       <TextInput
         label="First Name"
@@ -57,13 +61,24 @@ const UpdateProfileSection: React.FC = () => {
         rules={{ required: 'Required' }}
         error={profileForm.formState.errors.lastName?.message}
       />
-      <EmailInput
-        label="Email"
-        register={profileForm.register}
-        name="email"
-        rules={{ required: 'Required' }}
-        error={profileForm.formState.errors.email?.message}
-      />
+      <div className="flex gap-2 items-end">
+        <div className="flex-1">
+          <EmailInput
+            label="Email"
+            register={profileForm.register}
+            name="email"
+            readOnly
+            rules={{ required: 'Required' }}
+            error={profileForm.formState.errors.email?.message}
+          />
+        </div>
+        <Link
+          href={{ pathname: '/settings', query: { tab: 'email' } }}
+          className="btn btn-sm"
+        >
+          Change Email
+        </Link>
+      </div>
       <TextInput
         label="Phone Number"
         register={profileForm.register}

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -112,13 +112,15 @@ export function resetPassword(token: string, password: string) {
 
 export async function changeEmail(
   currentEmail: string,
-  token: string,
+  oldToken: string,
+  newToken: string,
   newEmail: string
 ) {
   const user = await prisma.user.findFirst({
     where: {
       email: currentEmail,
-      resetToken: token,
+      resetToken: oldToken,
+      verificationToken: newToken,
       resetExpires: { gt: new Date() },
     },
   });
@@ -127,7 +129,12 @@ export async function changeEmail(
   if (exists) throw new Error('Email exists');
   await prisma.user.update({
     where: { email: currentEmail },
-    data: { email: newEmail, resetToken: null, resetExpires: null },
+    data: {
+      email: newEmail,
+      resetToken: null,
+      resetExpires: null,
+      verificationToken: null,
+    },
   });
 }
 
@@ -142,11 +149,7 @@ export function findVendorByName(brandName: string) {
   });
 }
 
-export function getVendors(
-  search = '',
-  limit = 20,
-  offset = 0
-) {
+export function getVendors(search = '', limit = 20, offset = 0) {
   return prisma.user.findMany({
     where: {
       role: 'BRAND',

--- a/pages/api/change-email.ts
+++ b/pages/api/change-email.ts
@@ -13,11 +13,17 @@ export default async function handler(
     return res.status(405).json({ message: 'Method Not Allowed' });
   const session = await getServerSession(req, res, authOptions);
   if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
-  const { email, token } = req.body as { email?: string; token?: string };
-  if (!email || !token)
-    return res.status(400).json({ message: 'email and token required' });
+  const { email, oldToken, newToken } = req.body as {
+    email?: string;
+    oldToken?: string;
+    newToken?: string;
+  };
+  if (!email || !oldToken || !newToken)
+    return res
+      .status(400)
+      .json({ message: 'email, oldToken and newToken required' });
   try {
-    await changeEmail(session.user.email, token, email);
+    await changeEmail(session.user.email, oldToken, newToken, email);
     return res.status(200).json({ message: 'Email updated' });
   } catch (e) {
     return handleApiError(res, e, 'Error updating email');

--- a/pages/api/request-email-change.ts
+++ b/pages/api/request-email-change.ts
@@ -1,14 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { setResetToken, findUser } from '@lib/users';
+import { setResetToken, findUser, updateUserProfile } from '@lib/users';
 import crypto from 'crypto';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
-import type { ResetTokenResponse, ApiMessage } from '../../types';
+import type { EmailChangeTokensResponse, ApiMessage } from '../../types';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ResetTokenResponse | ApiMessage>
+  res: NextApiResponse<EmailChangeTokensResponse | ApiMessage>
 ): Promise<void> {
   try {
     if (req.method !== 'POST')
@@ -20,10 +20,14 @@ export default async function handler(
     if (!email) return res.status(400).json({ message: 'email required' });
     if (await findUser(email))
       return res.status(409).json({ message: 'Email exists' });
-    const token = crypto.randomBytes(6).toString('hex');
+    const oldToken = crypto.randomBytes(6).toString('hex');
+    const newToken = crypto.randomBytes(6).toString('hex');
     const expires = Date.now() + 3600 * 1000;
-    await setResetToken(session.user.email, token, expires);
-    return res.status(200).json({ message: 'Code sent', token });
+    await setResetToken(session.user.email, oldToken, expires);
+    await updateUserProfile(session.user.email, {
+      verificationToken: newToken,
+    });
+    return res.status(200).json({ message: 'Codes sent', oldToken, newToken });
   } catch (e) {
     return handleApiError(res, e, 'Failed to request email change');
   }

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
 import useRequireAuth from '@hooks/useRequireAuth';
@@ -12,9 +13,30 @@ import SettingsSidebar from '@components/Settings/SettingsSidebar';
 
 const SettingsPage: React.FC = () => {
   const user = useRequireAuth();
+  const router = useRouter();
   const [active, setActive] = useState<
     'profile' | 'password' | 'address' | 'email' | 'payments'
   >('profile');
+
+  useEffect(() => {
+    const tab = router.query.tab as string | undefined;
+    if (
+      tab === 'profile' ||
+      tab === 'password' ||
+      tab === 'address' ||
+      tab === 'email' ||
+      tab === 'payments'
+    ) {
+      setActive(tab);
+    }
+  }, [router.query.tab]);
+
+  const handleSelect = (tab: typeof active) => {
+    setActive(tab);
+    router.replace({ pathname: '/settings', query: { tab } }, undefined, {
+      shallow: true,
+    });
+  };
 
   if (!user) return null;
 
@@ -24,7 +46,7 @@ const SettingsPage: React.FC = () => {
         <Head>
           <title>{getPageTitle('Settings')}</title>
         </Head>
-        <SettingsSidebar active={active} onSelect={setActive} />
+        <SettingsSidebar active={active} onSelect={handleSelect} />
         <div className="flex-1">
           {active === 'profile' && <UpdateProfileSection />}
           {active === 'password' && <ChangePasswordSection />}

--- a/types/api.ts
+++ b/types/api.ts
@@ -54,6 +54,12 @@ export interface ResetTokenResponse {
   token: string;
 }
 
+export interface EmailChangeTokensResponse {
+  message: string;
+  oldToken: string;
+  newToken: string;
+}
+
 type CouponResponse = import('./coupon').Coupon;
 
 export interface CategoriesResponse {


### PR DESCRIPTION
## Summary
- show email read-only in profile settings
- add Change Email flow with old & new email verification codes
- update API to send/require both verification codes
- sync settings tab with URL query

## Testing
- `npm test` *(fails: 7 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68603f981b68832fa8f0a27f050b82a9