### PR TITLE
Add order cancel/refund feature

### DIFF
--- a/pages/api/orders/[uuid]/cancel.ts
+++ b/pages/api/orders/[uuid]/cancel.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getOrderByUuid, updateOrderStatus } from '@lib/orders';
+import { stripe } from '@lib/stripe';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
+import { logAudit } from '@lib/audit';
+import type { ApiMessage } from '../../../../types';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.status(405).json({ message: 'Method Not Allowed' });
+    return;
+  }
+  try {
+    const uuid = getQueryParam(req.query.uuid);
+    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    const order = await getOrderByUuid(uuid);
+    if (!order) return res.status(404).json({ message: 'Not found' });
+    if (['delivered', 'completed'].includes(order.status)) {
+      return res.status(400).json({ message: 'Cannot cancel this order' });
+    }
+    if (order.paymentMethod === 'card' && order.paymentReference) {
+      await stripe.refunds.create({ payment_intent: order.paymentReference });
+    }
+    await updateOrderStatus(uuid, 'cancelled');
+    logAudit('cancel_order', { uuid, by: req.user?.email });
+    return res.status(200).json({ message: 'cancelled' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to cancel order');
+  }
+}
+
+export default withRole(['BRAND', 'SUPER_ADMIN'])(handler);

--- a/pages/api/user/orders/[uuid]/cancel.ts
+++ b/pages/api/user/orders/[uuid]/cancel.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { getOrderByUuid, updateOrderStatus } from '@lib/orders';
+import { stripe } from '@lib/stripe';
+import { handleApiError } from '@utils/handleApiError';
+import { getQueryParam } from '@utils/getQueryParam';
+import { logAudit } from '@lib/audit';
+import type { ApiMessage } from '../../../../../../types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.status(405).json({ message: 'Method Not Allowed' });
+    return;
+  }
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const uuid = getQueryParam(req.query.uuid);
+    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    const order = await getOrderByUuid(uuid);
+    if (!order || order.userEmail !== session.user.email) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+    if (['shipped', 'delivered', 'completed'].includes(order.status)) {
+      return res.status(400).json({ message: 'Cannot cancel this order' });
+    }
+    if (order.paymentMethod === 'card' && order.paymentReference) {
+      await stripe.refunds.create({ payment_intent: order.paymentReference });
+    }
+    await updateOrderStatus(uuid, 'cancelled');
+    logAudit('cancel_order', { uuid, by: session.user.email });
+    return res.status(200).json({ message: 'cancelled' });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to cancel order');
+  }
+}

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -13,10 +13,12 @@ import { getPageTitle } from '@lib/pageTitle';
 import OrderDetailsModal from '@components/brand/OrderDetailsModal';
 import ChatWindow from '@components/Chat/ChatWindow';
 import { ChatContext } from '@contexts/ChatContext';
+import { NotificationContext } from '@contexts/NotificationContext';
 
 const BrandOrders: React.FC = () => {
   const { user } = useContext(AppContext)!;
   const { openChat } = useContext(ChatContext);
+  const { addNotification } = useContext(NotificationContext);
   const { data: session, status } = useSession();
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
@@ -38,6 +40,18 @@ const BrandOrders: React.FC = () => {
       .catch(() => setError('Failed to load orders'))
       .finally(() => setLoading(false));
   }, [user]);
+
+  const cancelOrder = async (uuid: string) => {
+    if (!confirm('Cancel this order?')) return;
+    const res = await fetch(`/api/orders/${uuid}/cancel`, { method: 'POST' });
+    const data = await res.json().catch(() => null);
+    if (res.ok) {
+      addNotification('Order cancelled', 'success');
+      loadOrders();
+    } else {
+      addNotification(data?.message || 'Cancellation failed', 'error');
+    }
+  };
 
   const groupedOrders = useMemo(() => {
     const map = new Map<string, { order: Order; items: Order[] }>();
@@ -152,6 +166,15 @@ const BrandOrders: React.FC = () => {
                       >
                         Chat
                       </button>
+                      {!['delivered', 'completed'].includes(g.order.status) && (
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-error"
+                          onClick={() => cancelOrder(g.order.uuid)}
+                        >
+                          Cancel
+                        </button>
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useState, useMemo, Fragment } from 'react';
+import { useEffect, useState, useMemo, Fragment, useContext } from 'react';
 import useRequireAuth from '@hooks/useRequireAuth';
 import type { Order } from '../types';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
+import { NotificationContext } from '@contexts/NotificationContext';
 
 type OrdersProps = {};
 
 const Orders: React.FC<OrdersProps> = (_props) => {
   const user = useRequireAuth();
+  const { addNotification } = useContext(NotificationContext);
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -48,6 +50,18 @@ const Orders: React.FC<OrdersProps> = (_props) => {
       )
       .finally(() => setLoading(false));
   }, [user]);
+
+  const cancelOrder = async (uuid: string) => {
+    if (!confirm('Cancel this order?')) return;
+    const res = await fetch(`/api/user/orders/${uuid}/cancel`, { method: 'POST' });
+    const data = await res.json().catch(() => null);
+    if (res.ok) {
+      addNotification('Order cancelled', 'success');
+      setOrders((prev) => prev.map((o) => (o.uuid === uuid ? { ...o, status: 'cancelled' } : o)));
+    } else {
+      addNotification(data?.message || 'Cancellation failed', 'error');
+    }
+  };
 
   if (!user) {
     return null;
@@ -102,7 +116,8 @@ const Orders: React.FC<OrdersProps> = (_props) => {
                             ? 'badge-warning'
                             : group.order.status === 'shipped'
                               ? 'badge-info'
-                              : group.order.status === 'delivered'
+                              : group.order.status === 'delivered' ||
+                                  group.order.status === 'completed'
                                 ? 'badge-success'
                                 : 'badge-error'
                         }`}
@@ -127,6 +142,17 @@ const Orders: React.FC<OrdersProps> = (_props) => {
                       >
                         PDF
                       </a>
+                      {['pending', 'confirmed', 'processing'].includes(
+                        group.order.status
+                      ) && (
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-error"
+                          onClick={() => cancelOrder(group.order.uuid)}
+                        >
+                          Cancel
+                        </button>
+                      )}
                     </td>
                   </tr>
                   {expanded === idx && (


### PR DESCRIPTION
## Summary
- allow users and brands to cancel orders
- refund Stripe payments when cancelling
- show cancel buttons in orders tables
- use success color for completed orders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864ca5dd340832fa9c2eb015e2b0d64