### PR TITLE
Improve brand product search/filter UX

### DIFF
--- a/components/brand/BrandProductsPage.tsx
+++ b/components/brand/BrandProductsPage.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import { AppContext } from '@contexts/AppContext';
 import type { User } from '@/types/user';
 import type { Product } from '@/types/product';
+import type { Category } from '@/types/category';
 import { getPageTitle } from '@lib/pageTitle';
 import ProductTable from './ProductTable';
 import ProductDetailsModal from './ProductDetailsModal';
@@ -18,6 +19,10 @@ const BrandProductsPage: React.FC = () => {
   const { addNotification } = useContext(NotificationContext);
   const [products, setProducts] = useState<Product[]>([]);
   const [search, setSearch] = useState('');
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [minQty, setMinQty] = useState('');
+  const [maxQty, setMaxQty] = useState('');
   const [sort, setSort] = useState<BrandProductSortValue>('title_asc');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -29,14 +34,31 @@ const BrandProductsPage: React.FC = () => {
     if (!user) return;
     setLoading(true);
     setError('');
-    fetch(`/api/brand/products?sort=${sort}`, { credentials: 'include' })
+    const params = new URLSearchParams();
+    params.set('sort', sort);
+    if (search) params.set('search', search);
+    if (categoryFilter) params.set('category', categoryFilter);
+    if (minQty) params.set('minQty', minQty);
+    if (maxQty) params.set('maxQty', maxQty);
+    fetch(`/api/brand/products?${params.toString()}`, {
+      credentials: 'include',
+    })
       .then((res) => (res.ok ? res.json() : Promise.reject(res)))
       .then((data: { products: Product[]; total: number }) =>
         setProducts(data.products)
       )
       .catch(() => setError('Failed to load products'))
       .finally(() => setLoading(false));
-  }, [user, sort]);
+  }, [user, sort, search, categoryFilter, minQty, maxQty]);
+
+  useEffect(() => {
+    fetch('/api/categories?limit=250')
+      .then((res) => (res.ok ? res.json() : { categories: [] }))
+      .then((data: { categories: Category[] }) =>
+        setCategories(data.categories)
+      )
+      .catch(() => setCategories([]));
+  }, []);
 
   const slug = router.query.slug as string | undefined;
   useEffect(() => {
@@ -63,14 +85,6 @@ const BrandProductsPage: React.FC = () => {
   if (user.role !== 'brand') {
     return <div className="p-4">Brand access required.</div>;
   }
-
-  const filtered = products.filter((p) => {
-    const term = search.toLowerCase();
-    return (
-      p.title?.toLowerCase().includes(term) ||
-      p.sku?.toLowerCase().includes(term)
-    );
-  });
 
   const handleDelete = (id: string): void => {
     setDeleteId(id);
@@ -121,15 +135,17 @@ const BrandProductsPage: React.FC = () => {
           Add New Product
         </Link>
       </div>
-      <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
         <input
           type="text"
-          className="input input-bordered w-full sm:w-80"
+          className="input input-bordered w-full sm:w-72"
           placeholder="Search products"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
-        <BrandProductSort value={sort} onChange={setSort} />
+        <div className="sm:ml-auto">
+          <BrandProductSort value={sort} onChange={setSort} />
+        </div>
       </div>
       {loading ? (
         <div className="flex justify-center my-4">
@@ -139,7 +155,14 @@ const BrandProductsPage: React.FC = () => {
         <div className="text-error py-4">{error}</div>
       ) : (
         <ProductTable
-          products={filtered}
+          products={products}
+          categories={categories}
+          category={categoryFilter}
+          onCategoryChange={setCategoryFilter}
+          minQty={minQty}
+          maxQty={maxQty}
+          onMinQtyChange={setMinQty}
+          onMaxQtyChange={setMaxQty}
           onView={handleView}
           onDelete={handleDelete}
         />

--- a/components/brand/ProductTable.tsx
+++ b/components/brand/ProductTable.tsx
@@ -5,13 +5,33 @@ import type { Product } from '@/types/product';
 
 interface ProductTableProps {
   products: Product[];
+  categories: { name: string; slug: string }[];
+  category: string;
+  onCategoryChange: (value: string) => void;
+  minQty: string;
+  maxQty: string;
+  onMinQtyChange: (value: string) => void;
+  onMaxQtyChange: (value: string) => void;
   onView: (product: Product) => void;
   onDelete: (id: string) => void;
 }
 
-const ProductTable: React.FC<ProductTableProps> = ({ products, onView, onDelete }) => {
+const ProductTable: React.FC<ProductTableProps> = ({
+  products,
+  categories,
+  category,
+  onCategoryChange,
+  minQty,
+  maxQty,
+  onMinQtyChange,
+  onMaxQtyChange,
+  onView,
+  onDelete,
+}) => {
   const getCategory = (p: Product): string =>
-    typeof p.category === 'string' ? p.category : p.category?.name || p.productType;
+    typeof p.category === 'string'
+      ? p.category
+      : p.category?.name || p.productType;
 
   return (
     <div className="overflow-x-auto">
@@ -25,10 +45,51 @@ const ProductTable: React.FC<ProductTableProps> = ({ products, onView, onDelete 
               <th>Qty</th>
               <th></th>
             </tr>
+            <tr>
+              <th></th>
+              <th className="hidden sm:table-cell">
+                <select
+                  className="select select-xs select-bordered w-full"
+                  value={category}
+                  onChange={(e) => onCategoryChange(e.target.value)}
+                >
+                  <option value="">All</option>
+                  {categories.map((c) => (
+                    <option key={c.slug} value={c.slug}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+              </th>
+              <th></th>
+              <th>
+                <div className="flex items-center gap-1">
+                  <input
+                    type="number"
+                    placeholder="Min"
+                    className="input input-xs w-20"
+                    value={minQty}
+                    onChange={(e) => onMinQtyChange(e.target.value)}
+                  />
+                  <input
+                    type="number"
+                    placeholder="Max"
+                    className="input input-xs w-20"
+                    value={maxQty}
+                    onChange={(e) => onMaxQtyChange(e.target.value)}
+                  />
+                </div>
+              </th>
+              <th></th>
+            </tr>
           </thead>
           <tbody>
             {products.map((p) => (
-              <tr key={p.id} className="cursor-pointer" onClick={() => onView(p)}>
+              <tr
+                key={p.id}
+                className="cursor-pointer"
+                onClick={() => onView(p)}
+              >
                 <td className="whitespace-nowrap">{p.title}</td>
                 <td className="hidden sm:table-cell">{getCategory(p)}</td>
                 <td>
@@ -37,8 +98,8 @@ const ProductTable: React.FC<ProductTableProps> = ({ products, onView, onDelete 
                       p.status === 'approved'
                         ? 'success'
                         : p.status === 'pending'
-                        ? 'warning'
-                        : 'error'
+                          ? 'warning'
+                          : 'error'
                     }
                     size="sm"
                   >
@@ -46,7 +107,10 @@ const ProductTable: React.FC<ProductTableProps> = ({ products, onView, onDelete 
                   </StatusLabel>
                 </td>
                 <td>{p.quantity ?? p.totalInventory ?? 0}</td>
-                <td className="space-x-2 whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
+                <td
+                  className="space-x-2 whitespace-nowrap"
+                  onClick={(e) => e.stopPropagation()}
+                >
                   <button
                     type="button"
                     className="btn btn-xs sm:btn-sm"
@@ -54,7 +118,10 @@ const ProductTable: React.FC<ProductTableProps> = ({ products, onView, onDelete 
                   >
                     View
                   </button>
-                  <Link href={`/brand/products/new?edit=${p.uuid || p.id}`} className="btn btn-xs sm:btn-sm">
+                  <Link
+                    href={`/brand/products/new?edit=${p.uuid || p.id}`}
+                    className="btn btn-xs sm:btn-sm"
+                  >
                     Edit
                   </Link>
                   <button

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -80,15 +80,37 @@ async function handler(
         return res.status(400).json({ message: 'Invalid session data' });
       }
 
+      const search = String((req.query.search as string) || '');
+      const category = String((req.query.category as string) || '');
+      const minQty = String((req.query.minQty as string) || '');
+      const maxQty = String((req.query.maxQty as string) || '');
+
+      const where: any = { vendorId };
+      if (search) {
+        where.OR = [
+          { title: { contains: search, mode: 'insensitive' } },
+          { sku: { contains: search, mode: 'insensitive' } },
+        ];
+      }
+      if (category) {
+        where.category = { slug: category };
+      }
+      const qtyFilter: any = {};
+      if (minQty) qtyFilter.gte = parseInt(minQty, 10);
+      if (maxQty) qtyFilter.lte = parseInt(maxQty, 10);
+      if (Object.keys(qtyFilter).length) {
+        where.quantity = qtyFilter;
+      }
+
       const [rows, total] = await Promise.all([
         db.product.findMany({
-          where: { vendorId },
+          where,
           include: { category: true, vendor: true },
           orderBy,
           take: limit,
           skip,
         }),
-        db.product.count({ where: { vendorId } }),
+        db.product.count({ where }),
       ]);
 
       const products = rows.map((row: any) => mapDbRowToProduct(row));


### PR DESCRIPTION
## Summary
- update brand product table with column filters for category and quantity
- load products with server-side search and filters
- support search and quantity/category filters in brand products API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863df578cfc832f8e62ac62d5fcea66