### PR TITLE
Add brand product sorting and scroll

### DIFF
--- a/components/brand/BrandProductSort.tsx
+++ b/components/brand/BrandProductSort.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export type BrandProductSortValue =
+  | 'title_asc'
+  | 'title_desc'
+  | 'category_asc'
+  | 'category_desc'
+  | 'quantity_asc'
+  | 'quantity_desc';
+
+interface BrandProductSortProps {
+  value: BrandProductSortValue;
+  onChange: (v: BrandProductSortValue) => void;
+}
+
+const BrandProductSort: React.FC<BrandProductSortProps> = ({ value, onChange }) => (
+  <div className="flex items-center gap-2">
+    <label htmlFor="brand-sort" className="font-medium">
+      Sort by:
+    </label>
+    <select
+      id="brand-sort"
+      className="select select-sm select-bordered"
+      value={value}
+      onChange={(e) => onChange(e.target.value as BrandProductSortValue)}
+    >
+      <option value="title_asc">Name (A-Z)</option>
+      <option value="title_desc">Name (Z-A)</option>
+      <option value="category_asc">Category (A-Z)</option>
+      <option value="category_desc">Category (Z-A)</option>
+      <option value="quantity_asc">Quantity (Low-High)</option>
+      <option value="quantity_desc">Quantity (High-Low)</option>
+    </select>
+  </div>
+);
+
+export default BrandProductSort;

--- a/components/brand/BrandProductsPage.tsx
+++ b/components/brand/BrandProductsPage.tsx
@@ -8,12 +8,14 @@ import type { Product } from '@/types/product';
 import { getPageTitle } from '@lib/pageTitle';
 import ProductTable from './ProductTable';
 import ProductDetailsModal from './ProductDetailsModal';
+import BrandProductSort, { BrandProductSortValue } from './BrandProductSort';
 
 const BrandProductsPage: React.FC = () => {
   const router = useRouter();
   const { user } = useContext(AppContext) as { user: User | null };
   const [products, setProducts] = useState<Product[]>([]);
   const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<BrandProductSortValue>('title_asc');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [viewProduct, setViewProduct] = useState<Product | null>(null);
@@ -22,12 +24,12 @@ const BrandProductsPage: React.FC = () => {
     if (!user) return;
     setLoading(true);
     setError('');
-    fetch('/api/brand/products', { credentials: 'include' })
+    fetch(`/api/brand/products?sort=${sort}`, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : Promise.reject(res)))
       .then((data: { products: Product[]; total: number }) => setProducts(data.products))
       .catch(() => setError('Failed to load products'))
       .finally(() => setLoading(false));
-  }, [user]);
+  }, [user, sort]);
 
   const slug = router.query.slug as string | undefined;
   useEffect(() => {
@@ -94,13 +96,16 @@ const BrandProductsPage: React.FC = () => {
           Add New Product
         </Link>
       </div>
-      <input
-        type="text"
-        className="input input-bordered w-full sm:w-80"
-        placeholder="Search products"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-      />
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+        <input
+          type="text"
+          className="input input-bordered w-full sm:w-80"
+          placeholder="Search products"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <BrandProductSort value={sort} onChange={setSort} />
+      </div>
       {loading ? (
         <div className="flex justify-center my-4">
           <span className="loading loading-spinner"></span>

--- a/components/brand/ProductTable.tsx
+++ b/components/brand/ProductTable.tsx
@@ -15,7 +15,7 @@ const ProductTable: React.FC<ProductTableProps> = ({ products, onView, onDelete 
 
   return (
     <div className="overflow-x-auto">
-      <div className="max-h-[80vh] overflow-y-auto">
+      <div className="max-h-[70vh] overflow-y-auto">
         <table className="table w-full">
           <thead>
             <tr>

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -56,6 +56,24 @@ async function handler(
       const limit = parseInt(String((req.query.limit as string) || '20'), 10);
       const skip = (page - 1) * limit;
 
+      const sortParam = String((req.query.sort as string) || 'title_asc');
+      const orderBy = (() => {
+        switch (sortParam) {
+          case 'title_desc':
+            return { title: 'desc' } as const;
+          case 'category_asc':
+            return { category: { name: 'asc' } } as const;
+          case 'category_desc':
+            return { category: { name: 'desc' } } as const;
+          case 'quantity_desc':
+            return { quantity: 'desc' } as const;
+          case 'quantity_asc':
+            return { quantity: 'asc' } as const;
+          default:
+            return { title: 'asc' } as const;
+        }
+      })();
+
       const vendorId = (session.user as { brandId?: number }).brandId;
       if (!vendorId) {
         console.warn('Missing brandId for brand user', session.user);
@@ -66,7 +84,7 @@ async function handler(
         db.product.findMany({
           where: { vendorId },
           include: { category: true, vendor: true },
-          orderBy: { id: 'asc' },
+          orderBy,
           take: limit,
           skip,
         }),


### PR DESCRIPTION
## Summary
- make brand product table scrollable
- add sorting dropdown for brand products
- implement server-side sorting for brand products

## Testing
- `npm test` *(fails: jest not installed)*
- `npm run lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863d7925310832fb4436dd06d04a657