### PR TITLE
Support multiple brand payment methods

### DIFF
--- a/__tests__/order.detail.test.tsx
+++ b/__tests__/order.detail.test.tsx
@@ -33,7 +33,7 @@ describe('OrderDetail page', () => {
           id: 1,
           uuid: 'abc',
           status: 'processing',
-          product: { title: 'Test' },
+          product: { title: 'Test', vendor: { brandName: 'Brand', logo: null } },
           quantity: 2,
           total: 20,
         }),

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -36,6 +36,7 @@ interface ProductWithRelations {
     brandName: string | null;
     phoneNumber?: string | null | undefined;
     address?: string | null;
+    paymentMethods?: import('@/types/vendor').BrandPaymentMethod[] | null;
   };
   category: Category;
   variants: Variant[];
@@ -52,6 +53,7 @@ interface ProductRow {
         brandName: string | null;
         phoneNumber?: string | null | undefined;
         address?: string | null;
+        paymentMethods?: import('@/types/vendor').BrandPaymentMethod[] | null;
       })
     | null;
   description?: string | null;
@@ -175,6 +177,7 @@ export function mapDbRowToProduct(row: ProductRow): Product {
           brandName: row.vendor.brandName ?? '',
           phoneNumber: row.vendor.phoneNumber ?? undefined,
           address: row.vendor.address ?? null,
+          paymentMethods: (row.vendor.paymentMethods as any) ?? null,
         }
       : null,
     category: row.category ?? null,

--- a/pages/api/brand/profile.ts
+++ b/pages/api/brand/profile.ts
@@ -30,6 +30,7 @@ export default async function handler(
         website: userData.website ?? undefined,
         description: userData.businessDescription ?? undefined,
         taxId: userData.taxId ?? undefined,
+        paymentMethods: (userData.paymentMethods as any) ?? undefined,
         status: userData.disabled ? 'disabled' : 'active',
         createdAt: userData.createdAt ?? undefined,
         updatedAt: userData.updatedAt ?? undefined,
@@ -47,6 +48,7 @@ export default async function handler(
         businessDescription,
         logo,
         taxId,
+        paymentMethods,
       } = req.body;
       await updateUserProfile(session.user.email, {
         brandName,
@@ -58,6 +60,7 @@ export default async function handler(
         businessDescription,
         logo,
         taxId,
+        paymentMethods,
       });
       return res.status(200).json({ message: 'updated' });
     }

--- a/pages/api/checkout/complete.ts
+++ b/pages/api/checkout/complete.ts
@@ -30,6 +30,7 @@ export default async function handler(
       items: JSON.parse(metadata.items || '[]'),
       total: (session.amount_total ?? 0) / 100,
       status: 'processing',
+      paymentMethod: 'stripe',
     });
     const orderId =
       Array.isArray(orders) && orders.length > 0 ? orders[0].id : '';

--- a/pages/api/checkout/create-session.ts
+++ b/pages/api/checkout/create-session.ts
@@ -22,16 +22,24 @@ export default async function handler(
   }
   try {
     let stripeAccountId: string | undefined;
+    let allowedStripe = false;
     if (items.length > 0) {
       const product = await getProductByUuid(
         String(items[0].uuid || items[0].id)
       );
       if (product) {
         const vendor = await findUserById(product.vendorId);
-        if (vendor && vendor.stripeAccountId) {
-          stripeAccountId = vendor.stripeAccountId;
+        if (vendor) {
+          const methods = (vendor.paymentMethods as any[]) || [];
+          allowedStripe = methods.some((m) => m.type === 'stripe');
+          if (vendor.stripeAccountId) {
+            stripeAccountId = vendor.stripeAccountId;
+          }
         }
       }
+    }
+    if (!allowedStripe) {
+      return res.status(400).json({ message: 'payment method not supported' });
     }
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ['card'],

--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -5,7 +5,7 @@ import {
   getAllOrders,
   getOrdersForVendor,
 } from '@lib/orders';
-import { findUser } from '@lib/users';
+import { findUser, findUserById } from '@lib/users';
 import {
   getProductByUuid,
   decreaseProductQuantity,
@@ -71,6 +71,22 @@ async function handler(
       }
       if (!email || !items) {
         return res.status(400).json({ message: 'email and items required' });
+      }
+
+      let allowed = true;
+      let vendorMethods: any[] = [];
+      if (items.length > 0) {
+        const product = await getProductByUuid(String(items[0].uuid || items[0].id));
+        if (product) {
+          const vendor = await findUserById(product.vendorId);
+          vendorMethods = (vendor?.paymentMethods as any[]) || [];
+          if (paymentMethod && !vendorMethods.some((m) => m.type === paymentMethod)) {
+            allowed = false;
+          }
+        }
+      }
+      if (!allowed) {
+        return res.status(400).json({ message: 'payment method not supported' });
       }
 
       for (const item of items) {

--- a/pages/brand/profile.tsx
+++ b/pages/brand/profile.tsx
@@ -45,6 +45,11 @@ export const BrandProfile: React.FC = () => {
 
   const [message, setMessage] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
+  const [stripeEnabled, setStripeEnabled] = useState(false);
+  const [jazzcashEnabled, setJazzcashEnabled] = useState(false);
+  const [jazzcashDetails, setJazzcashDetails] = useState('');
+  const [bankEnabled, setBankEnabled] = useState(false);
+  const [bankDetails, setBankDetails] = useState('');
 
   useEffect(() => {
     if (user) {
@@ -58,6 +63,14 @@ export const BrandProfile: React.FC = () => {
         businessDescription: user.businessDescription || '',
         taxId: user.taxId || '',
       });
+      const methods = Array.isArray(user.paymentMethods) ? user.paymentMethods : [];
+      setStripeEnabled(methods.some((m) => m.type === 'stripe'));
+      const jazz = methods.find((m) => m.type === 'jazzcash');
+      setJazzcashEnabled(!!jazz);
+      setJazzcashDetails(jazz?.details || '');
+      const bank = methods.find((m) => m.type === 'bank_transfer');
+      setBankEnabled(!!bank);
+      setBankDetails(bank?.details || '');
     }
   }, [user, reset]);
 
@@ -78,6 +91,14 @@ export const BrandProfile: React.FC = () => {
           businessDescription: data.description || '',
           taxId: data.taxId || '',
         });
+        const methods = Array.isArray(data.paymentMethods) ? data.paymentMethods : [];
+        setStripeEnabled(methods.some((m) => m.type === 'stripe'));
+        const jazz = methods.find((m) => m.type === 'jazzcash');
+        setJazzcashEnabled(!!jazz);
+        setJazzcashDetails(jazz?.details || '');
+        const bank = methods.find((m) => m.type === 'bank_transfer');
+        setBankEnabled(!!bank);
+        setBankDetails(bank?.details || '');
       })
       .catch(() => {})
       .finally(() => setLoading(false));
@@ -85,10 +106,16 @@ export const BrandProfile: React.FC = () => {
 
   const submit: SubmitHandler<FormValues> = async (values) => {
     setMessage('');
+    const methods = [] as { type: string; details?: string }[];
+    if (stripeEnabled) methods.push({ type: 'stripe' });
+    if (jazzcashEnabled)
+      methods.push({ type: 'jazzcash', details: jazzcashDetails });
+    if (bankEnabled)
+      methods.push({ type: 'bank_transfer', details: bankDetails });
     const res = await fetch('/api/brand/profile', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(values),
+      body: JSON.stringify({ ...values, paymentMethods: methods }),
     });
     if (res.ok) setMessage('Profile updated');
     else setMessage('Update failed');
@@ -166,6 +193,52 @@ export const BrandProfile: React.FC = () => {
           placeholder="Tax ID"
           error={errors.taxId?.message}
         />
+        <div className="border p-3 rounded space-y-2">
+          <label className="font-semibold">Payment Methods</label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              className="checkbox"
+              checked={stripeEnabled}
+              onChange={(e) => setStripeEnabled(e.target.checked)}
+            />
+            Stripe
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              className="checkbox"
+              checked={jazzcashEnabled}
+              onChange={(e) => setJazzcashEnabled(e.target.checked)}
+            />
+            JazzCash
+          </label>
+          {jazzcashEnabled && (
+            <TextInput
+              name="jazzcashDetails"
+              placeholder="JazzCash account"
+              value={jazzcashDetails}
+              onChange={(e) => setJazzcashDetails(e.target.value)}
+            />
+          )}
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              className="checkbox"
+              checked={bankEnabled}
+              onChange={(e) => setBankEnabled(e.target.checked)}
+            />
+            Bank Transfer
+          </label>
+          {bankEnabled && (
+            <Textarea
+              name="bankDetails"
+              placeholder="Bank details"
+              value={bankDetails}
+              onChange={(e) => setBankDetails(e.target.value)}
+            />
+          )}
+        </div>
         <button className="btn btn-primary w-full" type="submit">
           Update
         </button>

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -42,7 +42,8 @@ const Checkout: React.FC = () => {
   const [error, setError] = useState('');
   const [coupon, setCoupon] = useState('');
   const [discount, setDiscount] = useState(0);
-  const [paymentMethod, setPaymentMethod] = useState('card');
+  const [availableMethods, setAvailableMethods] = useState<{ type: string; details?: string }[]>([]);
+  const [paymentMethod, setPaymentMethod] = useState('stripe');
   const [paymentReference, setPaymentReference] = useState('');
   const [paymentProof, setPaymentProof] = useState<File | null>(null);
   const [step, setStep] = useState(1);
@@ -65,6 +66,14 @@ const Checkout: React.FC = () => {
   const finalTotal = discountedTotal + shippingCost;
 
   useEffect(() => {
+    if (cart.length > 0 && (cart[0] as any).vendor) {
+      const methods = (cart[0] as any).vendor.paymentMethods || [];
+      setAvailableMethods(methods);
+      if (methods.length > 0) setPaymentMethod(methods[0].type);
+    }
+  }, [cart]);
+
+  useEffect(() => {
     if (!country) return;
     fetch(`/api/delivery-estimate?country=${country}`)
       .then((res) => (res.ok ? res.json() : Promise.reject()))
@@ -79,7 +88,7 @@ const Checkout: React.FC = () => {
     setError('');
     try {
       if (user) {
-        if (paymentMethod === 'card') {
+        if (paymentMethod === 'stripe') {
           const res = await fetch('/api/checkout/create-session', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -269,7 +278,7 @@ const Checkout: React.FC = () => {
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          if (paymentMethod !== 'card' && !paymentReference) {
+          if (paymentMethod !== 'stripe' && !paymentReference) {
             setError('Payment reference required');
             return;
           }
@@ -278,6 +287,9 @@ const Checkout: React.FC = () => {
         }}
         className="space-y-3"
       >
+        {availableMethods.length === 0 && (
+          <p>No payment methods available.</p>
+        )}
         <div>
           <label className="label" htmlFor="paymentMethod">Payment Method</label>
           <select
@@ -286,21 +298,25 @@ const Checkout: React.FC = () => {
             value={paymentMethod}
             onChange={(e) => setPaymentMethod(e.target.value)}
           >
-            <option value="card">Credit/Debit Card</option>
-            <option value="easypaisa">EasyPaisa</option>
-            <option value="jazzcash">JazzCash</option>
-            <option value="bank">Bank Transfer</option>
+            {availableMethods.map((m) => (
+              <option key={m.type} value={m.type}>
+                {m.type === 'card' || m.type === 'stripe'
+                  ? 'Credit/Debit Card'
+                  : m.type === 'jazzcash'
+                  ? 'JazzCash'
+                  : m.type === 'bank_transfer'
+                  ? 'Bank Transfer'
+                  : m.type}
+              </option>
+            ))}
           </select>
         </div>
-        {paymentMethod !== 'card' && (
+        {paymentMethod !== 'stripe' && paymentMethod !== 'card' && (
           <div className="border p-3 rounded space-y-2">
-            {paymentMethod === 'easypaisa' && (
-              <p>Send payment to EasyPaisa account <b>0300-1234567</b> and enter the transaction ID below.</p>
-            )}
             {paymentMethod === 'jazzcash' && (
               <p>Send payment to JazzCash account <b>0300-7654321</b> and enter the transaction ID below.</p>
             )}
-            {paymentMethod === 'bank' && (
+            {paymentMethod === 'bank_transfer' && (
               <p>Transfer to Bank Account <b>PK00 TEST 1234 5678 9012 3456</b> and provide reference.</p>
             )}
             <TextInput

--- a/prisma/migrations/20250702145549_add-paymentmethods-field/migration.sql
+++ b/prisma/migrations/20250702145549_add-paymentmethods-field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "paymentMethods" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   profileImage        String?
   taxId               String?
   stripeAccountId     String?
+  paymentMethods      Json?
   role                Role      @default(USER)
   verified            Boolean   @default(false)
   disabled            Boolean   @default(false)

--- a/types/user.ts
+++ b/types/user.ts
@@ -22,6 +22,7 @@ export interface User {
   profileImage?: string;
   taxId?: string;
   stripeAccountId?: string;
+  paymentMethods?: import('./vendor').BrandPaymentMethod[];
   verificationToken?: string;
   resetToken?: string;
   resetExpires?: Date;
@@ -53,6 +54,7 @@ export interface UserInput {
   profileImage?: string;
   taxId?: string;
   stripeAccountId?: string;
+  paymentMethods?: import('./vendor').BrandPaymentMethod[];
   role?: Role;
   verificationToken?: string;
 }

--- a/types/vendor.ts
+++ b/types/vendor.ts
@@ -13,7 +13,13 @@ export interface Vendor {
   description?: string;
   logo?: string;
   taxId?: string;
+  paymentMethods?: BrandPaymentMethod[];
   status?: string;
   createdAt?: Date;
   updatedAt?: Date;
+}
+
+export interface BrandPaymentMethod {
+  type: 'stripe' | 'jazzcash' | 'bank_transfer';
+  details?: string | null;
 }


### PR DESCRIPTION
## Summary
- let brands store payment methods in Prisma
- expose payment methods in Brand profile API
- allow editing payment options in Brand profile UI
- expose methods with products
- validate payment method during checkout and order creation
- show dynamic payment methods during checkout
- record `stripe` as order payment method
- update failing order detail test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686546e8d830832fb351703c83b6e44c