### PR TITLE
Enhance sorting UI on brand products page

### DIFF
--- a/components/brand/BrandProductsPage.tsx
+++ b/components/brand/BrandProductsPage.tsx
@@ -10,9 +10,19 @@ import ProductTable from './ProductTable';
 import ProductDetailsModal from './ProductDetailsModal';
 import { NotificationContext } from '@contexts/NotificationContext';
 import { ConfirmModal } from '@components/UI';
-import BrandProductSort, { BrandProductSortValue } from './BrandProductSort';
-import Pagination from '@components/Pagination';
 import type { BrandProductSortValue } from './BrandProductSort';
+import Pagination from '@components/Pagination';
+
+const SORT_VALUES: BrandProductSortValue[] = [
+  'title_asc',
+  'title_desc',
+  'category_asc',
+  'category_desc',
+  'status_asc',
+  'status_desc',
+  'quantity_asc',
+  'quantity_desc',
+];
 
 const BrandProductsPage: React.FC = () => {
   const router = useRouter();
@@ -76,6 +86,15 @@ const BrandProductsPage: React.FC = () => {
     }
   }, [router.query.page]);
 
+  useEffect(() => {
+    const sortParam = router.query.sort;
+    if (!sortParam) return;
+    const value = Array.isArray(sortParam) ? sortParam[0] : sortParam;
+    if (SORT_VALUES.includes(value as BrandProductSortValue) && value !== sort) {
+      setSort(value as BrandProductSortValue);
+    }
+  }, [router.query.sort]);
+
   const slug = router.query.slug as string | undefined;
   useEffect(() => {
     if (!slug) {
@@ -128,6 +147,25 @@ const BrandProductsPage: React.FC = () => {
     }
     setDeleting(false);
     setDeleteId(null);
+  };
+
+  const handleSortChange = (
+    field: 'title' | 'category' | 'status' | 'quantity'
+  ) => {
+    setSort((cur) => {
+      const [f, dir] = cur.split('_') as [string, 'asc' | 'desc'];
+      const next =
+        f === field ? `${field}_${dir === 'asc' ? 'desc' : 'asc'}` : `${field}_asc`;
+      const query = {
+        ...router.query,
+        sort: next,
+        page: '1',
+      } as Record<string, string>;
+      router.push({ pathname: '/brand/products', query }, undefined, {
+        shallow: true,
+      });
+      return next as BrandProductSortValue;
+    });
   };
 
   const handlePageChange = (p: number) => {
@@ -183,27 +221,22 @@ const BrandProductsPage: React.FC = () => {
           onChange={(e) => setSearch(e.target.value)}
         />
       </div>
-      {loading ? (
-        <div className="flex justify-center my-4">
-          <span className="loading loading-spinner"></span>
+      {error && <div className="text-error py-4">{error}</div>}
+      {!error && (
+        <div className="relative">
+          <ProductTable
+            products={products}
+            sort={sort}
+            onSort={handleSortChange}
+            onView={handleView}
+            onDelete={handleDelete}
+          />
+          {loading && (
+            <div className="absolute inset-0 bg-base-100/50 flex items-center justify-center">
+              <span className="loading loading-spinner" />
+            </div>
+          )}
         </div>
-      ) : error ? (
-        <div className="text-error py-4">{error}</div>
-      ) : (
-        <ProductTable
-          products={products}
-          sort={sort}
-          onSort={(field) =>
-            setSort((cur) => {
-              const [f, dir] = cur.split('_') as [string, 'asc' | 'desc'];
-              return f === field
-                ? `${field}_${dir === 'asc' ? 'desc' : 'asc'}`
-                : `${field}_asc`;
-            })
-          }
-          onView={handleView}
-          onDelete={handleDelete}
-        />
       )}
       <Pagination
         currentPage={currentPage}

--- a/components/brand/ProductTable.tsx
+++ b/components/brand/ProductTable.tsx
@@ -24,47 +24,62 @@ const ProductTable: React.FC<ProductTableProps> = ({
       ? p.category
       : p.category?.name || p.productType;
 
+  const arrow = (active: boolean, dir: 'asc' | 'desc') => (
+    <span className={`${active ? '' : 'invisible'}`}>{dir === 'asc' ? '▲' : '▼'}</span>
+  );
+
+  const headerClass = (field: string) =>
+    sort.startsWith(`${field}_`) ? 'bg-base-200 text-primary font-semibold' : '';
+
+  const headerAria = (field: string) => {
+    if (!sort.startsWith(`${field}_`)) return 'none';
+    return sort.endsWith('asc') ? 'ascending' : 'descending';
+  };
+
   return (
     <div className="overflow-x-auto">
       <div className="max-h-[70vh] overflow-y-auto">
         <table className="table w-full">
           <thead>
             <tr>
-              <th
-                className="cursor-pointer select-none"
-                onClick={() => onSort('title')}
-              >
-                Product{' '}
-                {sort.startsWith('title_') && (
-                  <span>{sort.endsWith('asc') ? '▲' : '▼'}</span>
-                )}
+              <th className={headerClass('title')} aria-sort={headerAria('title')}>
+                <button
+                  type="button"
+                  className="w-full text-left flex items-center gap-1 cursor-pointer select-none"
+                  onClick={() => onSort('title')}
+                >
+                  Product {arrow(sort.startsWith('title_'), sort.endsWith('asc') ? 'asc' : 'desc')}
+                </button>
               </th>
               <th
-                className="hidden sm:table-cell cursor-pointer select-none"
-                onClick={() => onSort('category')}
+                className={`hidden sm:table-cell ${headerClass('category')}`}
+                aria-sort={headerAria('category')}
               >
-                Category{' '}
-                {sort.startsWith('category_') && (
-                  <span>{sort.endsWith('asc') ? '▲' : '▼'}</span>
-                )}
+                <button
+                  type="button"
+                  className="w-full text-left flex items-center gap-1 cursor-pointer select-none"
+                  onClick={() => onSort('category')}
+                >
+                  Category {arrow(sort.startsWith('category_'), sort.endsWith('asc') ? 'asc' : 'desc')}
+                </button>
               </th>
-              <th
-                className="cursor-pointer select-none"
-                onClick={() => onSort('status')}
-              >
-                Status{' '}
-                {sort.startsWith('status_') && (
-                  <span>{sort.endsWith('asc') ? '▲' : '▼'}</span>
-                )}
+              <th className={headerClass('status')} aria-sort={headerAria('status')}>
+                <button
+                  type="button"
+                  className="w-full text-left flex items-center gap-1 cursor-pointer select-none"
+                  onClick={() => onSort('status')}
+                >
+                  Status {arrow(sort.startsWith('status_'), sort.endsWith('asc') ? 'asc' : 'desc')}
+                </button>
               </th>
-              <th
-                className="cursor-pointer select-none"
-                onClick={() => onSort('quantity')}
-              >
-                Qty{' '}
-                {sort.startsWith('quantity_') && (
-                  <span>{sort.endsWith('asc') ? '▲' : '▼'}</span>
-                )}
+              <th className={headerClass('quantity')} aria-sort={headerAria('quantity')}>
+                <button
+                  type="button"
+                  className="w-full text-left flex items-center gap-1 cursor-pointer select-none"
+                  onClick={() => onSort('quantity')}
+                >
+                  Qty {arrow(sort.startsWith('quantity_'), sort.endsWith('asc') ? 'asc' : 'desc')}
+                </button>
               </th>
               <th></th>
             </tr>


### PR DESCRIPTION
## Summary
- highlight current sort column and add sort arrows
- keep table visible while loading new sort results
- preserve sort value in query params for reloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864baeddf00832facec7bdb3948570c