### PR TITLE
Improve product detail modal UI

### DIFF
--- a/components/Modals/GenericModal.tsx
+++ b/components/Modals/GenericModal.tsx
@@ -5,6 +5,8 @@ interface GenericModalProps {
   onClose: () => void;
   title?: string;
   children: React.ReactNode;
+  /** Optional actions to render in a footer */
+  actions?: React.ReactNode;
 }
 
 const GenericModal: React.FC<GenericModalProps> = ({
@@ -12,6 +14,7 @@ const GenericModal: React.FC<GenericModalProps> = ({
   onClose,
   title,
   children,
+  actions,
 }) => {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   if (!isOpen) return null;
@@ -24,7 +27,7 @@ const GenericModal: React.FC<GenericModalProps> = ({
         if (e.target === dialogRef.current) onClose();
       }}
     >
-      <div className="modal-box">
+      <div className="modal-box max-h-[90vh] flex flex-col">
         <div className="flex justify-between items-center mb-2">
           {title && <h2 className="font-semibold text-lg">{title}</h2>}
           <button
@@ -35,7 +38,8 @@ const GenericModal: React.FC<GenericModalProps> = ({
             ✕
           </button>
         </div>
-        {children}
+        <div className="overflow-y-auto flex-1">{children}</div>
+        {actions && <div className="mt-4">{actions}</div>}
       </div>
     </dialog>
   );

--- a/components/brand/ProductDetailsModal.tsx
+++ b/components/brand/ProductDetailsModal.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
-import Image from 'next/image';
+import React, { useEffect, useState } from 'react';
 import { GenericModal, StatusLabel } from '@components/UI';
+import ImageGallery from '@components/Product/ImageGallery';
 import type { Product } from '@/types/product';
 import { formatCurrency } from '@utils/formatCurrency';
 
@@ -10,7 +10,13 @@ interface ProductDetailsModalProps {
   onClose: () => void;
 }
 
-const ProductDetailsModal: React.FC<ProductDetailsModalProps> = ({ product, isOpen, onClose }) => {
+const ProductDetailsModal: React.FC<ProductDetailsModalProps> = ({
+  product,
+  isOpen,
+  onClose,
+}) => {
+  const [showAll, setShowAll] = useState(false);
+
   useEffect(() => {
     if (!isOpen) return;
     const handler = (e: KeyboardEvent) => {
@@ -23,28 +29,83 @@ const ProductDetailsModal: React.FC<ProductDetailsModalProps> = ({ product, isOp
   if (!product) return null;
 
   const price = formatCurrency(product.minPrice || 0, product.currency);
-  const imageUrl = product.featuredImage?.url || product.images?.[0]?.url;
+  const images =
+    product.images && product.images.length > 0
+      ? product.images
+      : product.featuredImage
+        ? [product.featuredImage]
+        : [];
+  const description =
+    product.descriptionText ||
+    product.bodyHtmlText ||
+    product.description ||
+    'No description.';
+  const category =
+    typeof product.category === 'string'
+      ? product.category
+      : product.category?.name;
 
   return (
-    <GenericModal isOpen={isOpen} onClose={onClose} title={product.title || 'Product'}>
-      <div className="space-y-4">
-        {imageUrl && (
-          <div className="relative w-full aspect-square overflow-hidden rounded-box">
-            <Image src={imageUrl} alt={product.title || 'Product image'} fill sizes="100vw" className="object-cover" />
-          </div>
-        )}
-        <div className="flex items-center gap-2">
-          <StatusLabel size="sm" color={product.status === 'approved' ? 'success' : product.status === 'pending' ? 'warning' : 'error'}>
-            {product.status}
-          </StatusLabel>
-          <span className="text-sm">Stock: {product.totalInventory ?? product.quantity ?? 0}</span>
-        </div>
-        <p className="font-semibold">Price: {price}</p>
-        <p>{product.descriptionText || product.bodyHtmlText || product.description || 'No description.'}</p>
+    <GenericModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={product.title || 'Product'}
+      actions={
         <div className="flex justify-end">
           <button type="button" className="btn" onClick={onClose}>
             Close
           </button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        {images.length > 0 && (
+          <ImageGallery images={images} className="w-full" imgClass="rounded-box" />
+        )}
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <StatusLabel
+              size="sm"
+              color={
+                product.status === 'approved'
+                  ? 'success'
+                  : product.status === 'pending'
+                    ? 'warning'
+                    : 'error'
+              }
+            >
+              {product.status}
+            </StatusLabel>
+            <span className="text-sm">
+              Stock: {product.totalInventory ?? product.quantity ?? 0}
+            </span>
+          </div>
+          <p className="font-semibold">Price: {price}</p>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-1">Description</h3>
+          <p className={showAll ? undefined : 'line-clamp-5'}>{description}</p>
+          {!showAll && description.length > 200 && (
+            <button
+              type="button"
+              className="btn btn-link btn-xs px-0"
+              onClick={() => setShowAll(true)}
+            >
+              Show More
+            </button>
+          )}
+        </div>
+        <div className="border-t pt-2 space-y-1 text-sm">
+          <p>
+            <span className="font-semibold">SKU:</span> {product.sku || 'N/A'}
+          </p>
+          <p>
+            <span className="font-semibold">Vendor:</span>{' '}
+            {product.vendor?.brandName || 'N/A'}
+          </p>
+          <p>
+            <span className="font-semibold">Category:</span> {category || 'N/A'}
+          </p>
         </div>
       </div>
     </GenericModal>


### PR DESCRIPTION
## Summary
- support modal footer actions
- redesign brand product detail modal with gallery preview and truncated description

## Testing
- `npm run type-check` *(fails: TS errors due to repo issues)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863d99d4670832fa5b30cf4f737a806