### PR TITLE
Fix product delete with stock

### DIFF
--- a/components/brand/BrandProductsPage.tsx
+++ b/components/brand/BrandProductsPage.tsx
@@ -91,6 +91,8 @@ const BrandProductsPage: React.FC = () => {
         prev.filter((p) => String(p.uuid || p.id) !== deleteId)
       );
       addNotification('Product deleted', 'success');
+    } else if (res.status === 409) {
+      addNotification('Cannot delete product with stock or orders', 'error');
     } else {
       addNotification('Failed to delete product', 'error');
     }

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -198,7 +198,7 @@ async function handler(
       }
       if (existing.quantity > 0 || (await hasOrdersForProduct(String(uuid)))) {
         res
-          .status(400)
+          .status(409)
           .json({ message: 'cannot delete product with stock or orders' });
         return;
       }

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -157,7 +157,7 @@ export default async function handler(
       if (!existing) return res.status(404).json({ message: 'Not found' });
       if (existing.quantity > 0 || (await hasOrdersForProduct(String(uuid)))) {
         return res
-          .status(400)
+          .status(409)
           .json({ message: 'cannot delete product with stock or orders' });
       }
       await deleteProduct(String(uuid));

--- a/pages/vendor/index.tsx
+++ b/pages/vendor/index.tsx
@@ -185,6 +185,8 @@ export default function VendorDashboard() {
     if (res.ok) {
       fetchProducts();
       addNotification('Product deleted', 'success');
+    } else if (res.status === 409) {
+      addNotification('Cannot delete product with stock or orders', 'error');
     } else {
       addNotification('Failed to delete product', 'error');
     }


### PR DESCRIPTION
## Summary
- return 409 Conflict when deleting a product that still has stock or orders
- show a helpful notification when that 409 occurs

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: blocked while fetching prisma binaries)*

------
https://chatgpt.com/codex/tasks/task_e_6863dff8281c832f9d2862198782118c