### PR TITLE
Fix cleave ref usage in card input

### DIFF
--- a/__tests__/CardNumberInput.test.tsx
+++ b/__tests__/CardNumberInput.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CardNumberInput from '@components/form-fields/CardNumberInput';
 
+let mockCleaveInstance: any = null;
+
 // Mock cleave.js to avoid relying on the real implementation in tests
 jest.mock('cleave.js/react', () => {
   const React = require('react');
@@ -10,13 +12,14 @@ jest.mock('cleave.js/react', () => {
     React.useEffect(() => {
       if (onInit) {
         const instance = {
-          setRawValue: (val: string) => {
+          setRawValue: jest.fn((val: string) => {
             if (inputRef.current) {
               inputRef.current.value = val.replace(/(\d{4})(?=\d)/g, '$1 ').trim();
             }
-          },
-          getFormattedValue: () => inputRef.current?.value || '',
+          }),
+          getFormattedValue: jest.fn(() => inputRef.current?.value || ''),
         };
+        mockCleaveInstance = instance;
         onInit(instance);
       }
     }, [onInit]);
@@ -72,4 +75,18 @@ test('invokes onCardTypeChange with detected brand', async () => {
   );
   fireEvent.change(input, { target: { value: '4111111111111111' } });
   expect(handleBrand).toHaveBeenCalledWith('visa');
+});
+
+test('exposes cleave instance and setRawValue does not throw', async () => {
+  const input = await setup(<CardNumberInput name="card" />);
+  expect(mockCleaveInstance).toBeTruthy();
+  expect(() => mockCleaveInstance.setRawValue('4111111111111111')).not.toThrow();
+});
+
+test('does not crash if change occurs before cleave init', () => {
+  const { getByLabelText } = render(<CardNumberInput name="card" />);
+  const input = getByLabelText(/card number/i) as HTMLInputElement;
+  expect(() => {
+    fireEvent.change(input, { target: { value: '4111111111111111' } });
+  }).not.toThrow();
 });

--- a/components/form-fields/CardNumberInput.tsx
+++ b/components/form-fields/CardNumberInput.tsx
@@ -69,23 +69,28 @@ const CardNumberInput = <T extends FieldValues>(
     const val = valueProp || '';
     setValue(val);
     setBrand(detectCardBrand(val));
-    cleaveRef.current?.setRawValue(val.replace(/\D/g, ''));
+    const digits = val.replace(/\D/g, '');
+    cleaveRef.current?.setRawValue?.(digits);
   }, [valueProp]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const digits = e.target.value.replace(/\D/g, '');
     const b = detectCardBrand(digits);
     const max = getCardMaxLength(b);
-    let trimmed = digits.slice(0, max);
-    if (cleaveRef.current) {
-      cleaveRef.current.setRawValue(trimmed);
-      trimmed = cleaveRef.current.getFormattedValue();
+    const raw = digits.slice(0, max);
+    const cleave = cleaveRef.current;
+    let formatted = raw;
+    if (cleave && typeof cleave.setRawValue === 'function') {
+      cleave.setRawValue(raw);
+      formatted = cleave.getFormattedValue();
+    } else {
+      formatted = raw.replace(/(\d{4})(?=\d)/g, '$1 ').trim();
     }
-    setValue(trimmed);
+    setValue(formatted);
     setBrand(b);
     onCardTypeChange?.(b);
     if (onChange) {
-      onChange({ ...e, target: { ...e.target, value: trimmed } });
+      onChange({ ...e, target: { ...e.target, value: formatted } });
     }
   };
 


### PR DESCRIPTION
## Summary
- handle missing cleave instance when value changes
- provide fallback formatting when cleave isn't ready
- expose cleave instance in tests and add regression checks

## Testing
- `npm test` *(fails: TypeError in Header.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68604183af9c832f9e30497fb39cdc51