### PR TITLE
Implement checkout autofill

### DIFF
--- a/pages/api/me.ts
+++ b/pages/api/me.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
+import { findUser } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ name: string; address: string | null; country: string | null; email?: string } | { message: string }>
+): Promise<void> {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    if (req.method !== 'GET') {
+      return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+    const dbUser = await findUser(session.user.email);
+    if (!dbUser) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    const name = `${dbUser.firstName || ''} ${dbUser.lastName || ''}`.trim();
+    return res.status(200).json({
+      name,
+      address: dbUser.address || null,
+      country: dbUser.country || null,
+      email: dbUser.email,
+    });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to load user info');
+  }
+}

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,4 +1,10 @@
-import { useContext, useState, useEffect, FormEvent, ChangeEvent } from 'react';
+import {
+  useContext,
+  useState,
+  useEffect,
+  FormEvent,
+  ChangeEvent,
+} from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import Head from 'next/head';
@@ -9,11 +15,11 @@ import type { User } from '@/types/user';
 import type { Coupon } from '../types';
 import {
   TextInput,
-  Textarea,
   CountrySelect,
   AddressAutocomplete,
 } from '@components/form-fields';
 import FileUpload from '@components/form-fields/FileUpload';
+import Loader from '@components/Loader';
 
 const STRAPI_URL = process.env.NEXT_PUBLIC_STRAPI_URL || '';
 
@@ -50,6 +56,7 @@ const Checkout: React.FC = () => {
   const [paymentProof, setPaymentProof] = useState<File | null>(null);
   const [step, setStep] = useState(1);
   const [deliveryDate, setDeliveryDate] = useState('');
+  const [loadingUser, setLoadingUser] = useState(false);
 
   const itemCount = cart.reduce((s, i) => s + i.qty, 0);
   const totalPrice = cart.reduce(
@@ -76,6 +83,22 @@ const Checkout: React.FC = () => {
   }, [cart]);
 
   useEffect(() => {
+    if (!user) return;
+    setLoadingUser(true);
+    fetch('/api/me')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!data) return;
+        if (data.name) setName(data.name);
+        if (data.address) setAddress(data.address);
+        if (data.country) setCountry(data.country);
+        if (data.email) setEmail(data.email);
+      })
+      .catch(() => {})
+      .finally(() => setLoadingUser(false));
+  }, [user]);
+
+  useEffect(() => {
     if (!country) return;
     fetch(`/api/delivery-estimate?country=${country}`)
       .then((res) => (res.ok ? res.json() : Promise.reject()))
@@ -84,6 +107,7 @@ const Checkout: React.FC = () => {
   }, [country]);
 
   if (cart.length === 0) return <div className="p-4">Your cart is empty.</div>;
+  if (loadingUser) return <Loader className="py-8" />;
 
   const submit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- add `/api/me` endpoint to return logged-in user info
- auto-populate checkout details from `/api/me`
- show a loader while user info loads

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing Jest/Node type definitions)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654f2dc38c832f9497b7e2d3a27ffd