### PR TITLE
Add chat support widget

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -1,0 +1,72 @@
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { ChatContext } from '@contexts/ChatContext';
+import ChatIcon from './icons/ChatIcon';
+
+const ChatWidget: React.FC = () => {
+  const { messages, sendMessage } = useContext(ChatContext);
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  const toggle = () => setOpen((o) => !o);
+
+  const submit = () => {
+    if (!text.trim()) return;
+    sendMessage(text.trim());
+    setText('');
+  };
+
+  useEffect(() => {
+    if (open) {
+      endRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, open]);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      {open ? (
+        <div className="bg-base-100 rounded-lg shadow-lg w-72 h-96 flex flex-col fade-in">
+          <div className="flex justify-between items-center p-2 border-b">
+            <span className="font-semibold">Support Chat</span>
+            <button type="button" className="btn btn-xs btn-circle" onClick={toggle}>
+              ✕
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto p-2 space-y-1 text-sm">
+            {messages.map((m) => (
+              <div key={m.id}>
+                <span className="text-gray-500 mr-2">
+                  {m.sender === 'user' ? 'You' : 'Support'}:
+                </span>
+                <span>{m.content}</span>
+              </div>
+            ))}
+            <div ref={endRef} />
+          </div>
+          <div className="p-2 border-t flex gap-2">
+            <input
+              className="input input-bordered flex-1"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && submit()}
+              placeholder="Type a message"
+            />
+            <button type="button" className="btn btn-primary" onClick={submit}>
+              Send
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="btn btn-primary btn-circle"
+          onClick={toggle}
+        >
+          <ChatIcon size={20} />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ChatWidget;

--- a/components/icons/ChatIcon.tsx
+++ b/components/icons/ChatIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const ChatIcon: React.FC<IconProps> = ({
+  size = 24,
+  color = 'currentColor',
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M2.25 12.75v6.213c0 .966 1.098 1.548 1.882.99l3.083-2.164a.75.75 0 01.435-.139h8.1a4.5 4.5 0 004.5-4.5v-6a4.5 4.5 0 00-4.5-4.5h-9a4.5 4.5 0 00-4.5 4.5v5.1z"
+    />
+  </svg>
+);
+
+export default ChatIcon;

--- a/contexts/ChatContext.tsx
+++ b/contexts/ChatContext.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, useState, ReactNode } from 'react';
+
+export interface ChatMessage {
+  id: number;
+  sender: 'user' | 'support';
+  content: string;
+  timestamp: Date;
+}
+
+interface ChatContextValue {
+  messages: ChatMessage[];
+  sendMessage: (content: string) => void;
+}
+
+export const ChatContext = createContext<ChatContextValue>({
+  messages: [],
+  sendMessage: () => {},
+});
+
+interface ProviderProps {
+  children: ReactNode;
+}
+
+export function ChatProvider({ children }: ProviderProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const sendMessage = (content: string) => {
+    const msg: ChatMessage = {
+      id: Date.now(),
+      sender: 'user',
+      content,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, msg]);
+    // Simulate support reply
+    setTimeout(() => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now() + 1,
+          sender: 'support',
+          content: 'Thanks for your message! We\'ll get back to you shortly.',
+          timestamp: new Date(),
+        },
+      ]);
+    }, 1000);
+  };
+  return (
+    <ChatContext.Provider value={{ messages, sendMessage }}>
+      {children}
+    </ChatContext.Provider>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import Layout from '@components/Layout/Layout';
 import { SessionProvider } from 'next-auth/react';
 import { NotificationProvider } from '@contexts/NotificationContext';
 import { Toaster } from 'sonner';
+import { ChatProvider } from '@contexts/ChatContext';
 
 import type { AppProps } from 'next/app';
 
@@ -17,13 +18,15 @@ export default function App({
     <SessionProvider session={session}>
       <NotificationProvider>
         <AppProvider>
-          <Toaster position="top-right" richColors />
-          <Layout
-            heroSecond={HeroSecond ? <HeroSecond /> : null}
-            maxWidthClass={maxWidthClass}
-          >
-            <Component {...pageProps} />
-          </Layout>
+          <ChatProvider>
+            <Toaster position="top-right" richColors />
+            <Layout
+              heroSecond={HeroSecond ? <HeroSecond /> : null}
+              maxWidthClass={maxWidthClass}
+            >
+              <Component {...pageProps} />
+            </Layout>
+          </ChatProvider>
         </AppProvider>
       </NotificationProvider>
     </SessionProvider>

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -5,6 +5,7 @@ import { Order } from '../../types';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
 import OrderDetailsModal from '@components/brand/OrderDetailsModal';
+import ChatWidget from '@components/ChatWidget';
 
 const BrandOrders: React.FC = () => {
   const { user } = useContext(AppContext)!;
@@ -132,6 +133,7 @@ const BrandOrders: React.FC = () => {
         isOpen={!!viewGroup}
         onClose={() => setViewGroup(null)}
       />
+      <ChatWidget />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create ChatWidget component with floating chat box
- introduce ChatContext to handle sending messages
- create ChatIcon
- wrap application in ChatProvider
- show ChatWidget on brand orders page

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864c36eaf50832f991f541ee661224f