### PR TITLE
Add Typesense collection guard

### DIFF
--- a/lib/initTypesense.ts
+++ b/lib/initTypesense.ts
@@ -1,0 +1,26 @@
+import typesense from './typesenseClient';
+import { ObjectNotFound } from 'typesense';
+
+export async function ensureTypesenseProductCollection(): Promise<void> {
+  try {
+    await typesense.collections('products').retrieve();
+  } catch (err) {
+    if (err instanceof ObjectNotFound) {
+      await typesense.collections().create({
+        name: 'products',
+        fields: [
+          { name: 'id', type: 'string' },
+          { name: 'title', type: 'string' },
+          { name: 'description', type: 'string', optional: true },
+          { name: 'category', type: 'string', facet: true },
+          { name: 'price', type: 'float' },
+          { name: 'brand', type: 'string', facet: true },
+          { name: 'sold_count', type: 'int32', optional: true },
+        ],
+        default_sorting_field: 'price',
+      });
+    } else {
+      throw err;
+    }
+  }
+}

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -9,6 +9,7 @@ import { Prisma } from '@prisma/client';
 import client from './typesenseClient';
 import { getBestSellingProducts } from './orders';
 import { slugify } from './slugify';
+import { ensureTypesenseProductCollection } from './initTypesense';
 
 /**
  * Partial representation of a product record returned from Prisma including
@@ -193,6 +194,7 @@ export async function indexProductsToTypesense(
   products: Product[]
 ): Promise<void> {
   if (products.length === 0) return;
+  await ensureTypesenseProductCollection();
   const documents = products.map((p: Product) => ({
     id: String(p.id),
     title: p.title,


### PR DESCRIPTION
## Summary
- add helper to initialize Typesense product collection
- call the initializer before indexing products

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6863de41ca8c832f9149697744c9aad1