### PR TITLE
Fix country value in Manage Address form

### DIFF
--- a/components/Settings/ManageAddressSection.tsx
+++ b/components/Settings/ManageAddressSection.tsx
@@ -2,16 +2,10 @@ import { useState, useEffect, useContext } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { TextInput, CountrySelect } from '@components/form-fields';
 import { NotificationContext } from '@contexts/NotificationContext';
-import countries from '../../data/countries';
-
 interface AddressFormValues {
   address: string;
   city: string;
-  country: {
-    label: string;
-    value: string;
-    callingCode: string;
-  } | null;
+  country: string;
 }
 
 const ManageAddressSection: React.FC = () => {
@@ -27,7 +21,7 @@ const ManageAddressSection: React.FC = () => {
         addressForm.reset({
           address: data.address || '',
           city: data.city || '',
-          country: countries.find((c) => c.value === data.country) || null,
+          country: data.country || '',
         });
       })
       .catch(() => {});
@@ -38,7 +32,7 @@ const ManageAddressSection: React.FC = () => {
     const payload = {
       address: values.address,
       city: values.city,
-      country: values.country?.value || '',
+      country: values.country,
     };
     const res = await fetch('/api/user/profile', {
       method: 'PUT',


### PR DESCRIPTION
## Summary
- ensure `country` field stores string value in manage address section

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6864d6cecd88832f9a9fec0c99f40f74