### PR TITLE
Fix ProductRow vendor type mismatch

### DIFF
--- a/lib/products.ts
+++ b/lib/products.ts
@@ -137,7 +137,11 @@ export function mapDbRowToProduct(row: ProductRow): Product {
   return processProductRow({
     ...rest,
     vendor: row.vendor
-      ? { ...row.vendor, brandName: row.vendor.brandName ?? '' }
+      ? {
+          ...row.vendor,
+          brandName: row.vendor.brandName ?? '',
+          phoneNumber: row.vendor.phoneNumber ?? undefined,
+        }
       : null,
     category: row.category ?? null,
     images: parseImages(images),

--- a/types/category.ts
+++ b/types/category.ts
@@ -2,7 +2,7 @@ export interface Category {
   id?: number | string;
   uuid?: string;
   name: string;
-  slug?: string;
+  slug: string;
   createdAt?: Date;
   updatedAt?: Date;
   subcategories?: Category[];

--- a/types/user.ts
+++ b/types/user.ts
@@ -7,7 +7,7 @@ export interface User {
   firstName?: string;
   lastName?: string;
   role?: Role;
-  phoneNumber?: string;
+  phoneNumber?: string | null;
   address?: string;
   city?: string;
   country?: string;
@@ -38,7 +38,7 @@ export interface UserInput {
   lastName?: string;
   brandName?: string;
   gender?: string;
-  phoneNumber?: string;
+  phoneNumber?: string | null;
   address?: string;
   city?: string;
   country?: string;

--- a/types/vendor.ts
+++ b/types/vendor.ts
@@ -4,7 +4,7 @@ export interface Vendor {
   /** Display name used for the brand */
   brandName: string | null;
   email: string;
-  phoneNumber?: string;
+  phoneNumber?: string | null;
   address?: string;
   city?: string;
   country?: string;


### PR DESCRIPTION
## Summary
- allow nullable `phoneNumber` on `Vendor` and `User`
- make `Category.slug` required
- normalize vendor `phoneNumber` when mapping product rows

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run type-check` *(fails: Module '@prisma/client' has no exported members)*

------
https://chatgpt.com/codex/tasks/task_e_6860cd0e03bc832fa7e61cbfef37190c