### PR TITLE
Fix cleave recursion

### DIFF
--- a/__tests__/CardNumberInput.test.tsx
+++ b/__tests__/CardNumberInput.test.tsx
@@ -90,3 +90,12 @@ test('does not crash if change occurs before cleave init', () => {
     fireEvent.change(input, { target: { value: '4111111111111111' } });
   }).not.toThrow();
 });
+
+test('does not call setRawValue when value is unchanged', async () => {
+  const input = await setup(<CardNumberInput name="card" />);
+  mockCleaveInstance.setRawValue.mockClear();
+  fireEvent.change(input, { target: { value: '4111111111111111' } });
+  expect(mockCleaveInstance.setRawValue).toHaveBeenCalledTimes(1);
+  fireEvent.change(input, { target: { value: '4111 1111 1111 1111' } });
+  expect(mockCleaveInstance.setRawValue).toHaveBeenCalledTimes(1);
+});

--- a/components/form-fields/CardNumberInput.tsx
+++ b/components/form-fields/CardNumberInput.tsx
@@ -65,12 +65,19 @@ const CardNumberInput = <T extends FieldValues>(
   const [brand, setBrand] = useState<CardBrand>('unknown');
   const cleaveRef = useRef<any>(null);
   const [cleaveReady, setCleaveReady] = useState(false);
+  const lastRawValueRef = useRef('');
 
   const safeSetRawValue = (raw: string) => {
     const cleave = cleaveRef.current;
-    if (cleaveReady && cleave && typeof cleave.setRawValue === 'function') {
+    if (
+      cleaveReady &&
+      cleave &&
+      typeof cleave.setRawValue === 'function' &&
+      lastRawValueRef.current !== raw
+    ) {
       try {
         cleave.setRawValue(raw);
+        lastRawValueRef.current = raw;
       } catch (err) {
         console.error('Cleave setRawValue failed', err);
       }


### PR DESCRIPTION
## Summary
- prevent recursively calling `setRawValue` in CardNumberInput
- test that no additional call occurs when value hasn't changed

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: blocked domain binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_686045b88188832f8d3b20483c132090