### PR TITLE
Add inline chat widget on brand orders

### DIFF
--- a/components/Chat/ChatWindow.tsx
+++ b/components/Chat/ChatWindow.tsx
@@ -1,14 +1,20 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { ChatContext } from '@contexts/ChatContext';
-import ChatIcon from './icons/ChatIcon';
+import ChatIcon from '../icons/ChatIcon';
 
-const ChatWidget: React.FC = () => {
-  const { messages, sendMessage } = useContext(ChatContext);
-  const [open, setOpen] = useState(false);
+const ChatWindow: React.FC = () => {
+  const { messages, sendMessage, isOpen, openChat, closeChat } =
+    useContext(ChatContext);
   const [text, setText] = useState('');
   const endRef = useRef<HTMLDivElement | null>(null);
 
-  const toggle = () => setOpen((o) => !o);
+  const toggle = () => {
+    if (isOpen) {
+      closeChat();
+    } else {
+      openChat();
+    }
+  };
 
   const submit = () => {
     if (!text.trim()) return;
@@ -17,14 +23,14 @@ const ChatWidget: React.FC = () => {
   };
 
   useEffect(() => {
-    if (open) {
+    if (isOpen) {
       endRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [messages, open]);
+  }, [messages, isOpen]);
 
   return (
     <div className="fixed bottom-4 right-4 z-50">
-      {open ? (
+      {isOpen ? (
         <div className="bg-base-100 rounded-lg shadow-lg w-72 h-96 flex flex-col fade-in">
           <div className="flex justify-between items-center p-2 border-b">
             <span className="font-semibold">Support Chat</span>
@@ -69,4 +75,4 @@ const ChatWidget: React.FC = () => {
   );
 };
 
-export default ChatWidget;
+export default ChatWindow;

--- a/contexts/ChatContext.tsx
+++ b/contexts/ChatContext.tsx
@@ -9,11 +9,21 @@ export interface ChatMessage {
 
 interface ChatContextValue {
   messages: ChatMessage[];
+  isOpen: boolean;
+  openChat: (context?: { orderId?: string; customerName?: string }) => void;
+  closeChat: () => void;
   sendMessage: (content: string) => void;
+  context?: {
+    orderId?: string;
+    customerName?: string;
+  };
 }
 
 export const ChatContext = createContext<ChatContextValue>({
   messages: [],
+  isOpen: false,
+  openChat: () => {},
+  closeChat: () => {},
   sendMessage: () => {},
 });
 
@@ -23,6 +33,11 @@ interface ProviderProps {
 
 export function ChatProvider({ children }: ProviderProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [chatCtx, setChatCtx] = useState<{
+    orderId?: string;
+    customerName?: string;
+  } | undefined>();
   const sendMessage = (content: string) => {
     const msg: ChatMessage = {
       id: Date.now(),
@@ -44,8 +59,18 @@ export function ChatProvider({ children }: ProviderProps) {
       ]);
     }, 1000);
   };
+
+  const openChat = (context?: { orderId?: string; customerName?: string }) => {
+    if (context) setChatCtx(context);
+    setIsOpen(true);
+  };
+
+  const closeChat = () => setIsOpen(false);
+
   return (
-    <ChatContext.Provider value={{ messages, sendMessage }}>
+    <ChatContext.Provider
+      value={{ messages, sendMessage, isOpen, openChat, closeChat, context: chatCtx }}
+    >
       {children}
     </ChatContext.Provider>
   );

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -11,10 +11,12 @@ import { Order } from '../../types';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
 import OrderDetailsModal from '@components/brand/OrderDetailsModal';
-import ChatWidget from '@components/ChatWidget';
+import ChatWindow from '@components/Chat/ChatWindow';
+import { ChatContext } from '@contexts/ChatContext';
 
 const BrandOrders: React.FC = () => {
   const { user } = useContext(AppContext)!;
+  const { openChat } = useContext(ChatContext);
   const { data: session, status } = useSession();
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
@@ -133,9 +135,23 @@ const BrandOrders: React.FC = () => {
                       >
                         View
                       </button>
-                      <a className="link" href={`/messages/${g.order.uuid}`}>
+                      <button
+                        type="button"
+                        className="link"
+                        onClick={() =>
+                          openChat({
+                            orderId: g.order.uuid,
+                            customerName:
+                              g.order.user
+                                ? `${g.order.user.firstName || ''} ${
+                                    g.order.user.lastName || ''
+                                  }`.trim() || g.order.user.email
+                                : undefined,
+                          })
+                        }
+                      >
                         Chat
-                      </a>
+                      </button>
                     </td>
                   </tr>
                 ))}
@@ -152,7 +168,7 @@ const BrandOrders: React.FC = () => {
         onClose={() => setViewGroup(null)}
         onUpdated={loadOrders}
       />
-      <ChatWidget />
+      <ChatWindow />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- introduce `ChatWindow` component for floating in-page chat
- manage chat open state in `ChatContext`
- open chat from Brand Orders instead of navigating away

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6864c5cffc44832fb5b6f99cabf1b9a2