### PR TITLE
Add vendor update script with reindex

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "generate:erd": "ts-node scripts/generateErd.ts",
     "seed:products": "ts-node scripts/seedProducts.ts",
     "update:quantities": "ts-node scripts/updateQuantities.ts",
+    "update:products-vendor": "ts-node -r tsconfig-paths/register scripts/update-products-vendor.ts",
     "link:products-brand": "ts-node -r tsconfig-paths/register scripts/linkProductsToBrand.ts"
   },
   "dependencies": {

--- a/scripts/update-products-vendor.ts
+++ b/scripts/update-products-vendor.ts
@@ -1,0 +1,29 @@
+import { prisma } from '@lib/prisma';
+import { loadAndIndexProducts } from '@lib/products';
+
+async function main() {
+  const email = process.env.BRAND_EMAIL || 'junaid@gmail.com';
+  const vendor = await prisma.user.findUnique({ where: { email } });
+  if (!vendor) {
+    throw new Error(`Vendor with email ${email} not found`);
+  }
+
+  const result = await prisma.product.updateMany({
+    data: { vendorId: vendor.id },
+  });
+  console.log(`Updated ${result.count} products to vendor ${email}`);
+
+  try {
+    const { products } = await loadAndIndexProducts();
+    console.log(`Re-indexed ${products.length} products`);
+  } catch (err) {
+    console.error('Failed to re-index products', err);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  prisma.$disconnect().finally(() => process.exit(1));
+});


### PR DESCRIPTION
## Summary
- add `update-products-vendor.ts` script to set vendorId for all products and reindex to Typesense
- expose script via new npm script `update:products-vendor`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611dbcf9f4832fbb55312c3cb607c7