### PR TITLE
Add brand order management features

### DIFF
--- a/components/brand/OrderDetailsModal.tsx
+++ b/components/brand/OrderDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
 import { GenericModal, StatusLabel } from '@components/UI';
 import type { Order } from '@/types';
@@ -18,6 +18,27 @@ const OrderDetailsModal: React.FC<Props> = ({ group, isOpen, onClose }) => {
   if (!group) return null;
   const { order, items } = group;
 
+  const [status, setStatus] = useState(order.status);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateStatus = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/orders/${order.uuid}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) throw new Error('Failed');
+    } catch (e) {
+      setError('Failed to update');
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const customer = order.user
     ? `${order.user.firstName || ''} ${order.user.lastName || ''}`.trim() ||
       order.user.email
@@ -33,11 +54,15 @@ const OrderDetailsModal: React.FC<Props> = ({ group, isOpen, onClose }) => {
         <div className="flex items-center justify-between">
           <StatusLabel
             color={
-              order.status === 'processing'
+              order.status === 'pending'
+                ? 'info'
+                : order.status === 'confirmed'
+                ? 'info'
+                : order.status === 'processing'
                 ? 'warning'
                 : order.status === 'shipped'
                 ? 'info'
-                : order.status === 'delivered'
+                : order.status === 'delivered' || order.status === 'completed'
                 ? 'success'
                 : 'error'
             }
@@ -68,7 +93,48 @@ const OrderDetailsModal: React.FC<Props> = ({ group, isOpen, onClose }) => {
             </li>
           ))}
         </ul>
+        {error && <div className="alert alert-error">{error}</div>}
+        <div>
+          <label className="label" htmlFor="status-select">
+            <span className="label-text">Status</span>
+          </label>
+          <select
+            id="status-select"
+            className="select select-bordered w-full"
+            value={status}
+            onChange={(e) => setStatus(e.target.value as any)}
+          >
+            {[
+              'pending',
+              'confirmed',
+              'processing',
+              'shipped',
+              'delivered',
+              'completed',
+              'cancelled',
+              'returned',
+            ].map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
         <div className="flex justify-end">
+          <a
+            href={`/api/orders/${order.uuid}/invoice`}
+            className="btn btn-outline mr-auto"
+          >
+            Invoice
+          </a>
+          <button
+            type="button"
+            className="btn btn-primary mr-2"
+            disabled={saving}
+            onClick={updateStatus}
+          >
+            {saving ? 'Saving...' : 'Update'}
+          </button>
           <button type="button" className="btn" onClick={onClose}>
             Close
           </button>

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -91,3 +91,35 @@ export async function sendBackInStock(to: string, title: string) {
   }
 }
 
+export async function sendBrandNewOrder(
+  to: string,
+  order: { id: string | number }
+) {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.RESEND_FROM || 'orders@example.com';
+  if (!apiKey) {
+    console.log('No RESEND_API_KEY configured');
+    return;
+  }
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from,
+        to,
+        subject: `New Order #${order.id}`,
+        html: `<p>You have received a new order #${order.id}.</p>`,
+      }),
+    });
+    if (!res.ok) {
+      console.error('Failed to send email', await res.text());
+    }
+  } catch (e) {
+    console.error('Email error', e);
+  }
+}
+

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -2,6 +2,7 @@ import { Order, Product } from '../types';
 import { getDb } from './db';
 import { mapDbRowToProduct } from './products';
 import { createNotification } from './notifications';
+import { sendBrandNewOrder } from './email';
 import type { Prisma } from '@prisma/client';
 
 type OrderWithRelations = Prisma.OrderGetPayload<{
@@ -87,6 +88,12 @@ export async function addOrder({
         orderId: o.id,
         message: `New order for ${o.product.title}`,
       })
+    )
+  );
+
+  await Promise.all(
+    createdOrders.map((o) =>
+      sendBrandNewOrder(o.product.vendor.email, { id: o.id })
     )
   );
 

--- a/pages/api/orders/[uuid].ts
+++ b/pages/api/orders/[uuid].ts
@@ -25,10 +25,17 @@ async function handler(
 
     if (req.method === 'PATCH') {
       const { status } = req.body || {};
-      if (
-        !status ||
-        !['processing', 'shipped', 'delivered', 'cancelled'].includes(status)
-      ) {
+      const allowed = [
+        'pending',
+        'confirmed',
+        'processing',
+        'shipped',
+        'delivered',
+        'completed',
+        'cancelled',
+        'returned',
+      ];
+      if (!status || !allowed.includes(status)) {
         return res.status(400).json({ message: 'invalid status' });
       }
       await updateOrderStatus(String(uuid), status);

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -90,11 +90,15 @@ const BrandOrders: React.FC = () => {
                     <td>
                       <span
                         className={`badge ${
-                          g.order.status === 'processing'
+                          g.order.status === 'pending'
+                            ? 'badge-ghost'
+                            : g.order.status === 'confirmed'
+                            ? 'badge-secondary'
+                            : g.order.status === 'processing'
                             ? 'badge-warning'
                             : g.order.status === 'shipped'
                             ? 'badge-info'
-                            : g.order.status === 'delivered'
+                            : g.order.status === 'delivered' || g.order.status === 'completed'
                             ? 'badge-success'
                             : 'badge-error'
                         }`}

--- a/types/order.ts
+++ b/types/order.ts
@@ -3,10 +3,14 @@ import type { User } from './user';
 import type { Product } from './product';
 
 export enum OrderStatus {
+  PENDING = 'pending',
+  CONFIRMED = 'confirmed',
   PROCESSING = 'processing',
   SHIPPED = 'shipped',
   DELIVERED = 'delivered',
+  COMPLETED = 'completed',
   CANCELLED = 'cancelled',
+  RETURNED = 'returned',
 }
 
 export interface Order extends PrismaOrder {


### PR DESCRIPTION
## Summary
- send email notification to brand for new order
- extend order status enum
- allow brands to update order status and download invoice
- show full status badge in brand orders list
- accept new statuses in order API

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm install` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6864bce28c88832fa080cfa383ed5a8e