### PR TITLE
Fix full-width brand dashboard header

### DIFF
--- a/components/Layout/BrandHeader.tsx
+++ b/components/Layout/BrandHeader.tsx
@@ -14,13 +14,11 @@ import type { User } from '@/types/user';
 interface HeaderProps {
   theme?: string;
   setTheme?: React.Dispatch<React.SetStateAction<string>>;
-  maxWidthClass?: string;
 }
 
 const BrandHeader: FC<HeaderProps> = ({
   theme = 'light',
   setTheme,
-  maxWidthClass,
 }) => {
   const router = useRouter();
   const { data: session } = useSession();
@@ -37,11 +35,9 @@ const BrandHeader: FC<HeaderProps> = ({
   const logout = () => signOut({ callbackUrl: '/', redirect: true });
 
   return (
-    <header className="relative bg-base-300 mb-6 py-4">
+    <header className="relative bg-base-300 mb-6 py-4 shadow-md border-b border-base-200">
       <div
-        className={`w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-6 gap-y-2 mx-auto ${
-          maxWidthClass ?? 'max-w-[95%] 2xl:max-w-[1440px]'
-        }`}
+        className="w-full px-4 sm:px-6 lg:px-8 flex flex-wrap items-center gap-x-6 gap-y-2"
       >
         <Link
           href="/"

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -27,7 +27,6 @@ const Header: FC<HeaderProps> = ({
       <BrandHeader
         theme={theme}
         setTheme={setTheme}
-        maxWidthClass={maxWidthClass}
       />
     );
   }


### PR DESCRIPTION
## Summary
- stretch brand dashboard header across the viewport
- remove unused prop wiring

## Testing
- `npm test`
- `npx next lint` *(fails: React Hooks error in pages/product/[slug].tsx)*
- `npm run type-check` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6863d71da56c832fbe07f9c7d6aaaf29