### PR TITLE
Add rich text editor for product description

### DIFF
--- a/components/Product/ProductForm.tsx
+++ b/components/Product/ProductForm.tsx
@@ -4,10 +4,10 @@ import AsyncCreatableSelect from 'react-select/async-creatable';
 import type { SelectOption } from '../form-fields/SelectDropdown';
 import {
   TextInput,
-  Textarea,
   FileUpload,
   Checkbox,
   TagInput,
+  RichTextEditor,
 } from '../form-fields';
 import { VendorsResponse } from '../../types'
 
@@ -235,10 +235,10 @@ const ProductForm: React.FC<ProductFormProps> = ({
         error={errors.title?.message}
       />
       <div>
-        <Textarea<ProductFormValues>
+        <RichTextEditor<ProductFormValues>
           label="Description"
           name="description"
-          register={register}
+          control={control}
           rules={{ required: 'Required' }}
           error={errors.description?.message}
         />

--- a/components/brand/ProductDetailsModal.tsx
+++ b/components/brand/ProductDetailsModal.tsx
@@ -35,10 +35,10 @@ const ProductDetailsModal: React.FC<ProductDetailsModalProps> = ({
       : product.featuredImage
         ? [product.featuredImage]
         : [];
-  const description =
-    product.descriptionText ||
-    product.bodyHtmlText ||
+  const descriptionHtml =
     product.description ||
+    product.bodyHtmlText ||
+    product.descriptionText ||
     'No description.';
   const category =
     typeof product.category === 'string'
@@ -84,8 +84,11 @@ const ProductDetailsModal: React.FC<ProductDetailsModalProps> = ({
         </div>
         <div>
           <h3 className="font-semibold mb-1">Description</h3>
-          <p className={showAll ? undefined : 'line-clamp-5'}>{description}</p>
-          {!showAll && description.length > 200 && (
+          <p
+            className={showAll ? undefined : 'line-clamp-5'}
+            dangerouslySetInnerHTML={{ __html: descriptionHtml }}
+          />
+          {!showAll && descriptionHtml.length > 200 && (
             <button
               type="button"
               className="btn btn-link btn-xs px-0"

--- a/components/form-fields/RichTextEditor.tsx
+++ b/components/form-fields/RichTextEditor.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import dynamic from 'next/dynamic';
+import {
+  Control,
+  Controller,
+  FieldValues,
+  Path,
+  RegisterOptions,
+} from 'react-hook-form';
+
+const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
+
+interface RichTextEditorProps<T extends FieldValues> {
+  name: Path<T>;
+  control: Control<T>;
+  label?: string;
+  placeholder?: string;
+  error?: string;
+  rules?: RegisterOptions<T, Path<T>>;
+}
+
+const modules = {
+  toolbar: [
+    [{ header: [1, 2, 3, false] }],
+    ['bold', 'italic', 'underline'],
+    [{ list: 'ordered' }, { list: 'bullet' }],
+    ['link'],
+    ['clean'],
+  ],
+};
+
+const RichTextEditor = <T extends FieldValues>(props: RichTextEditorProps<T>) => {
+  const { name, control, label, placeholder, error, rules } = props;
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field }) => (
+        <div className="mb-4 w-full">
+          {label && (
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {label}
+            </label>
+          )}
+          <ReactQuill
+            theme="snow"
+            value={field.value || ''}
+            onChange={field.onChange}
+            onBlur={field.onBlur}
+            placeholder={placeholder}
+            modules={modules}
+          />
+          {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+        </div>
+      )}
+    />
+  );
+};
+
+export default RichTextEditor;

--- a/components/form-fields/index.ts
+++ b/components/form-fields/index.ts
@@ -11,3 +11,4 @@ export { default as CountrySelect } from './CountrySelect';
 export { default as TagInput } from './TagInput';
 export { default as AddressAutocomplete } from './AddressAutocomplete';
 export { default as CardNumberInput } from './CardNumberInput';
+export { default as RichTextEditor } from './RichTextEditor';

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-hook-form": "^7.50.0",
         "react-imask": "^7.6.1",
         "react-markdown": "^10.1.0",
+        "react-quill": "^2.0.0",
         "react-select": "^5.10.1",
         "react-select-country-list": "^2.2.3",
         "react-world-flags": "^1.6.0",
@@ -5860,6 +5861,15 @@
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
+    "node_modules/@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "license": "MIT",
+      "dependencies": {
+        "parchment": "^1.1.2"
+      }
+    },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
@@ -7348,7 +7358,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -8475,7 +8484,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -8492,7 +8500,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -9558,6 +9565,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fast-equals": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
@@ -9925,7 +9938,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10193,7 +10205,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -10523,7 +10534,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10699,7 +10709,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -10879,7 +10888,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -13824,7 +13832,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
       "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -13841,7 +13848,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -14079,6 +14085,12 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "license": "MIT"
+    },
+    "node_modules/parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -14642,6 +14654,80 @@
         }
       ]
     },
+    "node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/quill-delta/node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quill/node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quill/node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -14733,6 +14819,21 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/react-resize-detector": {
@@ -14960,7 +15061,6 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
@@ -15325,7 +15425,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -15342,7 +15441,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-hook-form": "^7.50.0",
     "react-imask": "^7.6.1",
     "react-markdown": "^10.1.0",
+    "react-quill": "^2.0.0",
     "react-select": "^5.10.1",
     "react-select-country-list": "^2.2.3",
     "react-world-flags": "^1.6.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import '../styles/globals.css';
+import 'react-quill/dist/quill.snow.css';
 import { AppProvider } from '@contexts/AppContext';
 import Layout from '@components/Layout/Layout';
 import { SessionProvider } from 'next-auth/react';

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -121,11 +121,16 @@ export default function ProductDetail({
           </p>
           <p className="mb-2">SKU: {product.sku || 'N/A'}</p>
           <p className="mb-2">Type: {product.productType || 'N/A'}</p>
-          <p className="mb-4">
-            {product.descriptionText ||
-              product.bodyHtmlText ||
-              'No description available.'}
-          </p>
+          <p
+            className="mb-4"
+            dangerouslySetInnerHTML={{
+              __html:
+                product.description ||
+                product.bodyHtmlText ||
+                product.descriptionText ||
+                'No description available.',
+            }}
+          />
           <p className="text-lg font-bold mb-4">
             {product.currency}{' '}
             {parseFloat(

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -128,11 +128,15 @@ const ProductDetail: React.FC<ProductDetailProps> = () => {
                 }`
               : ''}
           </p>
-          <p>
-            {product.descriptionText ||
-              product.bodyHtmlText ||
-              'No description available'}
-          </p>
+          <p
+            dangerouslySetInnerHTML={{
+              __html:
+                product.description ||
+                product.bodyHtmlText ||
+                product.descriptionText ||
+                'No description available',
+            }}
+          />
           <p className="text-lg font-bold">
             {formatCurrency(product.minPrice ?? 0, product.currency)}
           </p>


### PR DESCRIPTION
## Summary
- install `react-quill`
- create `RichTextEditor` component
- use rich editor in `ProductForm`
- render HTML descriptions in product pages and brand modal
- load Quill styles globally

## Testing
- `npm test`
- `npm run lint` *(fails: React hook errors)*
- `npm run type-check` *(fails: many type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864c9c6fc88832fbf86052f01b25f8a