### PR TITLE
Enable order chat for users

### DIFF
--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -12,7 +12,16 @@ const allowedTypes = [
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 ];
 
-const ChatInput: React.FC = () => {
+interface Props {
+  onSend?: (data: {
+    content?: string;
+    messageType: 'text' | 'image' | 'file';
+    fileUrl?: string;
+    fileName?: string;
+  }) => void;
+}
+
+const ChatInput: React.FC<Props> = ({ onSend }) => {
   const { sendMessage } = useContext(ChatContext);
   const [text, setText] = useState('');
   const [file, setFile] = useState<File | null>(null);
@@ -56,7 +65,8 @@ const ChatInput: React.FC = () => {
         fileName = file.name;
       }
     }
-    sendMessage({ content: text.trim(), messageType, fileUrl, fileName });
+    const fn = onSend || sendMessage;
+    fn({ content: text.trim(), messageType, fileUrl, fileName });
     setText('');
     setFile(null);
     setPreview(null);

--- a/components/Chat/OrderChatWindow.tsx
+++ b/components/Chat/OrderChatWindow.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState, useRef, useContext } from 'react';
+import ChatInput from './ChatInput';
+import { AppContext } from '@contexts/AppContext';
+import type { Message } from '@/types';
+
+interface Props {
+  orderId: string;
+  brandName: string;
+  brandLogo?: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const OrderChatWindow: React.FC<Props> = ({
+  orderId,
+  brandName,
+  brandLogo,
+  isOpen,
+  onClose,
+}) => {
+  const app = useContext(AppContext);
+  const user = app?.user;
+  const [messages, setMessages] = useState<Message[]>([]);
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  const fetchMsgs = () => {
+    if (!orderId) return;
+    fetch(`/api/messages/${orderId}`)
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setMessages(data))
+      .catch(() => {});
+  };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    fetchMsgs();
+    const i = setInterval(fetchMsgs, 5000);
+    return () => clearInterval(i);
+  }, [isOpen, orderId]);
+
+  useEffect(() => {
+    if (isOpen) {
+      endRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, isOpen]);
+
+  const send = async (data: {
+    content?: string;
+    messageType: 'text' | 'image' | 'file';
+    fileUrl?: string;
+    fileName?: string;
+  }) => {
+    await fetch(`/api/messages/${orderId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    }).then((res) => res.ok && res.json()).catch(() => {});
+    fetchMsgs();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      <div className="bg-base-100 rounded-lg shadow-lg w-72 h-96 flex flex-col fade-in">
+        <div className="flex justify-between items-center p-2 border-b">
+          <div className="flex items-center gap-2">
+            {brandLogo && (
+              <img src={brandLogo} alt={brandName} className="w-6 h-6 rounded" />
+            )}
+            <span className="font-semibold">{brandName}</span>
+          </div>
+          <button type="button" className="btn btn-xs btn-circle" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <div className="p-1 text-xs text-center text-gray-500">
+          You are chatting with {brandName}
+        </div>
+        <div className="flex-1 overflow-y-auto p-2 space-y-1 text-sm">
+          {messages.map((m) => (
+            <div key={m.id}>
+              <span className="text-gray-500 mr-2">
+                {m.senderId === user?.id ? 'You' : brandName}:
+              </span>
+              {m.messageType === 'image' && m.fileUrl ? (
+                <img
+                  src={m.fileUrl}
+                  alt={m.fileName || 'image'}
+                  className="max-w-[150px] rounded inline"
+                />
+              ) : m.messageType === 'file' && m.fileUrl ? (
+                <a href={m.fileUrl} target="_blank" rel="noopener" className="link">
+                  {m.fileName || 'Download file'}
+                </a>
+              ) : (
+                <span>{m.content}</span>
+              )}
+            </div>
+          ))}
+          <div ref={endRef} />
+        </div>
+        <ChatInput onSend={send} />
+      </div>
+    </div>
+  );
+};
+
+export default OrderChatWindow;

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useMemo, Fragment } from 'react';
+import OrderChatWindow from '@components/Chat/OrderChatWindow';
 import useRequireAuth from '@hooks/useRequireAuth';
 import type { Order } from '../types';
 import Head from 'next/head';
@@ -12,6 +13,11 @@ const Orders: React.FC<OrdersProps> = (_props) => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<number | null>(null);
+  const [chatOrder, setChatOrder] = useState<{
+    id: string;
+    brandName: string;
+    brandLogo?: string | null;
+  } | null>(null);
 
   const groupedOrders = useMemo(() => {
     const map = new Map<string, { order: Order; items: Order[] }>();
@@ -115,19 +121,33 @@ const Orders: React.FC<OrdersProps> = (_props) => {
                       {new Date(group.order.createdAt).toLocaleDateString()}
                     </td>
                     <td className="space-x-2">
-                      <a
-                        className="btn btn-sm"
-                        href={`/orders/${group.order.uuid}`}
-                      >
-                        View
-                      </a>
-                      <a
-                        className="link"
-                        href={`/api/orders/${group.order.uuid}/invoice`}
-                      >
-                        PDF
-                      </a>
-                    </td>
+                    <a
+                      className="btn btn-sm"
+                      href={`/orders/${group.order.uuid}`}
+                    >
+                      View
+                    </a>
+                    <a
+                      className="link"
+                      href={`/api/orders/${group.order.uuid}/invoice`}
+                    >
+                      PDF
+                    </a>
+                    <button
+                      type="button"
+                      className="link"
+                      onClick={() =>
+                        setChatOrder({
+                          id: group.order.uuid,
+                          brandName:
+                            group.order.product.vendor.brandName || 'Brand',
+                          brandLogo: group.order.product.vendor.logo,
+                        })
+                      }
+                    >
+                      Chat
+                    </button>
+                  </td>
                   </tr>
                   {expanded === idx && (
                     <tr className="bg-base-200">
@@ -163,6 +183,13 @@ const Orders: React.FC<OrdersProps> = (_props) => {
       ) : (
         !loading && <p>No orders found.</p>
       )}
+      <OrderChatWindow
+        isOpen={!!chatOrder}
+        orderId={chatOrder?.id || ''}
+        brandName={chatOrder?.brandName || ''}
+        brandLogo={chatOrder?.brandLogo}
+        onClose={() => setChatOrder(null)}
+      />
     </div>
   );
 };

--- a/pages/orders/[orderId].tsx
+++ b/pages/orders/[orderId].tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useContext } from 'react';
+import OrderChatWindow from '@components/Chat/OrderChatWindow';
 import { useRouter } from 'next/router';
 import type { Order } from '../../types';
 import Head from 'next/head';
@@ -13,6 +14,7 @@ export default function OrderDetail() {
   const [order, setOrder] = useState<Order | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [chatOpen, setChatOpen] = useState(false);
 
   useEffect(() => {
     if (!orderId) return;
@@ -66,6 +68,20 @@ export default function OrderDetail() {
       >
         Download Invoice
       </a>
+      <button
+        type="button"
+        className="btn btn-secondary mt-4 ml-2"
+        onClick={() => setChatOpen(true)}
+      >
+        Chat with Brand
+      </button>
+      <OrderChatWindow
+        isOpen={chatOpen}
+        orderId={order.uuid}
+        brandName={order.product.vendor.brandName || 'Brand'}
+        brandLogo={order.product.vendor.logo}
+        onClose={() => setChatOpen(false)}
+      />
     </div>
   );
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -235,6 +235,7 @@ model Message {
   fileUrl     String?
   fileName    String?
   createdAt  DateTime @default(now())
+  seen       Boolean  @default(false)
 
   sender   User  @relation("SentMessages", fields: [senderId], references: [id])
   receiver User  @relation("ReceivedMessages", fields: [receiverId], references: [id])

--- a/types/message.ts
+++ b/types/message.ts
@@ -8,4 +8,5 @@ export interface Message {
   fileUrl?: string | null;
   fileName?: string | null;
   createdAt: Date;
+  seen: boolean;
 }


### PR DESCRIPTION
## Summary
- support message 'seen' state in schema and types
- allow ChatInput to send via custom handler
- add OrderChatWindow component
- show chat buttons on order list and detail pages
- display vendor chat window for users

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6864caa961a0832fa8fae293cc835ed0