### PR TITLE
Fix brand deletion API logic

### DIFF
--- a/components/brand/BrandProductsPage.tsx
+++ b/components/brand/BrandProductsPage.tsx
@@ -122,7 +122,7 @@ const BrandProductsPage: React.FC = () => {
       );
       addNotification('Product deleted', 'success');
     } else if (res.status === 409) {
-      addNotification('Cannot delete product with stock or orders', 'error');
+      addNotification('Cannot delete product with orders', 'error');
     } else {
       addNotification('Failed to delete product', 'error');
     }

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -196,10 +196,10 @@ async function handler(
         res.status(404).json({ message: 'Not found' });
         return;
       }
-      if (existing.quantity > 0 || (await hasOrdersForProduct(String(uuid)))) {
+      if (await hasOrdersForProduct(String(uuid))) {
         res
           .status(409)
-          .json({ message: 'cannot delete product with stock or orders' });
+          .json({ message: 'cannot delete product with orders' });
         return;
       }
       await db.product.delete({ where: { uuid } });

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -155,10 +155,10 @@ export default async function handler(
     if (req.method === 'DELETE') {
       const existing = await getProductByUuid(String(uuid));
       if (!existing) return res.status(404).json({ message: 'Not found' });
-      if (existing.quantity > 0 || (await hasOrdersForProduct(String(uuid)))) {
+      if (await hasOrdersForProduct(String(uuid))) {
         return res
           .status(409)
-          .json({ message: 'cannot delete product with stock or orders' });
+          .json({ message: 'cannot delete product with orders' });
       }
       await deleteProduct(String(uuid));
       await loadAndIndexProducts();

--- a/pages/vendor/index.tsx
+++ b/pages/vendor/index.tsx
@@ -186,7 +186,7 @@ export default function VendorDashboard() {
       fetchProducts();
       addNotification('Product deleted', 'success');
     } else if (res.status === 409) {
-      addNotification('Cannot delete product with stock or orders', 'error');
+      addNotification('Cannot delete product with orders', 'error');
     } else {
       addNotification('Failed to delete product', 'error');
     }


### PR DESCRIPTION
## Summary
- allow deletion of products that still have stock
- keep deletion blocked for products with orders
- update notification text accordingly

## Testing
- `npm install` *(fails: prisma binaries blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6864bc5de07c832f9a93da8141eef5ad