### PR TITLE
Implement order auto-refresh and stock sync

### DIFF
--- a/components/brand/OrderDetailsModal.tsx
+++ b/components/brand/OrderDetailsModal.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Image from 'next/image';
 import { GenericModal, StatusLabel } from '@components/UI';
 import type { Order } from '@/types';
+import { NotificationContext } from '@contexts/NotificationContext';
 
 interface OrderGroup {
   order: Order;
@@ -12,15 +13,22 @@ interface Props {
   group: OrderGroup | null;
   isOpen: boolean;
   onClose: () => void;
+  onUpdated?: () => void;
 }
 
-const OrderDetailsModal: React.FC<Props> = ({ group, isOpen, onClose }) => {
+const OrderDetailsModal: React.FC<Props> = ({
+  group,
+  isOpen,
+  onClose,
+  onUpdated,
+}) => {
   if (!group) return null;
   const { order, items } = group;
 
   const [status, setStatus] = useState(order.status);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { addNotification } = useContext(NotificationContext);
 
   const updateStatus = async () => {
     setSaving(true);
@@ -32,6 +40,8 @@ const OrderDetailsModal: React.FC<Props> = ({ group, isOpen, onClose }) => {
         body: JSON.stringify({ status }),
       });
       if (!res.ok) throw new Error('Failed');
+      addNotification('Order updated', 'success');
+      if (onUpdated) onUpdated();
     } catch (e) {
       setError('Failed to update');
     } finally {
@@ -57,14 +67,15 @@ const OrderDetailsModal: React.FC<Props> = ({ group, isOpen, onClose }) => {
               order.status === 'pending'
                 ? 'info'
                 : order.status === 'confirmed'
-                ? 'info'
-                : order.status === 'processing'
-                ? 'warning'
-                : order.status === 'shipped'
-                ? 'info'
-                : order.status === 'delivered' || order.status === 'completed'
-                ? 'success'
-                : 'error'
+                  ? 'info'
+                  : order.status === 'processing'
+                    ? 'warning'
+                    : order.status === 'shipped'
+                      ? 'info'
+                      : order.status === 'delivered' ||
+                          order.status === 'completed'
+                        ? 'success'
+                        : 'error'
             }
           >
             {order.status}

--- a/lib/orders.ts
+++ b/lib/orders.ts
@@ -218,6 +218,20 @@ export async function updateOrderStatus(
   status: string
 ): Promise<void> {
   const db = getDb();
+  const existing = await db.order.findUnique({
+    where: { uuid },
+    include: { product: true },
+  });
+  if (!existing) return;
+  if (
+    status === 'shipped' &&
+    !['shipped', 'delivered', 'completed'].includes(existing.status)
+  ) {
+    await db.product.update({
+      where: { id: existing.productId },
+      data: { quantity: { decrement: existing.quantity } },
+    });
+  }
   await db.order.update({ where: { uuid }, data: { status } });
 }
 

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, {
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useCallback,
+} from 'react';
 import { AppContext } from '@contexts/AppContext';
 import { useSession } from 'next-auth/react';
 import { Order } from '../../types';
@@ -12,12 +18,29 @@ const BrandOrders: React.FC = () => {
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [viewGroup, setViewGroup] = useState<{ order: Order; items: Order[] } | null>(null);
+  const [viewGroup, setViewGroup] = useState<{
+    order: Order;
+    items: Order[];
+  } | null>(null);
+
+  const loadOrders = useCallback(() => {
+    if (!user) return;
+    setLoading(true);
+    fetch('/api/brand/orders')
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data: Order[]) => {
+        setOrders(data);
+        setError(null);
+      })
+      .catch(() => setError('Failed to load orders'))
+      .finally(() => setLoading(false));
+  }, [user]);
 
   const groupedOrders = useMemo(() => {
     const map = new Map<string, { order: Order; items: Order[] }>();
     for (const o of orders) {
-      const key = o.paymentReference || new Date(o.createdAt).toISOString().split('.')[0];
+      const key =
+        o.paymentReference || new Date(o.createdAt).toISOString().split('.')[0];
       const existing = map.get(key);
       if (existing) {
         existing.items.push(o);
@@ -30,16 +53,8 @@ const BrandOrders: React.FC = () => {
 
   useEffect(() => {
     if (!user || status === 'loading') return;
-    setLoading(true);
-    fetch('/api/brand/orders')
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data: Order[]) => {
-        setOrders(data);
-        setError(null);
-      })
-      .catch(() => setError('Failed to load orders'))
-      .finally(() => setLoading(false));
-  }, [user, session, status]);
+    loadOrders();
+  }, [user, session, status, loadOrders]);
 
   if (!user) {
     return <div className="p-4">Please log in to view orders.</div>;
@@ -93,14 +108,15 @@ const BrandOrders: React.FC = () => {
                           g.order.status === 'pending'
                             ? 'badge-ghost'
                             : g.order.status === 'confirmed'
-                            ? 'badge-secondary'
-                            : g.order.status === 'processing'
-                            ? 'badge-warning'
-                            : g.order.status === 'shipped'
-                            ? 'badge-info'
-                            : g.order.status === 'delivered' || g.order.status === 'completed'
-                            ? 'badge-success'
-                            : 'badge-error'
+                              ? 'badge-secondary'
+                              : g.order.status === 'processing'
+                                ? 'badge-warning'
+                                : g.order.status === 'shipped'
+                                  ? 'badge-info'
+                                  : g.order.status === 'delivered' ||
+                                      g.order.status === 'completed'
+                                    ? 'badge-success'
+                                    : 'badge-error'
                         }`}
                       >
                         {g.order.status}
@@ -116,7 +132,9 @@ const BrandOrders: React.FC = () => {
                       >
                         View
                       </button>
-                      <a className="link" href={`/messages/${g.order.uuid}`}>Chat</a>
+                      <a className="link" href={`/messages/${g.order.uuid}`}>
+                        Chat
+                      </a>
                     </td>
                   </tr>
                 ))}
@@ -131,6 +149,7 @@ const BrandOrders: React.FC = () => {
         group={viewGroup}
         isOpen={!!viewGroup}
         onClose={() => setViewGroup(null)}
+        onUpdated={loadOrders}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- auto-refresh brand orders view after status changes
- update order status handler to deduct product quantity when shipped
- show toast notification on status update

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6864c4188ffc832f9dc902b49f649172