### PR TITLE
Fix Top Products chart layout

### DIFF
--- a/components/analytics/TopProductsChart.tsx
+++ b/components/analytics/TopProductsChart.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import ChartContainer from '../ChartContainer';
+import {
+  ResponsiveContainer,
+  BarChart as ReBarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Bar,
+  Cell,
+} from 'recharts';
+
+const BAR_COLORS = ['#ef4444', '#f59e0b', '#10b981', '#3b82f6', '#8b5cf6'];
+
+export interface TopProduct {
+  id: string;
+  qty: number;
+}
+
+interface Props {
+  data: TopProduct[];
+  height?: string | number;
+}
+
+const TopProductsChart: React.FC<Props> = ({ data, height = '16rem' }) => (
+  <ChartContainer dataLength={data.length} height={height}>
+    <ResponsiveContainer width="100%" height="100%">
+      <ReBarChart data={data.map((d) => ({ label: d.id, value: d.qty }))}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="label" />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey="value">
+          {data.map((_, i) => (
+            <Cell key={i} fill={BAR_COLORS[i % BAR_COLORS.length]} />
+          ))}
+        </Bar>
+      </ReBarChart>
+    </ResponsiveContainer>
+  </ChartContainer>
+);
+
+export default TopProductsChart;

--- a/pages/brand/analytics.tsx
+++ b/pages/brand/analytics.tsx
@@ -2,8 +2,8 @@ import React, { useContext, useEffect, useState } from 'react';
 import { AppContext } from '@contexts/AppContext';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
-import BarChart from '@components/BarChart';
 import ChartContainer from '@components/ChartContainer';
+import TopProductsChart from '@components/analytics/TopProductsChart';
 import DashboardCard from '@components/dashboard/DashboardCard';
 import TotalProductsCard from '@components/dashboard/TotalProductsCard';
 import TotalSalesCard from '@components/dashboard/TotalSalesCard';
@@ -188,11 +188,7 @@ const BrandAnalytics: React.FC = () => {
                   </li>
                 ))}
               </ul>
-              <div className="mt-4">
-                <BarChart
-                  data={data.topProducts.map((p) => ({ label: p.id, value: p.qty }))}
-                />
-              </div>
+              <TopProductsChart data={data.topProducts} />
             </>
           ) : (
             <div className="flex flex-col items-center justify-center h-32 text-gray-500">


### PR DESCRIPTION
## Summary
- make a dedicated `TopProductsChart` component using recharts
- show `TopProductsChart` in brand analytics page

## Testing
- `npm run type-check` *(fails: cannot find Prisma types)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864c3bbb93c832f8690e6e735999982