### PR TITLE
Fix authOptions import paths

### DIFF
--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -3,7 +3,7 @@ import { getOrdersForVendorId } from '@lib/orders';
 import { handleApiError } from '@utils/handleApiError';
 import type { AnalyticsData, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -3,7 +3,7 @@ import { getCategoriesFlat, createCategory } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage, Category } from '../../../types';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/brand/earnings.ts
+++ b/pages/api/brand/earnings.ts
@@ -3,7 +3,7 @@ import { getOrdersForVendorId } from '@lib/orders';
 import { handleApiError } from '@utils/handleApiError';
 import type { EarningsData, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/brand/notifications.ts
+++ b/pages/api/brand/notifications.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { getNotificationsForUser, markNotificationsRead } from '@lib/notifications';
 import { findUser } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';

--- a/pages/api/brand/orders.ts
+++ b/pages/api/brand/orders.ts
@@ -3,7 +3,7 @@ import { getOrdersForVendorId } from '@lib/orders';
 import { handleApiError } from '@utils/handleApiError';
 import type { Order, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -12,7 +12,7 @@ import { uploadFileToS3 } from '@lib/s3';
 import path from 'path';
 import { withRole, type AuthedNextApiRequest } from '@lib/withRole';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { getDb } from '@lib/db';
 
 export const config = {

--- a/pages/api/brand/profile.ts
+++ b/pages/api/brand/profile.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateUserProfile, findUser } from '@lib/users';
 import type { Vendor, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
 
 export default async function handler(

--- a/pages/api/brand/stripe-account.ts
+++ b/pages/api/brand/stripe-account.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { stripe } from '@lib/stripe';
 import { findUser, updateUserProfile } from '@lib/users';
 

--- a/pages/api/cart.ts
+++ b/pages/api/cart.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCart, setCart } from '@lib/db';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from './auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
 import type { CartItem, ApiMessage } from '../../types';
 

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -7,7 +7,7 @@ import {
 } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from './auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import type {
   CategoriesResponse,
   CategoryResponse,

--- a/pages/api/categories/check-or-create.ts
+++ b/pages/api/categories/check-or-create.ts
@@ -3,7 +3,7 @@ import { getCategoriesFlat, createCategory } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage, Category } from '../../../types';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 
 interface CheckOrCreateResponse {
   exists?: boolean;

--- a/pages/api/change-email.ts
+++ b/pages/api/change-email.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { changeEmail } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from './auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import type { ApiMessage } from '../../types';
 
 export default async function handler(

--- a/pages/api/change-password.ts
+++ b/pages/api/change-password.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import bcrypt from 'bcryptjs';
-import { authOptions } from './auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { findUser, updateUserProfile } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage } from '../../types';

--- a/pages/api/messages/[orderId].ts
+++ b/pages/api/messages/[orderId].ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { createMessage, getMessagesForOrder } from '@lib/messages';
 import { getOrderByUuid } from '@lib/orders';
 import { findUser } from '@lib/users';

--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -15,7 +15,7 @@ import { withRole } from '@lib/withRole';
 import { sendOrderConfirmation } from '@lib/email';
 import { handleApiError } from '@utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from './auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import type { Order, OrderPlacedResponse, ApiMessage } from '../../types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import fs from 'fs';

--- a/pages/api/payment-methods/[id].ts
+++ b/pages/api/payment-methods/[id].ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import {
   setDefaultPaymentMethod,
   deletePaymentMethod,

--- a/pages/api/payment-methods/index.ts
+++ b/pages/api/payment-methods/index.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { paymentProvider } from '@lib/paymentProvider';
 import {
   addPaymentMethod,

--- a/pages/api/payments/charge.ts
+++ b/pages/api/payments/charge.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { paymentProvider } from '@lib/paymentProvider';
 import { recordPayment } from '@lib/payments';
 import { getDb } from '@lib/db';

--- a/pages/api/request-email-change.ts
+++ b/pages/api/request-email-change.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { setResetToken, findUser, updateUserProfile } from '@lib/users';
 import crypto from 'crypto';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from './auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
 import type { EmailChangeTokensResponse, ApiMessage } from '../../types';
 

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -4,7 +4,7 @@ import { getDb } from '@lib/db';
 import type { Product } from '@/types/product';
 import type { SearchApiResponse, ApiMessage } from '../../types';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from './auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import client from '@lib/typesenseClient';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';

--- a/pages/api/support.ts
+++ b/pages/api/support.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getDb } from '@lib/db';
 import { handleApiError } from '@utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from './auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {

--- a/pages/api/user/orders.ts
+++ b/pages/api/user/orders.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForUser } from '@lib/orders';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
 import type { Order, ApiMessage } from '../../../types';
 

--- a/pages/api/user/orders/[uuid].ts
+++ b/pages/api/user/orders/[uuid].ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { getOrderByUuid } from '@lib/orders';
 import { handleApiError } from '@utils/handleApiError';
 import type { Order, ApiMessage } from '../../../../types';

--- a/pages/api/user/orders/[uuid]/reorder.ts
+++ b/pages/api/user/orders/[uuid]/reorder.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { getOrderByUuid } from '@lib/orders';
 import { getProductByUuid, getCart, setCart } from '@lib/db';
 import { handleApiError } from '@utils/handleApiError';

--- a/pages/api/user/profile.ts
+++ b/pages/api/user/profile.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateUserProfile, findUser } from '@lib/users';
 import bcrypt from 'bcryptjs';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
 import type { User, ApiMessage } from '../../../types';
 import formidable, { type Fields, type Files, type File } from 'formidable';

--- a/pages/api/user/wishlist/[id].ts
+++ b/pages/api/user/wishlist/[id].ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { findUser } from '@lib/users';
 import { removeWishlistItem } from '@lib/wishlist';
 import { handleApiError } from '@utils/handleApiError';

--- a/pages/api/user/wishlist/index.ts
+++ b/pages/api/user/wishlist/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@lib/wishlist';
 import { handleApiError } from '@utils/handleApiError';
 import type { WishlistItem, ApiMessage } from '../../../../types';
-import { authOptions } from '../../auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/wishlist.ts
+++ b/pages/api/wishlist.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getWishlist, setWishlist } from '@lib/db';
 import { getServerSession } from 'next-auth/next';
-import { authOptions } from './auth/[...nextauth]';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
 import type { Product, ApiMessage } from '../../types';
 


### PR DESCRIPTION
## Summary
- use `@pages/api/auth/[...nextauth]` for next-auth imports across API routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860c92163e4832f828f327612e8a66a