### PR TITLE
Improve brand order history

### DIFF
--- a/components/brand/OrderDetailsModal.tsx
+++ b/components/brand/OrderDetailsModal.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import Image from 'next/image';
+import { GenericModal, StatusLabel } from '@components/UI';
+import type { Order } from '@/types';
+
+interface OrderGroup {
+  order: Order;
+  items: Order[];
+}
+
+interface Props {
+  group: OrderGroup | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const OrderDetailsModal: React.FC<Props> = ({ group, isOpen, onClose }) => {
+  if (!group) return null;
+  const { order, items } = group;
+
+  const customer = order.user
+    ? `${order.user.firstName || ''} ${order.user.lastName || ''}`.trim() ||
+      order.user.email
+    : '-';
+
+  return (
+    <GenericModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`Order #${order.id}`}
+    >
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <StatusLabel
+            color={
+              order.status === 'processing'
+                ? 'warning'
+                : order.status === 'shipped'
+                ? 'info'
+                : order.status === 'delivered'
+                ? 'success'
+                : 'error'
+            }
+          >
+            {order.status}
+          </StatusLabel>
+          <span>{new Date(order.createdAt).toLocaleDateString()}</span>
+        </div>
+        <p className="text-sm">Customer: {customer}</p>
+        <p className="text-sm font-semibold">Total: £{order.total}</p>
+        <ul className="divide-y divide-base-200">
+          {items.map((item) => (
+            <li key={item.uuid} className="flex gap-2 py-2 items-center">
+              <div className="relative w-12 h-12 shrink-0 overflow-hidden rounded">
+                <Image
+                  src={
+                    item.product.featuredImage?.url ||
+                    `https://picsum.photos/seed/${item.product.id}/80/80`
+                  }
+                  alt={item.product.title}
+                  fill
+                  sizes="80px"
+                  className="object-cover"
+                />
+              </div>
+              <span className="flex-1">{item.product.title}</span>
+              <span className="whitespace-nowrap">x {item.quantity}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="flex justify-end">
+          <button type="button" className="btn" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </GenericModal>
+  );
+};
+
+export default OrderDetailsModal;

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -1,9 +1,10 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { AppContext } from '@contexts/AppContext';
 import { useSession } from 'next-auth/react';
 import { Order } from '../../types';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
+import OrderDetailsModal from '@components/brand/OrderDetailsModal';
 
 const BrandOrders: React.FC = () => {
   const { user } = useContext(AppContext)!;
@@ -11,6 +12,21 @@ const BrandOrders: React.FC = () => {
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [viewGroup, setViewGroup] = useState<{ order: Order; items: Order[] } | null>(null);
+
+  const groupedOrders = useMemo(() => {
+    const map = new Map<string, { order: Order; items: Order[] }>();
+    for (const o of orders) {
+      const key = o.paymentReference || new Date(o.createdAt).toISOString().split('.')[0];
+      const existing = map.get(key);
+      if (existing) {
+        existing.items.push(o);
+      } else {
+        map.set(key, { order: o, items: [o] });
+      }
+    }
+    return Array.from(map.values());
+  }, [orders]);
 
   useEffect(() => {
     if (!user || status === 'loading') return;
@@ -33,7 +49,7 @@ const BrandOrders: React.FC = () => {
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="max-w-4xl mx-auto">
       <Head>
         <title>{getPageTitle('Brand Orders')}</title>
       </Head>
@@ -44,22 +60,74 @@ const BrandOrders: React.FC = () => {
           <span className="loading loading-spinner"></span>
         </div>
       )}
-      <ul className="space-y-2">
-        {orders.map((o) => (
-          <li key={o.id} className="border p-2 space-y-1">
-            <p>
-              Order #{o.id} - {o.status}
-            </p>
-            <p>Total: £{o.total}</p>
-            <p>
-              <a className="link" href={`/messages/${o.uuid}`}>
-                Chat
-              </a>
-            </p>
-          </li>
-        ))}
-        {!loading && orders.length === 0 && <li>No orders found.</li>}
-      </ul>
+      {groupedOrders.length > 0 ? (
+        <div className="overflow-x-auto">
+          <div className="max-h-[70vh] overflow-y-auto">
+            <table className="table w-full">
+              <thead>
+                <tr>
+                  <th>Order #</th>
+                  <th>Items</th>
+                  <th>Customer</th>
+                  <th>Status</th>
+                  <th>Total</th>
+                  <th>Date</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {groupedOrders.map((g, idx) => (
+                  <tr key={idx} className="hover">
+                    <td>{g.order.id}</td>
+                    <td>{g.items.length}</td>
+                    <td>
+                      {g.order.user
+                        ? `${g.order.user.firstName || ''} ${
+                            g.order.user.lastName || ''
+                          }`.trim() || g.order.user.email
+                        : '-'}
+                    </td>
+                    <td>
+                      <span
+                        className={`badge ${
+                          g.order.status === 'processing'
+                            ? 'badge-warning'
+                            : g.order.status === 'shipped'
+                            ? 'badge-info'
+                            : g.order.status === 'delivered'
+                            ? 'badge-success'
+                            : 'badge-error'
+                        }`}
+                      >
+                        {g.order.status}
+                      </span>
+                    </td>
+                    <td>£{g.order.total}</td>
+                    <td>{new Date(g.order.createdAt).toLocaleDateString()}</td>
+                    <td className="space-x-2 whitespace-nowrap">
+                      <button
+                        type="button"
+                        className="btn btn-sm"
+                        onClick={() => setViewGroup(g)}
+                      >
+                        View
+                      </button>
+                      <a className="link" href={`/messages/${g.order.uuid}`}>Chat</a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : (
+        !loading && <p>No orders found.</p>
+      )}
+      <OrderDetailsModal
+        group={viewGroup}
+        isOpen={!!viewGroup}
+        onClose={() => setViewGroup(null)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create `OrderDetailsModal` for rich order information
- upgrade `/brand/orders` to use a table layout
- show order metadata and per-item details in a modal

## Testing
- `npx jest` *(fails: need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6863d85caea4832fb76d70faef15b979