### PR TITLE
Enable product editing in brand portal

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -9,7 +9,10 @@ const reviewsStore = new Map<string, Review[]>();
 export const getDb = () => prisma;
 
 export async function getProductByUuid(uuid: string) {
-  return prisma.product.findUnique({ where: { uuid }, include: { variants: true } });
+  return prisma.product.findUnique({
+    where: { uuid },
+    include: { variants: true, vendor: true, category: true },
+  });
 }
 
 export async function getProductBySlug(slug: string) {

--- a/pages/brand/products/new.tsx
+++ b/pages/brand/products/new.tsx
@@ -1,15 +1,18 @@
-import React, { useContext, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import ProductForm from '@components/Product/ProductForm';
 import CreateCategoryModal from '@components/Category/CreateCategoryModal';
 import { AppContext } from '@contexts/AppContext';
 import { NotificationContext } from '@contexts/NotificationContext';
 import type { User } from '@/types/user';
+import type { Product, ProductFormValues } from '@/types';
 import { getPageTitle } from '@lib/pageTitle';
 import PageContainer from '@components/Layout/PageContainer';
 
 const NewProductPage: React.FC = () => {
+  const router = useRouter();
   const { user } = useContext(AppContext) as { user: User | null };
   const { addNotification } = useContext(NotificationContext);
 
@@ -21,19 +24,74 @@ const NewProductPage: React.FC = () => {
   const [formKey, setFormKey] = useState(0);
   const [serverError, setServerError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [fetching, setFetching] = useState(false);
+  const [fetchError, setFetchError] = useState('');
+  const [initialValues, setInitialValues] = useState<
+    Partial<ProductFormValues> | undefined
+  >(undefined);
+
+  const editId =
+    typeof router.query.edit === 'string' ? router.query.edit : undefined;
+
+  useEffect(() => {
+    if (!editId) {
+      setInitialValues(undefined);
+      return;
+    }
+    setFetching(true);
+    setFetchError('');
+    fetch(`/api/products/${encodeURIComponent(editId)}`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(res.statusText);
+        const data: Product = await res.json();
+        const init: Partial<ProductFormValues> = {
+          id: data.uuid || String(data.id),
+          vendor: data.vendor?.brandName || '',
+          sku: data.sku || '',
+          title: data.title || '',
+          description: data.description || '',
+          productType: data.productType || '',
+          tags:
+            data.tags?.split(',').map((t) => t.trim()).filter(Boolean) || [],
+          categoryId: data.category?.id
+            ? String(data.category.id)
+            : data.categoryId
+            ? String(data.categoryId)
+            : '',
+          quantity: data.quantity ?? 0,
+          minPrice: data.minPrice ?? 0,
+          maxPrice: data.maxPrice ?? 0,
+          currency: data.currency || 'USD',
+          discountType:
+            (data.discountType as 'percentage' | 'fixed' | null) || 'none',
+          discountValue: data.discountValue ?? undefined,
+          available: (data.quantity ?? 0) > 0,
+        };
+        setInitialValues(init);
+      })
+      .catch(() => setFetchError('Failed to load product'))
+      .finally(() => setFetching(false));
+  }, [editId]);
 
   const submitProduct = async (values: FormData) => {
     setServerError('');
     setLoading(true);
     try {
-      const res = await fetch('/api/brand/products', {
-        method: 'POST',
+      const url = editId
+        ? `/api/brand/products/${encodeURIComponent(editId)}`
+        : '/api/brand/products';
+      const method = editId ? 'PUT' : 'POST';
+      const res = await fetch(url, {
+        method,
         credentials: 'include',
         body: values,
       });
       if (res.ok) {
-        addNotification('Product added', 'success');
-        setFormKey((k) => k + 1);
+        addNotification(
+          editId ? 'Product updated' : 'Product added',
+          'success'
+        );
+        if (!editId) setFormKey((k) => k + 1);
       } else {
         const data = await res.json().catch(() => ({ error: 'Error' }));
         setServerError(data.error || data.message || 'Error');
@@ -93,19 +151,31 @@ const NewProductPage: React.FC = () => {
   return (
     <div className="min-h-screen flex items-center justify-center overflow-auto px-4 py-6 sm:px-6 lg:px-8">
       <Head>
-        <title>{getPageTitle('New Product')}</title>
+        <title>{getPageTitle(editId ? 'Edit Product' : 'New Product')}</title>
       </Head>
       <PageContainer>
-        <h1 className="text-2xl font-bold mb-4 text-center">Add New Product</h1>
-        <ProductForm
-          key={formKey}
-          onSubmit={submitProduct}
-          submitLabel="Add Product"
-          requestNewCategory={requestNewCategory}
-          requestNewVendor={requestNewVendor}
-          loading={loading}
-          serverError={serverError}
-        />
+        <h1 className="text-2xl font-bold mb-4 text-center">
+          {editId ? 'Edit Product' : 'Add New Product'}
+        </h1>
+        {fetchError && (
+          <p className="text-error text-center mb-2">{fetchError}</p>
+        )}
+        {fetching && !initialValues ? (
+          <div className="flex justify-center py-4">
+            <span className="loading loading-spinner"></span>
+          </div>
+        ) : (
+          <ProductForm
+            key={formKey}
+            onSubmit={submitProduct}
+            submitLabel={editId ? 'Update Product' : 'Add Product'}
+            requestNewCategory={requestNewCategory}
+            requestNewVendor={requestNewVendor}
+            loading={loading}
+            initial={initialValues}
+            serverError={serverError}
+          />
+        )}
         <CreateCategoryModal
           isOpen={catModalOpen}
           initialName={catInitialName}


### PR DESCRIPTION
## Summary
- load vendor and category in `getProductByUuid`
- fetch product details in `brand/products/new` when `?edit=` param is present
- pre-fill product form and submit updates via PUT

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run type-check` *(fails with TS errors)*


------
https://chatgpt.com/codex/tasks/task_e_6863d805fc00832f99c118c21f3f71d8