### PR TITLE
Fix ChangeEmailSection alignment

### DIFF
--- a/components/Settings/ChangeEmailSection.tsx
+++ b/components/Settings/ChangeEmailSection.tsx
@@ -54,7 +54,7 @@ const ChangeEmailSection: React.FC = () => {
         rules={{ required: 'Required' }}
         error={emailForm.formState.errors.email?.message}
       />
-      <div className="flex flex-col sm:flex-row sm:items-end gap-2">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2">
         <div className="flex-1">
           <TextInput
             label="Verification Code"


### PR DESCRIPTION
## Summary
- align verification code input with its button

## Testing
- `npm run lint`
- `npm run test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_686040ef8594832f8b8810aecc58fa4c