### PR TITLE
Fix dashboard sales metrics

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -1,0 +1,47 @@
+import { getSalesMetrics, ORDER_SUCCESS_STATUSES } from '@lib/analytics';
+import { getDb } from '@lib/db';
+
+jest.mock('@lib/db', () => ({
+  getDb: jest.fn(),
+}));
+
+const mockGetDb = getDb as jest.Mock;
+
+describe('getSalesMetrics', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds query with vendor and dates', async () => {
+    const count = jest.fn().mockResolvedValue(2);
+    const aggregate = jest.fn().mockResolvedValue({ _sum: { total: 50 } });
+    mockGetDb.mockReturnValue({ order: { count, aggregate } });
+    const start = new Date('2024-01-01');
+    const end = new Date('2024-01-31');
+    const result = await getSalesMetrics({ vendorId: 1, start, end });
+    expect(count).toHaveBeenCalledWith({
+      where: {
+        status: { in: ORDER_SUCCESS_STATUSES },
+        createdAt: { gte: start, lte: end },
+        product: { vendorId: 1 },
+      },
+    });
+    expect(aggregate).toHaveBeenCalledWith({
+      where: {
+        status: { in: ORDER_SUCCESS_STATUSES },
+        createdAt: { gte: start, lte: end },
+        product: { vendorId: 1 },
+      },
+      _sum: { total: true },
+    });
+    expect(result).toEqual({ count: 2, revenue: 50 });
+  });
+
+  it('handles empty totals', async () => {
+    const count = jest.fn().mockResolvedValue(0);
+    const aggregate = jest.fn().mockResolvedValue({ _sum: { total: null } });
+    mockGetDb.mockReturnValue({ order: { count, aggregate } });
+    const result = await getSalesMetrics();
+    expect(result).toEqual({ count: 0, revenue: 0 });
+  });
+});

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,25 @@
+import { getDb } from './db';
+
+export const ORDER_SUCCESS_STATUSES = ['shipped', 'delivered', 'completed'] as const;
+
+export interface SalesMetricsParams {
+  start?: Date;
+  end?: Date;
+  vendorId?: number;
+}
+
+export async function getSalesMetrics({ start, end, vendorId }: SalesMetricsParams = {}) {
+  const db = getDb();
+  const where: any = { status: { in: ORDER_SUCCESS_STATUSES } };
+  if (start || end) {
+    where.createdAt = {};
+    if (start) where.createdAt.gte = start;
+    if (end) where.createdAt.lte = end;
+  }
+  if (vendorId) {
+    where.product = { vendorId };
+  }
+  const count = await db.order.count({ where });
+  const agg = await db.order.aggregate({ where, _sum: { total: true } });
+  return { count, revenue: agg._sum.total ?? 0 };
+}

--- a/pages/api/dashboard/orders-this-month.ts
+++ b/pages/api/dashboard/orders-this-month.ts
@@ -1,6 +1,6 @@
 import type { NextApiResponse } from 'next';
 import dayjs from 'dayjs';
-import { getDb } from '@lib/db';
+import { getSalesMetrics } from '@lib/analytics';
 import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
@@ -14,7 +14,6 @@ async function handler(
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const db = getDb();
     const user = req.user;
     const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const queryBrandId = Number.isNaN(param) ? undefined : param;
@@ -32,14 +31,8 @@ async function handler(
       .subtract(monthOffset, 'month')
       .toDate();
     const end = dayjs(start).endOf('month').toDate();
-    const where: any = {
-      createdAt: { gte: start, lte: end },
-      status: 'delivered',
-    };
-    if (vendorId) where.product = { vendorId };
-    const count = await db.order.count({ where });
-    const result = await db.order.aggregate({ where, _sum: { total: true } });
-    return res.status(200).json({ count, revenue: result._sum.total ?? 0 });
+    const { count, revenue } = await getSalesMetrics({ start, end, vendorId });
+    return res.status(200).json({ count, revenue });
   } catch (error) {
     return handleApiError(res, error, 'Failed to load orders');
   }

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -1,5 +1,5 @@
 import type { NextApiResponse } from 'next';
-import { getDb } from '@lib/db';
+import { getSalesMetrics } from '@lib/analytics';
 import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
@@ -13,7 +13,6 @@ async function handler(
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const db = getDb();
     const user = req.user;
     const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const queryBrandId = Number.isNaN(param) ? undefined : param;
@@ -23,23 +22,22 @@ async function handler(
       return res.status(401).json({ message: 'Unauthorized' });
     }
     const monthOffset = getQueryParam(req.query.monthOffset);
-    const where: any = { status: 'delivered' };
+    let start: Date | undefined;
+    let end: Date | undefined;
     if (
       monthOffset !== null &&
       monthOffset !== undefined &&
       monthOffset !== ''
     ) {
       const m = parseInt(monthOffset, 10);
-      const start = require('dayjs')()
+      start = require('dayjs')()
         .startOf('month')
         .subtract(m, 'month')
         .toDate();
-      const end = require('dayjs')(start).endOf('month').toDate();
-      where.createdAt = { gte: start, lte: end };
+      end = require('dayjs')(start).endOf('month').toDate();
     }
-    if (vendorId) where.product = { vendorId };
-    const result = await db.order.aggregate({ where, _sum: { total: true } });
-    return res.status(200).json({ total: result._sum.total ?? 0 });
+    const { revenue } = await getSalesMetrics({ start, end, vendorId });
+    return res.status(200).json({ total: revenue });
   } catch (error) {
     return handleApiError(res, error, 'Failed to load total sales');
   }

--- a/pages/api/dashboard/weekly-summary.ts
+++ b/pages/api/dashboard/weekly-summary.ts
@@ -1,6 +1,6 @@
 import type { NextApiResponse } from 'next';
 import dayjs from 'dayjs';
-import { getDb } from '@lib/db';
+import { getSalesMetrics } from '@lib/analytics';
 import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
@@ -14,7 +14,6 @@ async function handler(
     if (req.method !== 'GET') {
       return res.status(405).json({ message: 'Method Not Allowed' });
     }
-    const db = getDb();
     const user = req.user;
     const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const queryBrandId = Number.isNaN(param) ? undefined : param;
@@ -24,11 +23,8 @@ async function handler(
       return res.status(401).json({ message: 'Unauthorized' });
     }
     const start = dayjs().subtract(7, 'day').startOf('day').toDate();
-    const where: any = { createdAt: { gte: start }, status: 'delivered' };
-    if (vendorId) where.product = { vendorId };
-    const count = await db.order.count({ where });
-    const result = await db.order.aggregate({ where, _sum: { total: true } });
-    return res.status(200).json({ count, revenue: result._sum.total ?? 0 });
+    const { count, revenue } = await getSalesMetrics({ start, vendorId });
+    return res.status(200).json({ count, revenue });
   } catch (error) {
     return handleApiError(res, error, 'Failed to load weekly summary');
   }


### PR DESCRIPTION
## Summary
- add sales metric helpers
- aggregate revenue using helper in dashboard APIs
- test sales metric calculations

## Testing
- `npm install` *(fails: Command failed: npx prisma migrate dev --name init --skip-seed)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c46bd35c832fb81b9987f96e3375