### PR TITLE
Enable chat file sharing

### DIFF
--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useContext, ChangeEvent } from 'react';
+import { ChatContext } from '@contexts/ChatContext';
+import PaperClipIcon from '../icons/PaperClipIcon';
+
+const allowedTypes = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'text/plain',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+];
+
+const ChatInput: React.FC = () => {
+  const { sendMessage } = useContext(ChatContext);
+  const [text, setText] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+
+  const onFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    if (f.size > 5 * 1024 * 1024) {
+      alert('File size exceeds 5MB');
+      return;
+    }
+    if (f.type && !allowedTypes.includes(f.type)) {
+      alert('Invalid file type');
+      return;
+    }
+    setFile(f);
+    if (f.type.startsWith('image/')) {
+      setPreview(URL.createObjectURL(f));
+    } else {
+      setPreview(null);
+    }
+  };
+
+  const submit = async () => {
+    if (!text.trim() && !file) return;
+    let messageType: 'text' | 'image' | 'file' = 'text';
+    let fileUrl: string | undefined;
+    let fileName: string | undefined;
+    if (file) {
+      messageType = file.type.startsWith('image/') ? 'image' : 'file';
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/chat/upload', {
+        method: 'POST',
+        body: formData,
+      });
+      if (res.ok) {
+        const data = await res.json();
+        fileUrl = data.url;
+        fileName = file.name;
+      }
+    }
+    sendMessage({ content: text.trim(), messageType, fileUrl, fileName });
+    setText('');
+    setFile(null);
+    setPreview(null);
+  };
+
+  return (
+    <div className="p-2 border-t flex gap-2 items-center">
+      <input id="chat-file" type="file" hidden onChange={onFileChange} />
+      <label htmlFor="chat-file" className="btn btn-square btn-sm">
+        <PaperClipIcon size={16} />
+      </label>
+      {preview && (
+        <img
+          src={preview}
+          alt="preview"
+          className="w-8 h-8 object-cover rounded"
+        />
+      )}
+      <input
+        className="input input-bordered flex-1"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && submit()}
+        placeholder="Type a message"
+      />
+      <button type="button" className="btn btn-primary" onClick={submit}>
+        Send
+      </button>
+    </div>
+  );
+};
+
+export default ChatInput;

--- a/components/Chat/ChatMessage.tsx
+++ b/components/Chat/ChatMessage.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { ChatMessage } from '@contexts/ChatContext';
+
+interface Props {
+  message: ChatMessage;
+}
+
+const ChatMessage: React.FC<Props> = ({ message }) => {
+  const label = message.sender === 'user' ? 'You' : 'Support';
+  return (
+    <div>
+      <span className="text-gray-500 mr-2">{label}:</span>
+      {message.messageType === 'image' && message.fileUrl ? (
+        <img
+          src={message.fileUrl}
+          alt={message.fileName || 'image'}
+          className="max-w-[150px] rounded inline"
+        />
+      ) : message.messageType === 'file' && message.fileUrl ? (
+        <a
+          href={message.fileUrl}
+          target="_blank"
+          rel="noopener"
+          className="link"
+        >
+          {message.fileName || 'Download file'}
+        </a>
+      ) : (
+        <span>{message.content}</span>
+      )}
+    </div>
+  );
+};
+
+export default ChatMessage;

--- a/components/Chat/ChatWindow.tsx
+++ b/components/Chat/ChatWindow.tsx
@@ -1,11 +1,11 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { ChatContext } from '@contexts/ChatContext';
 import ChatIcon from '../icons/ChatIcon';
+import ChatInput from './ChatInput';
+import ChatMessage from './ChatMessage';
 
 const ChatWindow: React.FC = () => {
-  const { messages, sendMessage, isOpen, openChat, closeChat } =
-    useContext(ChatContext);
-  const [text, setText] = useState('');
+  const { messages, isOpen, openChat, closeChat } = useContext(ChatContext);
   const endRef = useRef<HTMLDivElement | null>(null);
 
   const toggle = () => {
@@ -14,12 +14,6 @@ const ChatWindow: React.FC = () => {
     } else {
       openChat();
     }
-  };
-
-  const submit = () => {
-    if (!text.trim()) return;
-    sendMessage(text.trim());
-    setText('');
   };
 
   useEffect(() => {
@@ -34,33 +28,21 @@ const ChatWindow: React.FC = () => {
         <div className="bg-base-100 rounded-lg shadow-lg w-72 h-96 flex flex-col fade-in">
           <div className="flex justify-between items-center p-2 border-b">
             <span className="font-semibold">Support Chat</span>
-            <button type="button" className="btn btn-xs btn-circle" onClick={toggle}>
+            <button
+              type="button"
+              className="btn btn-xs btn-circle"
+              onClick={toggle}
+            >
               ✕
             </button>
           </div>
           <div className="flex-1 overflow-y-auto p-2 space-y-1 text-sm">
             {messages.map((m) => (
-              <div key={m.id}>
-                <span className="text-gray-500 mr-2">
-                  {m.sender === 'user' ? 'You' : 'Support'}:
-                </span>
-                <span>{m.content}</span>
-              </div>
+              <ChatMessage key={m.id} message={m} />
             ))}
             <div ref={endRef} />
           </div>
-          <div className="p-2 border-t flex gap-2">
-            <input
-              className="input input-bordered flex-1"
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && submit()}
-              placeholder="Type a message"
-            />
-            <button type="button" className="btn btn-primary" onClick={submit}>
-              Send
-            </button>
-          </div>
+          <ChatInput />
         </div>
       ) : (
         <button

--- a/components/icons/PaperClipIcon.tsx
+++ b/components/icons/PaperClipIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const PaperClipIcon: React.FC<IconProps> = ({
+  size = 24,
+  color = 'currentColor',
+  className = '',
+  ...rest
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M21.44 11.05l-8.49 8.49a5.25 5.25 0 01-7.42-7.42l8.49-8.49a3.75 3.75 0 015.3 5.3l-8.49 8.49a2.25 2.25 0 01-3.18-3.18l7.79-7.79"
+    />
+  </svg>
+);
+
+export default PaperClipIcon;

--- a/contexts/ChatContext.tsx
+++ b/contexts/ChatContext.tsx
@@ -3,7 +3,10 @@ import React, { createContext, useState, ReactNode } from 'react';
 export interface ChatMessage {
   id: number;
   sender: 'user' | 'support';
-  content: string;
+  messageType: 'text' | 'image' | 'file';
+  content?: string;
+  fileUrl?: string;
+  fileName?: string;
   timestamp: Date;
 }
 
@@ -12,7 +15,12 @@ interface ChatContextValue {
   isOpen: boolean;
   openChat: (context?: { orderId?: string; customerName?: string }) => void;
   closeChat: () => void;
-  sendMessage: (content: string) => void;
+  sendMessage: (data: {
+    content?: string;
+    messageType: 'text' | 'image' | 'file';
+    fileUrl?: string;
+    fileName?: string;
+  }) => void;
   context?: {
     orderId?: string;
     customerName?: string;
@@ -34,15 +42,26 @@ interface ProviderProps {
 export function ChatProvider({ children }: ProviderProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isOpen, setIsOpen] = useState(false);
-  const [chatCtx, setChatCtx] = useState<{
-    orderId?: string;
-    customerName?: string;
-  } | undefined>();
-  const sendMessage = (content: string) => {
+  const [chatCtx, setChatCtx] = useState<
+    | {
+        orderId?: string;
+        customerName?: string;
+      }
+    | undefined
+  >();
+  const sendMessage = (data: {
+    content?: string;
+    messageType: 'text' | 'image' | 'file';
+    fileUrl?: string;
+    fileName?: string;
+  }) => {
     const msg: ChatMessage = {
       id: Date.now(),
       sender: 'user',
-      content,
+      messageType: data.messageType,
+      content: data.content,
+      fileUrl: data.fileUrl,
+      fileName: data.fileName,
       timestamp: new Date(),
     };
     setMessages((prev) => [...prev, msg]);
@@ -53,7 +72,8 @@ export function ChatProvider({ children }: ProviderProps) {
         {
           id: Date.now() + 1,
           sender: 'support',
-          content: 'Thanks for your message! We\'ll get back to you shortly.',
+          messageType: 'text',
+          content: "Thanks for your message! We'll get back to you shortly.",
           timestamp: new Date(),
         },
       ]);
@@ -69,7 +89,14 @@ export function ChatProvider({ children }: ProviderProps) {
 
   return (
     <ChatContext.Provider
-      value={{ messages, sendMessage, isOpen, openChat, closeChat, context: chatCtx }}
+      value={{
+        messages,
+        sendMessage,
+        isOpen,
+        openChat,
+        closeChat,
+        context: chatCtx,
+      }}
     >
       {children}
     </ChatContext.Provider>

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -5,9 +5,22 @@ export async function createMessage(data: {
   senderId: number;
   receiverId: number;
   orderId: number;
-  content: string;
+  messageType?: 'text' | 'image' | 'file';
+  content?: string;
+  fileUrl?: string;
+  fileName?: string;
 }): Promise<Message> {
-  return prisma.message.create({ data });
+  return prisma.message.create({
+    data: {
+      messageType: data.messageType || 'text',
+      content: data.content,
+      fileUrl: data.fileUrl,
+      fileName: data.fileName,
+      senderId: data.senderId,
+      receiverId: data.receiverId,
+      orderId: data.orderId,
+    },
+  });
 }
 
 export async function getMessagesForOrder(orderId: number): Promise<Message[]> {

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -22,3 +22,19 @@ export async function uploadFileToS3(
   await s3.send(command);
   return `https://${bucket}.s3.${region}.amazonaws.com/${key}`;
 }
+
+export async function uploadBufferToS3(
+  buffer: Buffer,
+  key: string,
+  contentType?: string
+): Promise<string> {
+  const command = new PutObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    Body: buffer,
+    ContentType: contentType,
+    ACL: 'public-read',
+  });
+  await s3.send(command);
+  return `https://${bucket}.s3.${region}.amazonaws.com/${key}`;
+}

--- a/pages/api/chat/upload.ts
+++ b/pages/api/chat/upload.ts
@@ -1,0 +1,55 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+import formidable, { File } from 'formidable';
+import { uploadFileToS3 } from '@/lib/s3';
+import type { ApiMessage } from '../../../types';
+
+export const config = {
+  api: { bodyParser: false },
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ url: string } | ApiMessage>
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  const form = formidable({ multiples: false, maxFileSize: 5 * 1024 * 1024 });
+  form.parse(req, async (err, fields, files) => {
+    if (err) {
+      res.status(400).json({ message: 'Invalid form data' });
+      return;
+    }
+    const file = files.file as File | undefined;
+    if (!file) {
+      res.status(400).json({ message: 'file required' });
+      return;
+    }
+    const allowed = [
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/webp',
+      'application/pdf',
+      'text/plain',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ];
+    if (file.mimetype && !allowed.includes(file.mimetype)) {
+      res.status(400).json({ message: 'Invalid file type' });
+      return;
+    }
+    const key = `chat/${session.user.id}/${Date.now()}-${file.originalFilename || 'file'}`;
+    const url = await uploadFileToS3(
+      file.filepath,
+      key,
+      file.mimetype || undefined
+    );
+    res.status(200).json({ url });
+  });
+}

--- a/pages/api/messages/[orderId].ts
+++ b/pages/api/messages/[orderId].ts
@@ -14,10 +14,12 @@ export default async function handler(
 ): Promise<void> {
   try {
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
+    if (!session?.user)
+      return res.status(401).json({ message: 'Unauthorized' });
 
     const orderUuid = getQueryParam(req.query.orderId);
-    if (!orderUuid) return res.status(400).json({ message: 'orderId required' });
+    if (!orderUuid)
+      return res.status(400).json({ message: 'orderId required' });
     const order = await getOrderByUuid(String(orderUuid));
     if (!order) return res.status(404).json({ message: 'Order not found' });
 
@@ -36,14 +38,24 @@ export default async function handler(
     }
 
     if (req.method === 'POST') {
-      const { content } = req.body as { content?: string };
-      if (!content) return res.status(400).json({ message: 'content required' });
+      const { content, messageType, fileUrl, fileName } = req.body as {
+        content?: string;
+        messageType?: 'text' | 'image' | 'file';
+        fileUrl?: string;
+        fileName?: string;
+      };
+      if (messageType === 'text' && !content) {
+        return res.status(400).json({ message: 'content required' });
+      }
       const receiverId = isBuyer ? order.product.vendor.id : order.userId;
       const msg = await createMessage({
         senderId: user.id,
         receiverId,
         orderId: order.id,
+        messageType,
         content,
+        fileUrl,
+        fileName,
       });
       return res.status(201).json(msg);
     }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -230,7 +230,10 @@ model Message {
   senderId   Int
   receiverId Int
   orderId    Int
-  content    String
+  messageType String   @default("text")
+  content     String?
+  fileUrl     String?
+  fileName    String?
   createdAt  DateTime @default(now())
 
   sender   User  @relation("SentMessages", fields: [senderId], references: [id])

--- a/types/message.ts
+++ b/types/message.ts
@@ -1,3 +1,11 @@
-import type { Message as PrismaMessage } from '@prisma/client';
-
-export interface Message extends PrismaMessage {}
+export interface Message {
+  id: number;
+  senderId: number;
+  receiverId: number;
+  orderId: number;
+  messageType: 'text' | 'image' | 'file';
+  content?: string | null;
+  fileUrl?: string | null;
+  fileName?: string | null;
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- extend chat message database schema with file fields
- add buffer upload helper for S3
- support creating messages with files via API
- provide API endpoint for uploading chat attachments
- add frontend components to upload and show files/images in chat

## Testing
- `npx next lint` *(fails: need next package download)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c80478e0832fa5ab1e8069cf9c65