### PR TITLE
Fix checkout payment and address autocomplete

### DIFF
--- a/pages/api/address-autocomplete.ts
+++ b/pages/api/address-autocomplete.ts
@@ -6,7 +6,7 @@ export default async function handler(
   res: NextApiResponse
 ) {
   try {
-    const input = (req.query.input as string) || '';
+    const input = String(req.query.input || '').trim();
     if (!input) return res.status(400).json({ message: 'input required' });
     const key = process.env.GOOGLE_PLACES_API_KEY;
     if (!key) return res.status(500).json({ message: 'api key not set' });
@@ -14,9 +14,11 @@ export default async function handler(
       input
     )}&key=${key}`;
     const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`status ${resp.status}`);
     const data = await resp.json();
     return res.status(200).json(data);
   } catch (e) {
-    return handleApiError(res, e, 'autocomplete error');
+    console.error('Address autocomplete error:', e);
+    return res.status(200).json({ predictions: [] });
   }
 }

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -367,29 +367,30 @@ const Checkout: React.FC = () => {
         }}
         className="space-y-3"
       >
-        {availableMethods.length === 0 && (
-          <p>No payment methods available.</p>
-        )}
         <div>
           <label className="label" htmlFor="paymentMethod">Payment Method</label>
-          <select
-            id="paymentMethod"
-            className="select select-bordered w-full"
-            value={paymentMethod}
-            onChange={(e) => setPaymentMethod(e.target.value)}
-          >
-            {availableMethods.map((m) => (
-              <option key={m.type} value={m.type}>
-                {m.type === 'card' || m.type === 'stripe'
-                  ? 'Credit/Debit Card'
-                  : m.type === 'jazzcash'
-                  ? 'JazzCash'
-                  : m.type === 'bank_transfer'
-                  ? 'Bank Transfer'
-                  : m.type}
-              </option>
-            ))}
-          </select>
+          {availableMethods.length > 0 ? (
+            <select
+              id="paymentMethod"
+              className="select select-bordered w-full"
+              value={paymentMethod}
+              onChange={(e) => setPaymentMethod(e.target.value)}
+            >
+              {availableMethods.map((m) => (
+                <option key={m.type} value={m.type}>
+                  {m.type === 'card' || m.type === 'stripe'
+                    ? 'Credit/Debit Card'
+                    : m.type === 'jazzcash'
+                    ? 'JazzCash'
+                    : m.type === 'bank_transfer'
+                    ? 'Bank Transfer'
+                    : m.type}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <p className="text-sm">No payment methods available.</p>
+          )}
         </div>
         {paymentMethod !== 'stripe' && paymentMethod !== 'card' && (
           <div className="border p-3 rounded space-y-2">


### PR DESCRIPTION
## Summary
- handle errors from `/api/address-autocomplete` more gracefully
- show a fallback message when no payment methods are found during checkout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686551a39a70832f96ad03c2636d5f95