### PR TITLE
Centralize API response messages

### DIFF
--- a/constants/messages.ts
+++ b/constants/messages.ts
@@ -1,0 +1,23 @@
+export const METHOD_NOT_ALLOWED = 'Method Not Allowed';
+export const UNAUTHORIZED = 'Unauthorized';
+export const NOT_FOUND = 'Not found';
+export const UUID_REQUIRED = 'uuid required';
+export const USER_NOT_FOUND = 'User not found';
+export const NAME_REQUIRED = 'name required';
+export const MISSING_REQUIRED_FIELDS = 'missing required fields';
+export const EMAIL_REQUIRED = 'email required';
+export const UPDATED = 'updated';
+export const ID_REQUIRED = 'id required';
+export const USER_EXISTS = 'User exists';
+export const VENDOR_REQUIRED = 'vendor required';
+export const SAVED = 'saved';
+export const ITEMS_REQUIRED = 'items required';
+export const CATEGORY_EXISTS = 'category exists';
+export const CANNOT_DELETE_PRODUCT_WITH_ORDERS =
+  'cannot delete product with orders';
+export const CANCELLED = 'cancelled';
+export const PRODUCT_NOT_FOUND = 'Product not found';
+export const PERCENTAGE_DISCOUNT_BETWEEN_1_AND_99 =
+  'Percentage discount must be between 1 and 99';
+export const INVALID_FORM_DATA = 'Invalid form data';
+export const CANNOT_CANCEL_THIS_ORDER = 'Cannot cancel this order';

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
     '^@pages/(.*)$': '<rootDir>/pages/$1',
     '^@styles/(.*)$': '<rootDir>/styles/$1',
     '^@contexts/(.*)$': '<rootDir>/contexts/$1',
+    '^@/constants/(.*)$': '<rootDir>/constants/$1',
     '^@/types/(.*)$': '<rootDir>/types/$1',
     '^@test-utils/(.*)$': '<rootDir>/test-utils/$1',
   },

--- a/pages/api/admin/analytics.ts
+++ b/pages/api/admin/analytics.ts
@@ -4,13 +4,14 @@ import { handleApiError } from '@utils/handleApiError';
 import { AnalyticsData, ApiMessage } from '../../../types';
 import { getDb } from '@lib/db';
 import { getQueryParam } from '@utils/getQueryParam';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<AnalyticsData | ApiMessage>
 ): Promise<void> {
   if (req.method !== 'GET') {
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
     return;
   }
   try {
@@ -27,7 +28,8 @@ async function handler(
     }
     if (brandIdParam) {
       const id = parseInt(brandIdParam, 10);
-      if (!isNaN(id)) where.product = { ...(where.product || {}), vendorId: id };
+      if (!isNaN(id))
+        where.product = { ...(where.product || {}), vendorId: id };
     }
     if (categoryParam) {
       const cid = parseInt(categoryParam, 10);
@@ -36,7 +38,10 @@ async function handler(
     }
 
     const totalOrders = await db.order.count({ where });
-    const revenueAgg = await db.order.aggregate({ where, _sum: { total: true } });
+    const revenueAgg = await db.order.aggregate({
+      where,
+      _sum: { total: true },
+    });
     const grouped = await db.order.groupBy({
       by: ['productId'],
       where,

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -10,6 +10,12 @@ import { logAudit } from '@lib/audit';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import { Category, CategoryInput, ApiMessage } from '../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UUID_REQUIRED,
+  NAME_REQUIRED,
+  CATEGORY_EXISTS,
+} from '@/constants/messages';
 
 async function handler(
   req: NextApiRequest,
@@ -23,14 +29,14 @@ async function handler(
     }
     if (req.method === 'POST') {
       const { name, slug } = req.body as CategoryInput;
-      if (!name) return res.status(400).json({ message: 'name required' });
+      if (!name) return res.status(400).json({ message: NAME_REQUIRED });
       const exists = (await getCategoriesFlat()).find(
         (c: Category) =>
           c.name.toLowerCase() === name.toLowerCase() ||
           (slug && c.slug?.toLowerCase() === slug.toLowerCase())
       );
       if (exists) {
-        return res.status(409).json({ message: 'category exists' });
+        return res.status(409).json({ message: CATEGORY_EXISTS });
       }
       await createCategory(name, slug);
       logAudit('create_category', { name, slug });
@@ -48,7 +54,7 @@ async function handler(
     }
     if (req.method === 'DELETE') {
       const uuid = getQueryParam(req.query.uuid);
-      if (!uuid) return res.status(400).json({ message: 'uuid required' });
+      if (!uuid) return res.status(400).json({ message: UUID_REQUIRED });
       try {
         await removeCategory(String(uuid));
         logAudit('delete_category', { uuid });
@@ -63,7 +69,7 @@ async function handler(
         throw e;
       }
     }
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
     return;
   } catch (error) {
     handleApiError(res, error, 'Failed to manage categories');

--- a/pages/api/admin/coupons.ts
+++ b/pages/api/admin/coupons.ts
@@ -3,6 +3,7 @@ import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { createCoupon, listCoupons, updateCoupon } from '@lib/coupons';
 import type { Coupon, ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, ID_REQUIRED } from '@/constants/messages';
 
 async function handler(
   req: NextApiRequest,
@@ -16,8 +17,14 @@ async function handler(
     }
 
     if (req.method === 'POST') {
-      const { code, discountType, amount, minOrderValue, expirationDate, usageLimit } =
-        req.body as Partial<Coupon>;
+      const {
+        code,
+        discountType,
+        amount,
+        minOrderValue,
+        expirationDate,
+        usageLimit,
+      } = req.body as Partial<Coupon>;
       if (!code || !discountType || amount === undefined) {
         res
           .status(400)
@@ -39,7 +46,7 @@ async function handler(
     if (req.method === 'PUT') {
       const { id, ...rest } = req.body as Coupon;
       if (!id) {
-        res.status(400).json({ message: 'id required' });
+        res.status(400).json({ message: ID_REQUIRED });
         return;
       }
       await updateCoupon(Number(id), {
@@ -54,7 +61,7 @@ async function handler(
       return;
     }
 
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     handleApiError(res, error, 'Failed to manage coupons');
   }

--- a/pages/api/admin/low-stock.ts
+++ b/pages/api/admin/low-stock.ts
@@ -4,13 +4,14 @@ import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage, LowStockProduct } from '../../../types';
 import { DEFAULT_LOW_STOCK_THRESHOLD } from '@lib/config';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<{ products: LowStockProduct[] } | ApiMessage>
 ): Promise<void> {
   if (req.method !== 'GET') {
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
     return;
   }
   try {
@@ -18,7 +19,12 @@ async function handler(
     const param = parseInt(String(req.query.threshold || ''), 10);
     const threshold = Number.isNaN(param) ? DEFAULT_LOW_STOCK_THRESHOLD : param;
     const rows = await db.product.findMany({
-      select: { id: true, title: true, quantity: true, lowStockThreshold: true },
+      select: {
+        id: true,
+        title: true,
+        quantity: true,
+        lowStockThreshold: true,
+      },
     });
     const products = rows
       .filter((p) => p.quantity < (p.lowStockThreshold ?? threshold))

--- a/pages/api/admin/orders.ts
+++ b/pages/api/admin/orders.ts
@@ -4,6 +4,7 @@ import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, UPDATED } from '@/constants/messages';
 
 async function handler(
   req: NextApiRequest,
@@ -13,7 +14,10 @@ async function handler(
     if (req.method === 'GET') {
       const status = getQueryParam(req.query.status);
       const search = getQueryParam(req.query.search);
-      const orders = await getAllOrdersFiltered({ status: status || undefined, search: search || undefined });
+      const orders = await getAllOrdersFiltered({
+        status: status || undefined,
+        search: search || undefined,
+      });
       return res.status(200).json(orders);
     }
     if (req.method === 'PATCH') {
@@ -23,9 +27,9 @@ async function handler(
         return res.status(400).json({ message: 'uuid and status required' });
       }
       await updateOrderStatus(uuid, status);
-      return res.status(200).json({ message: 'updated' });
+      return res.status(200).json({ message: UPDATED });
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (e) {
     return handleApiError(res, e, 'Failed to manage orders');
   }

--- a/pages/api/admin/policies.ts
+++ b/pages/api/admin/policies.ts
@@ -2,12 +2,15 @@ import type { NextApiResponse } from 'next';
 import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { getDb } from '@lib/db';
 import { handleApiError } from '@utils/handleApiError';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 async function handler(req: AuthedNextApiRequest, res: NextApiResponse) {
   try {
     const db = getDb();
     if (req.method === 'GET') {
-      const type = Array.isArray(req.query.type) ? req.query.type[0] : req.query.type;
+      const type = Array.isArray(req.query.type)
+        ? req.query.type[0]
+        : req.query.type;
       if (type) {
         const doc = await db.policyDocument.findFirst({
           where: { type: String(type) },
@@ -48,7 +51,7 @@ async function handler(req: AuthedNextApiRequest, res: NextApiResponse) {
       res.status(201).json(doc);
       return;
     }
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     handleApiError(res, error, 'Failed to manage policies');
   }

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -10,6 +10,12 @@ import { getQueryParam } from '@utils/getQueryParam';
 import { slugify } from '@lib/slugify';
 import { Product, ApiMessage, Variant } from '../../../types';
 import { mapDbRowToProduct } from '@lib/products';
+import {
+  METHOD_NOT_ALLOWED,
+  NOT_FOUND,
+  UUID_REQUIRED,
+  CANNOT_DELETE_PRODUCT_WITH_ORDERS,
+} from '@/constants/messages';
 
 export const config = {
   api: {
@@ -105,7 +111,7 @@ async function handler(
       if (req.method === 'PUT') {
         existing = await db.product.findUnique({ where: { id: Number(id) } });
         if (!existing) {
-          res.status(404).json({ message: 'Not found' });
+          res.status(404).json({ message: NOT_FOUND });
           return;
         }
         const existingImages = existing.images
@@ -188,18 +194,16 @@ async function handler(
     if (req.method === 'DELETE') {
       const uuid = getQueryParam(req.query.uuid);
       if (!uuid) {
-        res.status(400).json({ message: 'uuid required' });
+        res.status(400).json({ message: UUID_REQUIRED });
         return;
       }
       const existing = await db.product.findUnique({ where: { uuid } });
       if (!existing) {
-        res.status(404).json({ message: 'Not found' });
+        res.status(404).json({ message: NOT_FOUND });
         return;
       }
       if (await hasOrdersForProduct(String(uuid))) {
-        res
-          .status(409)
-          .json({ message: 'cannot delete product with orders' });
+        res.status(409).json({ message: CANNOT_DELETE_PRODUCT_WITH_ORDERS });
         return;
       }
       await db.product.delete({ where: { uuid } });
@@ -220,7 +224,7 @@ async function handler(
       return;
     }
 
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
     return;
   } catch (error) {
     handleApiError(res, error, 'Failed to process product');

--- a/pages/api/admin/search-analytics.ts
+++ b/pages/api/admin/search-analytics.ts
@@ -3,6 +3,7 @@ import { SearchAnalyticsResponse, ApiMessage } from '../../../types';
 import { getDb } from '@lib/db';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 interface SearchLog {
   query: string;
@@ -15,7 +16,7 @@ async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'GET') {
-      res.status(405).json({ message: 'Method Not Allowed' });
+      res.status(405).json({ message: METHOD_NOT_ALLOWED });
       return;
     }
 

--- a/pages/api/admin/support.ts
+++ b/pages/api/admin/support.ts
@@ -2,14 +2,17 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { withRole } from '@lib/withRole';
 import { getDb } from '@lib/db';
 import { handleApiError } from '@utils/handleApiError';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     if (req.method !== 'GET') {
-      res.status(405).json({ message: 'Method Not Allowed' });
+      res.status(405).json({ message: METHOD_NOT_ALLOWED });
       return;
     }
-    const status = Array.isArray(req.query.status) ? req.query.status[0] : req.query.status;
+    const status = Array.isArray(req.query.status)
+      ? req.query.status[0]
+      : req.query.status;
     const db = getDb();
     const tickets = await db.supportTicket.findMany({
       where: status ? { status: String(status) } : undefined,

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -17,6 +17,11 @@ import {
   CreateUserRequest,
   ApiMessage,
 } from '../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  MISSING_REQUIRED_FIELDS,
+  EMAIL_REQUIRED,
+} from '@/constants/messages';
 
 async function handler(
   req: NextApiRequest,
@@ -46,7 +51,7 @@ async function handler(
     }
     if (req.method === 'DELETE') {
       const email = getQueryParam(req.query.email);
-      if (!email) return res.status(400).json({ message: 'email required' });
+      if (!email) return res.status(400).json({ message: EMAIL_REQUIRED });
       await deleteUser(email);
       res.status(200).json({ message: 'user deleted' });
       return;
@@ -55,7 +60,7 @@ async function handler(
       const { email, password, firstName, lastName, brandName, gender, role } =
         req.body as CreateUserRequest;
       if (!email || !password || !firstName || !lastName || !gender) {
-        return res.status(400).json({ message: 'missing required fields' });
+        return res.status(400).json({ message: MISSING_REQUIRED_FIELDS });
       }
       await addUser({
         email,
@@ -69,7 +74,7 @@ async function handler(
       res.status(201).json({ message: 'user created' });
       return;
     }
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
     return;
   } catch (error) {
     handleApiError(res, error, 'Failed to manage users');

--- a/pages/api/admin/vendor-products.ts
+++ b/pages/api/admin/vendor-products.ts
@@ -7,6 +7,7 @@ import {
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { PendingProduct, ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 async function handler(
   req: NextApiRequest,
@@ -38,7 +39,7 @@ async function handler(
       res.status(400).json({ message: 'invalid action' });
       return;
     }
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
     return;
   } catch (error) {
     handleApiError(res, error, 'Failed to process vendor products');

--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -4,6 +4,7 @@ import { handleApiError } from '@utils/handleApiError';
 import type { AnalyticsData, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -11,7 +12,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const session = await getServerSession(req, res, authOptions);
     const brandId =
@@ -19,7 +20,7 @@ export default async function handler(
         ? session.user.brandId
         : undefined;
     if (!session?.user || session.user.role !== 'BRAND' || !brandId) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const orders = await getOrdersForVendorId(brandId);
     const summary: AnalyticsData = {

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -4,6 +4,11 @@ import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage, Category } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  NAME_REQUIRED,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -11,14 +16,14 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'POST') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user || session.user.role !== 'BRAND') {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const { name, slug } = req.body || {};
-    if (!name) return res.status(400).json({ message: 'name required' });
+    if (!name) return res.status(400).json({ message: NAME_REQUIRED });
     const exists = (await getCategoriesFlat()).find(
       (c) =>
         c.name.toLowerCase() === name.toLowerCase() ||

--- a/pages/api/brand/earnings.ts
+++ b/pages/api/brand/earnings.ts
@@ -4,6 +4,7 @@ import { handleApiError } from '@utils/handleApiError';
 import type { EarningsData, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -11,7 +12,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const session = await getServerSession(req, res, authOptions);
     const brandId =
@@ -19,7 +20,7 @@ export default async function handler(
         ? session.user.brandId
         : undefined;
     if (!session?.user || session.user.role !== 'BRAND' || !brandId) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const orders = await getOrdersForVendorId(brandId);
     const totalEarned = orders.reduce((s, o) => s + (o.total || 0), 0);

--- a/pages/api/brand/low-stock.ts
+++ b/pages/api/brand/low-stock.ts
@@ -3,6 +3,7 @@ import { loadAndIndexProducts } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { Product, ApiMessage } from '../../../types';
+import { VENDOR_REQUIRED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -10,7 +11,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     const vendor = getQueryParam(req.query.vendor);
-    if (!vendor) return res.status(400).json({ message: 'vendor required' });
+    if (!vendor) return res.status(400).json({ message: VENDOR_REQUIRED });
     const { products } = await loadAndIndexProducts();
     const low = products.filter(
       (p) => p.vendor.brandName === vendor && (p.totalInventory ?? 0) <= 5

--- a/pages/api/brand/notifications.ts
+++ b/pages/api/brand/notifications.ts
@@ -1,10 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
-import { getNotificationsForUser, markNotificationsRead } from '@lib/notifications';
+import {
+  getNotificationsForUser,
+  markNotificationsRead,
+} from '@lib/notifications';
 import { findUser } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
 import type { Notification, ApiMessage } from '../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  USER_NOT_FOUND,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,9 +20,9 @@ export default async function handler(
 ): Promise<void> {
   try {
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
+    if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
     const user = await findUser(session.user.email);
-    if (!user) return res.status(404).json({ message: 'User not found' });
+    if (!user) return res.status(404).json({ message: USER_NOT_FOUND });
 
     if (req.method === 'GET') {
       const notes = await getNotificationsForUser(user.id);
@@ -27,7 +35,7 @@ export default async function handler(
       return res.status(200).json(notes);
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to manage notifications');
   }

--- a/pages/api/brand/orders.ts
+++ b/pages/api/brand/orders.ts
@@ -4,6 +4,7 @@ import { handleApiError } from '@utils/handleApiError';
 import type { Order, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -11,7 +12,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const session = await getServerSession(req, res, authOptions);
     const brandId =
@@ -19,9 +20,7 @@ export default async function handler(
         ? session.user.brandId
         : undefined;
     if (!brandId) {
-      return res
-        .status(401)
-        .json({ message: 'Unable to determine brand ID' });
+      return res.status(401).json({ message: 'Unable to determine brand ID' });
     }
     const orders = await getOrdersForVendorId(brandId);
     return res.status(200).json(orders);

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -12,6 +12,13 @@ import type { ApiMessage, ProductInput } from '../../../../types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import { uploadFileToS3 } from '@lib/s3';
 import path from 'path';
+import {
+  METHOD_NOT_ALLOWED,
+  NOT_FOUND,
+  UUID_REQUIRED,
+  CANNOT_DELETE_PRODUCT_WITH_ORDERS,
+  PERCENTAGE_DISCOUNT_BETWEEN_1_AND_99,
+} from '@/constants/messages';
 
 export const config = {
   api: {
@@ -44,11 +51,11 @@ export default async function handler(
 ): Promise<void> {
   try {
     const uuid = getQueryParam(req.query.uuid);
-    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    if (!uuid) return res.status(400).json({ message: UUID_REQUIRED });
 
     if (req.method === 'PUT') {
       const existing = await getProductByUuid(String(uuid));
-      if (!existing) return res.status(404).json({ message: 'Not found' });
+      if (!existing) return res.status(404).json({ message: NOT_FOUND });
       const { fields, files } = await parseBody(req);
       const {
         title,
@@ -82,7 +89,7 @@ export default async function handler(
         ) {
           return res
             .status(400)
-            .json({ message: 'Percentage discount must be between 1 and 99' });
+            .json({ message: PERCENTAGE_DISCOUNT_BETWEEN_1_AND_99 });
         }
       }
       if (parsedDiscountType === 'fixed') {
@@ -154,18 +161,18 @@ export default async function handler(
 
     if (req.method === 'DELETE') {
       const existing = await getProductByUuid(String(uuid));
-      if (!existing) return res.status(404).json({ message: 'Not found' });
+      if (!existing) return res.status(404).json({ message: NOT_FOUND });
       if (await hasOrdersForProduct(String(uuid))) {
         return res
           .status(409)
-          .json({ message: 'cannot delete product with orders' });
+          .json({ message: CANNOT_DELETE_PRODUCT_WITH_ORDERS });
       }
       await deleteProduct(String(uuid));
       await loadAndIndexProducts();
       return res.status(200).json({ message: 'product deleted' });
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to process product');
   }

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -14,6 +14,11 @@ import { withRole, type AuthedNextApiRequest } from '@lib/withRole';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { getDb } from '@lib/db';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  PERCENTAGE_DISCOUNT_BETWEEN_1_AND_99,
+} from '@/constants/messages';
 
 export const config = {
   api: {
@@ -48,7 +53,7 @@ async function handler(
     if (req.method === 'GET') {
       const session = await getServerSession(req, res, authOptions);
       if (!session?.user || session.user.role !== 'BRAND') {
-        return res.status(401).json({ message: 'Unauthorized' });
+        return res.status(401).json({ message: UNAUTHORIZED });
       }
 
       const db = getDb();
@@ -166,7 +171,7 @@ async function handler(
         ) {
           return res
             .status(400)
-            .json({ message: 'Percentage discount must be between 1 and 99' });
+            .json({ message: PERCENTAGE_DISCOUNT_BETWEEN_1_AND_99 });
         }
       }
       if (parsedDiscountType === 'fixed') {
@@ -213,7 +218,7 @@ async function handler(
       return res.status(201).json({ message: 'product created' });
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to manage products');
   }

--- a/pages/api/brand/profile.ts
+++ b/pages/api/brand/profile.ts
@@ -4,6 +4,12 @@ import type { Vendor, ApiMessage } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  NOT_FOUND,
+  UPDATED,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,12 +18,12 @@ export default async function handler(
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     if (req.method === 'GET') {
       const userData = await findUser(session.user.email);
       if (!userData) {
-        return res.status(404).json({ message: 'Not found' });
+        return res.status(404).json({ message: NOT_FOUND });
       }
       const vendor: Vendor = {
         id: Number(userData.id),
@@ -62,9 +68,9 @@ export default async function handler(
         taxId,
         paymentMethods,
       });
-      return res.status(200).json({ message: 'updated' });
+      return res.status(200).json({ message: UPDATED });
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to manage profile');
   }

--- a/pages/api/brand/stripe-account.ts
+++ b/pages/api/brand/stripe-account.ts
@@ -3,24 +3,29 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { stripe } from '@lib/stripe';
 import { findUser, updateUserProfile } from '@lib/users';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  USER_NOT_FOUND,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<{ url: string } | { message: string }>
 ): Promise<void> {
   if (req.method !== 'POST') {
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
     return;
   }
   const session = await getServerSession(req, res, authOptions);
   const email = session?.user?.email;
   if (!email) {
-    res.status(401).json({ message: 'Unauthorized' });
+    res.status(401).json({ message: UNAUTHORIZED });
     return;
   }
   const user = await findUser(email);
   if (!user) {
-    res.status(404).json({ message: 'User not found' });
+    res.status(404).json({ message: USER_NOT_FOUND });
     return;
   }
   let accountId = user.stripeAccountId || '';

--- a/pages/api/cart.ts
+++ b/pages/api/cart.ts
@@ -4,6 +4,12 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
 import type { CartItem, ApiMessage } from '../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  SAVED,
+  ITEMS_REQUIRED,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,7 +18,7 @@ export default async function handler(
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const email = session.user.email;
     if (req.method === 'GET') {
@@ -22,12 +28,12 @@ export default async function handler(
     if (req.method === 'POST') {
       const { items } = (req.body as { items?: CartItem[] }) || {};
       if (!Array.isArray(items)) {
-        return res.status(400).json({ message: 'items required' });
+        return res.status(400).json({ message: ITEMS_REQUIRED });
       }
       setCart(email, items);
-      return res.status(200).json({ message: 'saved' });
+      return res.status(200).json({ message: SAVED });
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to manage cart');
   }

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -14,6 +14,12 @@ import type {
   ApiMessage,
   Category,
 } from '../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  NAME_REQUIRED,
+  CATEGORY_EXISTS,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -39,10 +45,10 @@ export default async function handler(
     if (req.method === 'POST') {
       const session = await getServerSession(req, res, authOptions);
       if (!session?.user) {
-        return res.status(401).json({ message: 'Unauthorized' });
+        return res.status(401).json({ message: UNAUTHORIZED });
       }
       const { name, slug } = req.body as Partial<Category>;
-      if (!name) return res.status(400).json({ message: 'name required' });
+      if (!name) return res.status(400).json({ message: NAME_REQUIRED });
       const exists = (await getCategoriesFlat()).find(
         (c) =>
           c.name.toLowerCase() === name.toLowerCase() ||
@@ -51,12 +57,12 @@ export default async function handler(
       if (exists) {
         return res
           .status(409)
-          .json({ message: 'category exists', category: exists });
+          .json({ message: CATEGORY_EXISTS, category: exists });
       }
       const category = await createCategory(name, slug);
       return res.status(201).json({ category });
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to load categories');
   }

--- a/pages/api/categories/check-or-create.ts
+++ b/pages/api/categories/check-or-create.ts
@@ -4,6 +4,11 @@ import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage, Category } from '../../../types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  NAME_REQUIRED,
+} from '@/constants/messages';
 
 interface CheckOrCreateResponse {
   exists?: boolean;
@@ -18,14 +23,14 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'POST') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user || session.user.role !== 'BRAND') {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const { name, slug } = req.body || {};
-    if (!name) return res.status(400).json({ message: 'name required' });
+    if (!name) return res.status(400).json({ message: NAME_REQUIRED });
     const exists = (await getCategoriesFlat()).find(
       (c) =>
         c.name.toLowerCase() === name.toLowerCase() ||

--- a/pages/api/categories/check.ts
+++ b/pages/api/categories/check.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoriesFlat } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage, Category } from '../../../types';
+import { METHOD_NOT_ALLOWED, NAME_REQUIRED } from '@/constants/messages';
 
 interface CheckResponse {
   exists: boolean;
@@ -14,10 +15,10 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const name = String(req.query.name || '').trim();
-    if (!name) return res.status(400).json({ message: 'name required' });
+    if (!name) return res.status(400).json({ message: NAME_REQUIRED });
     const categories = await getCategoriesFlat();
     const match = categories.find(
       (c) => c.name.toLowerCase() === name.toLowerCase()

--- a/pages/api/category-tree.ts
+++ b/pages/api/category-tree.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoryTree } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import type { CategoriesResponse, ApiMessage } from '../../types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,7 +13,7 @@ export default async function handler(
       const categories = await getCategoryTree();
       return res.status(200).json({ categories });
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to load categories');
   }

--- a/pages/api/change-email.ts
+++ b/pages/api/change-email.ts
@@ -4,15 +4,16 @@ import { handleApiError } from '@utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import type { ApiMessage } from '../../types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ApiMessage>
 ): Promise<void> {
   if (req.method !== 'POST')
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   const session = await getServerSession(req, res, authOptions);
-  if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
+  if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
   const { email, oldToken, newToken } = req.body as {
     email?: string;
     oldToken?: string;

--- a/pages/api/change-password.ts
+++ b/pages/api/change-password.ts
@@ -5,6 +5,7 @@ import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { findUser, updateUserProfile } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage } from '../../types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,10 +13,9 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'POST')
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user)
-      return res.status(401).json({ message: 'Unauthorized' });
+    if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
 
     const { currentPassword, newPassword } = req.body as {
       currentPassword?: string;

--- a/pages/api/chat/upload.ts
+++ b/pages/api/chat/upload.ts
@@ -4,6 +4,11 @@ import { authOptions } from '@pages/api/auth/[...nextauth]';
 import formidable, { File } from 'formidable';
 import { uploadFileToS3 } from '@/lib/s3';
 import type { ApiMessage } from '../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  INVALID_FORM_DATA,
+} from '@/constants/messages';
 
 export const config = {
   api: { bodyParser: false },
@@ -14,16 +19,16 @@ export default async function handler(
   res: NextApiResponse<{ url: string } | ApiMessage>
 ) {
   const session = await getServerSession(req, res, authOptions);
-  if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
+  if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
 
   if (req.method !== 'POST') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   }
 
   const form = formidable({ multiples: false, maxFileSize: 5 * 1024 * 1024 });
   form.parse(req, async (err, fields, files) => {
     if (err) {
-      res.status(400).json({ message: 'Invalid form data' });
+      res.status(400).json({ message: INVALID_FORM_DATA });
       return;
     }
     const file = files.file as File | undefined;

--- a/pages/api/check-email.ts
+++ b/pages/api/check-email.ts
@@ -3,6 +3,7 @@ import { findUser } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../types';
+import { EMAIL_REQUIRED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -11,7 +12,7 @@ export default async function handler(
   try {
     const email = getQueryParam(req.query.email);
     if (!email) {
-      return res.status(400).json({ message: 'email required' });
+      return res.status(400).json({ message: EMAIL_REQUIRED });
     }
     const user = await findUser(email);
     return res.status(200).json({ exists: !!user });

--- a/pages/api/checkout/complete.ts
+++ b/pages/api/checkout/complete.ts
@@ -4,6 +4,7 @@ import { addOrder } from '@lib/orders';
 import { sendOrderConfirmation } from '@lib/email';
 import { handleApiError } from '@utils/handleApiError';
 import type { OrderIdResponse, ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2022-11-15',
@@ -14,7 +15,7 @@ export default async function handler(
   res: NextApiResponse<OrderIdResponse | ApiMessage>
 ): Promise<void> {
   if (req.method !== 'POST') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   }
   const { sessionId } = req.body || {};
   if (!sessionId)

--- a/pages/api/checkout/create-session.ts
+++ b/pages/api/checkout/create-session.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
 import { handleApiError } from '@utils/handleApiError';
 import type { CheckoutSessionResponse, ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2022-11-15',
@@ -12,7 +13,7 @@ export default async function handler(
   res: NextApiResponse<CheckoutSessionResponse | ApiMessage>
 ): Promise<void> {
   if (req.method !== 'POST') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   }
   const { items, lineItems, orderId, email, shipping } = req.body || {};
   if ((!items && !lineItems) || !email || !orderId) {

--- a/pages/api/dashboard/best-sellers.ts
+++ b/pages/api/dashboard/best-sellers.ts
@@ -4,6 +4,7 @@ import { withRole, type AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(
   req: AuthedNextApiRequest,
@@ -13,16 +14,17 @@ async function handler(
 ) {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const db = getDb();
     const user = req.user;
     const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const queryBrandId = Number.isNaN(param) ? undefined : param;
     const vendorId =
-      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+      user?.brandId ??
+      (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
     if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const where: any = {};
     if (vendorId) where.product = { vendorId };

--- a/pages/api/dashboard/inventory-alerts.ts
+++ b/pages/api/dashboard/inventory-alerts.ts
@@ -4,6 +4,7 @@ import { withRole, type AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(
   req: AuthedNextApiRequest,
@@ -13,16 +14,17 @@ async function handler(
 ) {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const db = getDb();
     const user = req.user;
     const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const queryBrandId = Number.isNaN(param) ? undefined : param;
     const vendorId =
-      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+      user?.brandId ??
+      (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
     if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const threshold = parseInt(getQueryParam(req.query.threshold) || '10', 10);
     const where: any = { quantity: { lt: threshold } };

--- a/pages/api/dashboard/orders-this-month.ts
+++ b/pages/api/dashboard/orders-this-month.ts
@@ -5,6 +5,7 @@ import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(
   req: AuthedNextApiRequest,
@@ -12,15 +13,16 @@ async function handler(
 ) {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const user = req.user;
     const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const queryBrandId = Number.isNaN(param) ? undefined : param;
     const vendorId =
-      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+      user?.brandId ??
+      (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
     if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const monthOffset = parseInt(
       getQueryParam(req.query.monthOffset) || '0',

--- a/pages/api/dashboard/total-products.ts
+++ b/pages/api/dashboard/total-products.ts
@@ -4,6 +4,7 @@ import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(
   req: AuthedNextApiRequest,
@@ -11,16 +12,17 @@ async function handler(
 ) {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const db = getDb();
     const user = req.user;
     const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const queryBrandId = Number.isNaN(param) ? undefined : param;
     const vendorId =
-      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+      user?.brandId ??
+      (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
     if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const where = vendorId ? { vendorId } : {};
     const count = await db.product.count({ where });

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -4,6 +4,7 @@ import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(
   req: AuthedNextApiRequest,
@@ -11,15 +12,16 @@ async function handler(
 ) {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const user = req.user;
     const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const queryBrandId = Number.isNaN(param) ? undefined : param;
     const vendorId =
-      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+      user?.brandId ??
+      (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
     if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const monthOffset = getQueryParam(req.query.monthOffset);
     let start: Date | undefined;
@@ -30,10 +32,7 @@ async function handler(
       monthOffset !== ''
     ) {
       const m = parseInt(monthOffset, 10);
-      start = require('dayjs')()
-        .startOf('month')
-        .subtract(m, 'month')
-        .toDate();
+      start = require('dayjs')().startOf('month').subtract(m, 'month').toDate();
       end = require('dayjs')(start).endOf('month').toDate();
     }
     const { revenue } = await getSalesMetrics({ start, end, vendorId });

--- a/pages/api/dashboard/weekly-summary.ts
+++ b/pages/api/dashboard/weekly-summary.ts
@@ -5,6 +5,7 @@ import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(
   req: AuthedNextApiRequest,
@@ -12,15 +13,16 @@ async function handler(
 ) {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const user = req.user;
     const param = parseInt(getQueryParam(req.query.brandId) || '', 10);
     const queryBrandId = Number.isNaN(param) ? undefined : param;
     const vendorId =
-      user?.brandId ?? (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
+      user?.brandId ??
+      (user?.role === 'SUPER_ADMIN' ? queryBrandId : undefined);
     if (!user?.brandId && user?.role !== 'SUPER_ADMIN') {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const start = dayjs().subtract(7, 'day').startOf('day').toDate();
     const { count, revenue } = await getSalesMetrics({ start, vendorId });

--- a/pages/api/guest-orders.ts
+++ b/pages/api/guest-orders.ts
@@ -1,6 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { addGuestOrder, getGuestOrder } from '@lib/guestOrders';
 import { handleApiError } from '@utils/handleApiError';
+import {
+  METHOD_NOT_ALLOWED,
+  NOT_FOUND,
+  ID_REQUIRED,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,19 +17,25 @@ export default async function handler(
       if (!name || !email || !address || !Array.isArray(items)) {
         return res.status(400).json({ message: 'invalid payload' });
       }
-      const order = await addGuestOrder({ name, email, address, items, total: Number(total) || 0 });
+      const order = await addGuestOrder({
+        name,
+        email,
+        address,
+        items,
+        total: Number(total) || 0,
+      });
       return res.status(201).json(order);
     }
 
     if (req.method === 'GET') {
       const id = req.query.id as string;
-      if (!id) return res.status(400).json({ message: 'id required' });
+      if (!id) return res.status(400).json({ message: ID_REQUIRED });
       const order = getGuestOrder(id);
-      if (!order) return res.status(404).json({ message: 'Not found' });
+      if (!order) return res.status(404).json({ message: NOT_FOUND });
       return res.status(200).json(order);
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (e) {
     return handleApiError(res, e, 'guest order error');
   }

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -3,6 +3,7 @@ import { findUser } from '@lib/users';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '@utils/handleApiError';
 import type { LoginResponse } from '../../types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -10,7 +11,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'POST') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const { email, password } = req.body as {
       email?: string;

--- a/pages/api/me.ts
+++ b/pages/api/me.ts
@@ -3,22 +3,35 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from './auth/[...nextauth]';
 import { findUser } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  USER_NOT_FOUND,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ name: string; address: string | null; country: string | null; email?: string } | { message: string }>
+  res: NextApiResponse<
+    | {
+        name: string;
+        address: string | null;
+        country: string | null;
+        email?: string;
+      }
+    | { message: string }
+  >
 ): Promise<void> {
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const dbUser = await findUser(session.user.email);
     if (!dbUser) {
-      return res.status(404).json({ message: 'User not found' });
+      return res.status(404).json({ message: USER_NOT_FOUND });
     }
     const name = `${dbUser.firstName || ''} ${dbUser.lastName || ''}`.trim();
     return res.status(200).json({

--- a/pages/api/messages/[orderId].ts
+++ b/pages/api/messages/[orderId].ts
@@ -7,6 +7,11 @@ import { findUser } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { Message, ApiMessage } from '../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  USER_NOT_FOUND,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -14,8 +19,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user)
-      return res.status(401).json({ message: 'Unauthorized' });
+    if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
 
     const orderUuid = getQueryParam(req.query.orderId);
     if (!orderUuid)
@@ -24,7 +28,7 @@ export default async function handler(
     if (!order) return res.status(404).json({ message: 'Order not found' });
 
     const user = await findUser(session.user.email);
-    if (!user) return res.status(404).json({ message: 'User not found' });
+    if (!user) return res.status(404).json({ message: USER_NOT_FOUND });
 
     const isBuyer = order.userId === user.id;
     const isVendor = order.product.vendor.id === user.id;
@@ -60,7 +64,7 @@ export default async function handler(
       return res.status(201).json(msg);
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to manage messages');
   }

--- a/pages/api/orders.ts
+++ b/pages/api/orders.ts
@@ -6,11 +6,7 @@ import {
   getOrdersForVendor,
 } from '@lib/orders';
 import { findUser, findUserById } from '@lib/users';
-import {
-  getProductByUuid,
-  decreaseProductQuantity,
-  clearCart,
-} from '@lib/db';
+import { getProductByUuid, decreaseProductQuantity, clearCart } from '@lib/db';
 import { withRole } from '@lib/withRole';
 import { sendOrderConfirmation } from '@lib/email';
 import { handleApiError } from '@utils/handleApiError';
@@ -20,6 +16,11 @@ import type { Order, OrderPlacedResponse, ApiMessage } from '../../types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import fs from 'fs';
 import path from 'path';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  PRODUCT_NOT_FOUND,
+} from '@/constants/messages';
 
 export const config = {
   api: {
@@ -76,23 +77,30 @@ async function handler(
       let allowed = true;
       let vendorMethods: any[] = [];
       if (items.length > 0) {
-        const product = await getProductByUuid(String(items[0].uuid || items[0].id));
+        const product = await getProductByUuid(
+          String(items[0].uuid || items[0].id)
+        );
         if (product) {
           const vendor = await findUserById(product.vendorId);
           vendorMethods = (vendor?.paymentMethods as any[]) || [];
-          if (paymentMethod && !vendorMethods.some((m) => m.type === paymentMethod)) {
+          if (
+            paymentMethod &&
+            !vendorMethods.some((m) => m.type === paymentMethod)
+          ) {
             allowed = false;
           }
         }
       }
       if (!allowed) {
-        return res.status(400).json({ message: 'payment method not supported' });
+        return res
+          .status(400)
+          .json({ message: 'payment method not supported' });
       }
 
       for (const item of items) {
         const product = await getProductByUuid(String(item.uuid || item.id));
         if (!product) {
-          return res.status(404).json({ message: 'Product not found' });
+          return res.status(404).json({ message: PRODUCT_NOT_FOUND });
         }
         if ((product.quantity || 0) < item.qty) {
           return res
@@ -123,7 +131,7 @@ async function handler(
     if (req.method === 'GET') {
       const session = await getServerSession(req, res, authOptions);
       const email = session?.user?.email;
-      if (!email) return res.status(401).json({ message: 'Unauthorized' });
+      if (!email) return res.status(401).json({ message: UNAUTHORIZED });
       const user = await findUser(email);
       if (!user) return res.status(404).json({ message: 'user not found' });
       if (user.role === 'SUPER_ADMIN') {
@@ -135,7 +143,7 @@ async function handler(
       return res.status(200).json(await getOrdersForUser(email));
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to process orders');
   }

--- a/pages/api/orders/[uuid].ts
+++ b/pages/api/orders/[uuid].ts
@@ -5,6 +5,12 @@ import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  NOT_FOUND,
+  UUID_REQUIRED,
+  CANCELLED,
+} from '@/constants/messages';
 
 async function handler(
   req: NextApiRequest,
@@ -13,12 +19,12 @@ async function handler(
   try {
     const uuid = getQueryParam(req.query.uuid);
     if (!uuid) {
-      return res.status(400).json({ message: 'uuid required' });
+      return res.status(400).json({ message: UUID_REQUIRED });
     }
 
     if (req.method === 'GET') {
       const result = await getOrderByUuid(String(uuid));
-      if (!result) return res.status(404).json({ message: 'Not found' });
+      if (!result) return res.status(404).json({ message: NOT_FOUND });
       const { userEmail, ...order } = result;
       return res.status(200).json(order);
     }
@@ -32,7 +38,7 @@ async function handler(
         'shipped',
         'delivered',
         'completed',
-        'cancelled',
+        CANCELLED,
         'returned',
       ];
       if (!status || !allowed.includes(status)) {
@@ -40,7 +46,7 @@ async function handler(
       }
       await updateOrderStatus(String(uuid), status);
       const result = await getOrderByUuid(String(uuid));
-      if (!result) return res.status(404).json({ message: 'Not found' });
+      if (!result) return res.status(404).json({ message: NOT_FOUND });
       const { userEmail, ...order } = result;
       await sendOrderStatusUpdate(userEmail, {
         id: order.id,
@@ -49,7 +55,7 @@ async function handler(
       return res.status(200).json(order);
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to manage order');
   }

--- a/pages/api/orders/[uuid]/cancel.ts
+++ b/pages/api/orders/[uuid]/cancel.ts
@@ -6,29 +6,36 @@ import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import { logAudit } from '@lib/audit';
 import type { ApiMessage } from '../../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  NOT_FOUND,
+  UUID_REQUIRED,
+  CANCELLED,
+  CANNOT_CANCEL_THIS_ORDER,
+} from '@/constants/messages';
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ApiMessage>
 ): Promise<void> {
   if (req.method !== 'POST') {
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
     return;
   }
   try {
     const uuid = getQueryParam(req.query.uuid);
-    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    if (!uuid) return res.status(400).json({ message: UUID_REQUIRED });
     const order = await getOrderByUuid(uuid);
-    if (!order) return res.status(404).json({ message: 'Not found' });
+    if (!order) return res.status(404).json({ message: NOT_FOUND });
     if (['delivered', 'completed'].includes(order.status)) {
-      return res.status(400).json({ message: 'Cannot cancel this order' });
+      return res.status(400).json({ message: CANNOT_CANCEL_THIS_ORDER });
     }
     if (order.paymentMethod === 'card' && order.paymentReference) {
       await stripe.refunds.create({ payment_intent: order.paymentReference });
     }
-    await updateOrderStatus(uuid, 'cancelled');
+    await updateOrderStatus(uuid, CANCELLED);
     logAudit('cancel_order', { uuid, by: req.user?.email });
-    return res.status(200).json({ message: 'cancelled' });
+    return res.status(200).json({ message: CANCELLED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to cancel order');
   }

--- a/pages/api/orders/[uuid]/invoice.ts
+++ b/pages/api/orders/[uuid]/invoice.ts
@@ -4,16 +4,20 @@ import { generateInvoice } from '@lib/invoice';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import { withRole } from '@lib/withRole';
+import { NOT_FOUND, UUID_REQUIRED } from '@/constants/messages';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const uuid = getQueryParam(req.query.uuid);
-    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    if (!uuid) return res.status(400).json({ message: UUID_REQUIRED });
     const order = await getOrderByUuid(uuid);
-    if (!order) return res.status(404).json({ message: 'Not found' });
+    if (!order) return res.status(404).json({ message: NOT_FOUND });
     const pdf = generateInvoice(order);
     res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader('Content-Disposition', `attachment; filename="invoice-${uuid}.pdf"`);
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="invoice-${uuid}.pdf"`
+    );
     return res.status(200).end(pdf);
   } catch (e) {
     return handleApiError(res, e, 'Failed to generate invoice');

--- a/pages/api/payment-methods/[id].ts
+++ b/pages/api/payment-methods/[id].ts
@@ -8,6 +8,7 @@ import {
 } from '@lib/paymentMethods';
 import { findUser } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -15,14 +16,13 @@ export default async function handler(
 ) {
   try {
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user)
-      return res.status(401).json({ message: 'Unauthorized' });
+    if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
     let userId = session.user.brandId;
     if (typeof userId !== 'number') {
       const user = await findUser(session.user.email);
       userId = user?.id;
     }
-    if (!userId) return res.status(401).json({ message: 'Unauthorized' });
+    if (!userId) return res.status(401).json({ message: UNAUTHORIZED });
     const id = parseInt(String(req.query.id));
     if (isNaN(id)) return res.status(400).json({ message: 'invalid id' });
     if (req.method === 'DELETE') {
@@ -38,7 +38,7 @@ export default async function handler(
       const methods = await getPaymentMethodsForUser(userId);
       return res.status(200).json(methods);
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to manage payment methods');
   }

--- a/pages/api/payment-methods/index.ts
+++ b/pages/api/payment-methods/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@lib/paymentMethods';
 import { findUser } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -15,14 +16,13 @@ export default async function handler(
 ) {
   try {
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user)
-      return res.status(401).json({ message: 'Unauthorized' });
+    if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
     let userId = session.user.brandId;
     if (typeof userId !== 'number') {
       const user = await findUser(session.user.email);
       userId = user?.id;
     }
-    if (!userId) return res.status(401).json({ message: 'Unauthorized' });
+    if (!userId) return res.status(401).json({ message: UNAUTHORIZED });
     if (req.method === 'GET') {
       const methods = await getPaymentMethodsForUser(userId);
       return res.status(200).json(methods);
@@ -48,7 +48,7 @@ export default async function handler(
       });
       return res.status(200).json(method);
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to manage payment methods');
   }

--- a/pages/api/payments/charge.ts
+++ b/pages/api/payments/charge.ts
@@ -5,6 +5,7 @@ import { paymentProvider } from '@lib/paymentProvider';
 import { recordPayment } from '@lib/payments';
 import { getDb } from '@lib/db';
 import { handleApiError } from '@utils/handleApiError';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -13,9 +14,9 @@ export default async function handler(
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user?.id)
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     if (req.method !== 'POST')
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     const { orderId, paymentMethodId, amount } = req.body || {};
     if (!orderId || !paymentMethodId || !amount)
       return res.status(400).json({ message: 'missing fields' });

--- a/pages/api/policies.ts
+++ b/pages/api/policies.ts
@@ -1,14 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getDb } from '@lib/db';
 import { handleApiError } from '@utils/handleApiError';
+import { METHOD_NOT_ALLOWED, NOT_FOUND } from '@/constants/messages';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   try {
     if (req.method !== 'GET') {
-      res.status(405).json({ message: 'Method Not Allowed' });
+      res.status(405).json({ message: METHOD_NOT_ALLOWED });
       return;
     }
-    const type = Array.isArray(req.query.type) ? req.query.type[0] : req.query.type;
+    const type = Array.isArray(req.query.type)
+      ? req.query.type[0]
+      : req.query.type;
     if (!type) {
       res.status(400).json({ message: 'type required' });
       return;
@@ -19,7 +25,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       orderBy: { version: 'desc' },
     });
     if (!doc) {
-      res.status(404).json({ message: 'Not found' });
+      res.status(404).json({ message: NOT_FOUND });
       return;
     }
     res.status(200).json(doc);

--- a/pages/api/products/[uuid].ts
+++ b/pages/api/products/[uuid].ts
@@ -5,6 +5,7 @@ import { Product } from '@/types/product';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { ApiMessage } from '../../../types';
+import { NOT_FOUND, UUID_REQUIRED } from '@/constants/messages';
 
 export interface ProductParams {
   uuid?: string | string[];
@@ -21,12 +22,12 @@ export default async function handler(
 ): Promise<void> {
   const uuid = getQueryParam(req.query.uuid);
   if (!uuid) {
-    return res.status(400).json({ message: 'uuid required' });
+    return res.status(400).json({ message: UUID_REQUIRED });
   }
   try {
     const row = await getProductByUuid(String(uuid));
     if (!row) {
-      return res.status(404).json({ message: 'Not found' });
+      return res.status(404).json({ message: NOT_FOUND });
     }
     const product = mapDbRowToProduct(row) as Product;
     const stats = getAverageRating(String(uuid));

--- a/pages/api/products/[uuid]/reviews.ts
+++ b/pages/api/products/[uuid]/reviews.ts
@@ -1,10 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getSession } from 'next-auth/react';
-import {
-  addReview,
-  getReviewsForProduct,
-  getAverageRating,
-} from '@lib/db';
+import { addReview, getReviewsForProduct, getAverageRating } from '@lib/db';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type {
@@ -13,6 +9,7 @@ import type {
   ReviewAddedResponse,
 } from '@/types/review';
 import type { ApiMessage } from '../../../../types';
+import { METHOD_NOT_ALLOWED, UUID_REQUIRED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -21,7 +18,7 @@ export default async function handler(
   const { method } = req;
   const uuid = getQueryParam(req.query.uuid);
   try {
-    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    if (!uuid) return res.status(400).json({ message: UUID_REQUIRED });
 
     if (method === 'GET') {
       const reviews = getReviewsForProduct(String(uuid)) as Review[];
@@ -60,7 +57,7 @@ export default async function handler(
       });
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to handle review');
   }

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -4,6 +4,7 @@ import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { Product } from '@/types/product';
 import type { ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 export interface ProductsQuery {
   category?: string | string[];
@@ -28,7 +29,7 @@ export default async function handler(
   res: NextApiResponse<ProductsResponse | ApiMessage>
 ): Promise<void> {
   if (req.method !== 'GET') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   }
   const catParam =
     getQueryParam(req.query.category) || getQueryParam(req.query.categorySlug);

--- a/pages/api/request-email-change.ts
+++ b/pages/api/request-email-change.ts
@@ -5,6 +5,11 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
 import type { EmailChangeTokensResponse, ApiMessage } from '../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  EMAIL_REQUIRED,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,12 +17,11 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'POST')
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user)
-      return res.status(401).json({ message: 'Unauthorized' });
+    if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
     const { email } = req.body as { email?: string };
-    if (!email) return res.status(400).json({ message: 'email required' });
+    if (!email) return res.status(400).json({ message: EMAIL_REQUIRED });
     if (await findUser(email))
       return res.status(409).json({ message: 'Email exists' });
     const oldToken = crypto.randomBytes(6).toString('hex');

--- a/pages/api/request-reset.ts
+++ b/pages/api/request-reset.ts
@@ -3,6 +3,11 @@ import { findUser, setResetToken } from '@lib/users';
 import crypto from 'crypto';
 import { handleApiError } from '@utils/handleApiError';
 import type { ResetTokenResponse, ApiMessage } from '../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  USER_NOT_FOUND,
+  EMAIL_REQUIRED,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -10,11 +15,11 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'POST')
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     const { email } = req.body;
-    if (!email) return res.status(400).json({ message: 'email required' });
+    if (!email) return res.status(400).json({ message: EMAIL_REQUIRED });
     const user = await findUser(email);
-    if (!user) return res.status(404).json({ message: 'User not found' });
+    if (!user) return res.status(404).json({ message: USER_NOT_FOUND });
     const token = crypto.randomBytes(20).toString('hex');
     const expires = Date.now() + 3600 * 1000; // 1 hour
     await setResetToken(email, token, expires);

--- a/pages/api/reset-password.ts
+++ b/pages/api/reset-password.ts
@@ -2,13 +2,14 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { resetPassword } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage } from '../../types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ApiMessage>
 ): Promise<void> {
   if (req.method !== 'POST')
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   const { token, password } = req.body;
   if (!token || !password)
     return res.status(400).json({ message: 'token and password required' });

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -8,6 +8,7 @@ import { authOptions } from '@pages/api/auth/[...nextauth]';
 import client from '@lib/typesenseClient';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 interface SearchParams {
   q: string;
@@ -53,7 +54,7 @@ export default async function handler(
   res: NextApiResponse<SearchApiResponse | ApiMessage>
 ): Promise<void> {
   if (req.method !== 'GET') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   }
 
   const db = getDb();

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -4,22 +4,27 @@ import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '@utils/handleApiError';
 import type { SignupResponse, ApiMessage } from '../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  MISSING_REQUIRED_FIELDS,
+  USER_EXISTS,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<SignupResponse | ApiMessage>
 ): Promise<void> {
   if (req.method !== 'POST') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   }
   const { email, password, firstName, lastName, brandName, gender, role } =
     req.body;
   if (!email || !password || !firstName || !lastName || !gender) {
-    return res.status(400).json({ message: 'missing required fields' });
+    return res.status(400).json({ message: MISSING_REQUIRED_FIELDS });
   }
   try {
     if (await findUser(email)) {
-      return res.status(409).json({ message: 'User exists' });
+      return res.status(409).json({ message: USER_EXISTS });
     }
     const hashed = await bcrypt.hash(password, 10);
     const token = crypto.randomBytes(20).toString('hex');

--- a/pages/api/signup/brand.ts
+++ b/pages/api/signup/brand.ts
@@ -4,6 +4,11 @@ import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '@utils/handleApiError';
 import type { SignupTokenResponse, ApiMessage } from '../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  MISSING_REQUIRED_FIELDS,
+  USER_EXISTS,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -11,7 +16,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'POST') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
 
     const { email, password, firstName } = req.body as {
@@ -21,10 +26,10 @@ export default async function handler(
     };
 
     if (!email || !password || !firstName) {
-      return res.status(400).json({ message: 'missing required fields' });
+      return res.status(400).json({ message: MISSING_REQUIRED_FIELDS });
     }
     if (await findUser(email)) {
-      return res.status(409).json({ message: 'User exists' });
+      return res.status(409).json({ message: USER_EXISTS });
     }
     const hashed = await bcrypt.hash(password, 10);
     const token = crypto.randomBytes(20).toString('hex');

--- a/pages/api/signup/user.ts
+++ b/pages/api/signup/user.ts
@@ -4,6 +4,11 @@ import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '@utils/handleApiError';
 import type { SignupTokenResponse, ApiMessage } from '../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  MISSING_REQUIRED_FIELDS,
+  USER_EXISTS,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -11,7 +16,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'POST') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const { email, password, firstName } = req.body as {
       email?: string;
@@ -19,10 +24,10 @@ export default async function handler(
       firstName?: string;
     };
     if (!email || !password || !firstName) {
-      return res.status(400).json({ message: 'missing required fields' });
+      return res.status(400).json({ message: MISSING_REQUIRED_FIELDS });
     }
     if (await findUser(email)) {
-      return res.status(409).json({ message: 'User exists' });
+      return res.status(409).json({ message: USER_EXISTS });
     }
     const hashed = await bcrypt.hash(password, 10);
     const token = crypto.randomBytes(20).toString('hex');

--- a/pages/api/stripe/webhook.ts
+++ b/pages/api/stripe/webhook.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { stripe } from '@lib/stripe';
 import { strapiMarkOrderPaid } from '@lib/strapi';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 export const config = {
   api: {
@@ -13,7 +14,7 @@ export default async function handler(
   res: NextApiResponse
 ): Promise<void> {
   if (req.method !== 'POST') {
-    res.status(405).end('Method Not Allowed');
+    res.status(405).end(METHOD_NOT_ALLOWED);
     return;
   }
   const sig = req.headers['stripe-signature'] as string;

--- a/pages/api/suggest.ts
+++ b/pages/api/suggest.ts
@@ -3,13 +3,14 @@ import client from '@lib/typesenseClient';
 import { handleApiError } from '@utils/handleApiError';
 import { ObjectNotFound } from 'typesense/lib/Typesense/Errors';
 import type { SuggestionsResponse, ApiMessage } from '../../types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<SuggestionsResponse | ApiMessage>
 ): Promise<void> {
   if (req.method !== 'GET') {
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   }
 
   const { q = '' } = req.query as { q?: string };

--- a/pages/api/support.ts
+++ b/pages/api/support.ts
@@ -3,14 +3,21 @@ import { getDb } from '@lib/db';
 import { handleApiError } from '@utils/handleApiError';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   try {
     if (req.method !== 'POST') {
-      res.status(405).json({ message: 'Method Not Allowed' });
+      res.status(405).json({ message: METHOD_NOT_ALLOWED });
       return;
     }
-    const { subject, message } = req.body as { subject?: string; message?: string };
+    const { subject, message } = req.body as {
+      subject?: string;
+      message?: string;
+    };
     if (!subject || !message) {
       res.status(400).json({ message: 'subject and message required' });
       return;
@@ -22,7 +29,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         subject,
         message,
         userId: session?.user?.email
-          ? (await db.user.findUnique({ where: { email: session.user.email } }))?.id
+          ? (await db.user.findUnique({ where: { email: session.user.email } }))
+              ?.id
           : null,
       },
     });

--- a/pages/api/tags.ts
+++ b/pages/api/tags.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getDistinctTags } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage } from '../../types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -9,7 +10,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const search = typeof req.query.search === 'string' ? req.query.search : '';
     const tags = await getDistinctTags(search);

--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import formidable, { File } from 'formidable';
 import { uploadFileToS3 } from '@/lib/s3';
 import path from 'path';
+import { METHOD_NOT_ALLOWED, INVALID_FORM_DATA } from '@/constants/messages';
 
 export const config = {
   api: { bodyParser: false },
@@ -12,14 +13,14 @@ export default async function handler(
   res: NextApiResponse<{ urls: string[] } | { message: string }>
 ) {
   if (req.method !== 'POST') {
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
     return;
   }
 
   const form = formidable({ multiples: true });
   form.parse(req, async (err, fields, files) => {
     if (err) {
-      res.status(400).json({ message: 'Invalid form data' });
+      res.status(400).json({ message: INVALID_FORM_DATA });
       return;
     }
     const folder = String(fields.folder || 'uploads');

--- a/pages/api/user/orders.ts
+++ b/pages/api/user/orders.ts
@@ -4,6 +4,7 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
 import type { Order, ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,10 +13,10 @@ export default async function handler(
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const orders = await getOrdersForUser(session.user.email);
     return res.status(200).json(orders);

--- a/pages/api/user/orders/[uuid].ts
+++ b/pages/api/user/orders/[uuid].ts
@@ -4,6 +4,7 @@ import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { getOrderByUuid } from '@lib/orders';
 import { handleApiError } from '@utils/handleApiError';
 import type { Order, ApiMessage } from '../../../../types';
+import { UNAUTHORIZED, NOT_FOUND, UUID_REQUIRED } from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,13 +13,15 @@ export default async function handler(
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
-    const uuid = Array.isArray(req.query.uuid) ? req.query.uuid[0] : req.query.uuid;
-    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    const uuid = Array.isArray(req.query.uuid)
+      ? req.query.uuid[0]
+      : req.query.uuid;
+    if (!uuid) return res.status(400).json({ message: UUID_REQUIRED });
     const order = await getOrderByUuid(String(uuid));
     if (!order || order.userEmail !== session.user.email) {
-      return res.status(404).json({ message: 'Not found' });
+      return res.status(404).json({ message: NOT_FOUND });
     }
     return res.status(200).json(order);
   } catch (error) {

--- a/pages/api/user/orders/[uuid]/cancel.ts
+++ b/pages/api/user/orders/[uuid]/cancel.ts
@@ -7,35 +7,43 @@ import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import { logAudit } from '@lib/audit';
 import type { ApiMessage } from '../../../../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  NOT_FOUND,
+  UUID_REQUIRED,
+  CANCELLED,
+  CANNOT_CANCEL_THIS_ORDER,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ApiMessage>
 ): Promise<void> {
   if (req.method !== 'POST') {
-    res.status(405).json({ message: 'Method Not Allowed' });
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
     return;
   }
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const uuid = getQueryParam(req.query.uuid);
-    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    if (!uuid) return res.status(400).json({ message: UUID_REQUIRED });
     const order = await getOrderByUuid(uuid);
     if (!order || order.userEmail !== session.user.email) {
-      return res.status(404).json({ message: 'Not found' });
+      return res.status(404).json({ message: NOT_FOUND });
     }
     if (['shipped', 'delivered', 'completed'].includes(order.status)) {
-      return res.status(400).json({ message: 'Cannot cancel this order' });
+      return res.status(400).json({ message: CANNOT_CANCEL_THIS_ORDER });
     }
     if (order.paymentMethod === 'card' && order.paymentReference) {
       await stripe.refunds.create({ payment_intent: order.paymentReference });
     }
-    await updateOrderStatus(uuid, 'cancelled');
+    await updateOrderStatus(uuid, CANCELLED);
     logAudit('cancel_order', { uuid, by: session.user.email });
-    return res.status(200).json({ message: 'cancelled' });
+    return res.status(200).json({ message: CANCELLED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to cancel order');
   }

--- a/pages/api/user/orders/[uuid]/reorder.ts
+++ b/pages/api/user/orders/[uuid]/reorder.ts
@@ -5,6 +5,13 @@ import { getOrderByUuid } from '@lib/orders';
 import { getProductByUuid, getCart, setCart } from '@lib/db';
 import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage } from '../../../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  NOT_FOUND,
+  UUID_REQUIRED,
+  PRODUCT_NOT_FOUND,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,28 +19,31 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'POST') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user) return res.status(401).json({ message: 'Unauthorized' });
+    if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
 
-    const uuid = Array.isArray(req.query.uuid) ? req.query.uuid[0] : req.query.uuid;
-    if (!uuid) return res.status(400).json({ message: 'uuid required' });
+    const uuid = Array.isArray(req.query.uuid)
+      ? req.query.uuid[0]
+      : req.query.uuid;
+    if (!uuid) return res.status(400).json({ message: UUID_REQUIRED });
 
     const order = await getOrderByUuid(String(uuid));
     if (!order || order.userEmail !== session.user.email) {
-      return res.status(404).json({ message: 'Not found' });
+      return res.status(404).json({ message: NOT_FOUND });
     }
 
     const product = await getProductByUuid(order.product.uuid);
-    if (!product) return res.status(404).json({ message: 'Product not found' });
+    if (!product) return res.status(404).json({ message: PRODUCT_NOT_FOUND });
 
     const qty = Math.min(product.quantity || 0, order.quantity);
     if (qty <= 0) return res.status(409).json({ message: 'Out of stock' });
 
     const cart = getCart(session.user.email);
     const existing = cart.find((c) => c.id === product.id);
-    if (existing) existing.qty += qty; else cart.push({ ...product, qty });
+    if (existing) existing.qty += qty;
+    else cart.push({ ...product, qty });
     setCart(session.user.email, cart);
 
     return res.status(200).json({ message: 'added to cart' });

--- a/pages/api/user/profile.ts
+++ b/pages/api/user/profile.ts
@@ -7,6 +7,11 @@ import { handleApiError } from '@utils/handleApiError';
 import type { User, ApiMessage } from '../../../types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import { uploadFileToS3 } from '@lib/s3';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  UPDATED,
+} from '@/constants/messages';
 
 export const config = {
   api: {
@@ -40,7 +45,7 @@ export default async function handler(
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     if (req.method === 'GET') {
       const userData = await findUser(session.user.email);
@@ -103,9 +108,9 @@ export default async function handler(
         update.profileImage = url;
       }
       await updateUserProfile(session.user.email, update);
-      return res.status(200).json({ message: 'updated' });
+      return res.status(200).json({ message: UPDATED });
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to update profile');
   }

--- a/pages/api/user/wishlist/[id].ts
+++ b/pages/api/user/wishlist/[id].ts
@@ -5,6 +5,12 @@ import { findUser } from '@lib/users';
 import { removeWishlistItem } from '@lib/wishlist';
 import { handleApiError } from '@utils/handleApiError';
 import type { ApiMessage } from '../../../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  USER_NOT_FOUND,
+  ID_REQUIRED,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -13,19 +19,19 @@ export default async function handler(
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const user = await findUser(session.user.email);
-    if (!user) return res.status(404).json({ message: 'User not found' });
+    if (!user) return res.status(404).json({ message: USER_NOT_FOUND });
 
     if (req.method === 'DELETE') {
       const { id } = req.query as { id?: string };
-      if (!id) return res.status(400).json({ message: 'id required' });
+      if (!id) return res.status(400).json({ message: ID_REQUIRED });
       await removeWishlistItem(parseInt(id, 10), user.id);
       return res.status(200).json({ message: 'removed' });
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to remove wishlist item');
   }

--- a/pages/api/user/wishlist/index.ts
+++ b/pages/api/user/wishlist/index.ts
@@ -1,13 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { findUser } from '@lib/users';
-import {
-  addWishlistItem,
-  getWishlistForUser,
-} from '@lib/wishlist';
+import { addWishlistItem, getWishlistForUser } from '@lib/wishlist';
 import { handleApiError } from '@utils/handleApiError';
 import type { WishlistItem, ApiMessage } from '../../../../types';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  USER_NOT_FOUND,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -16,10 +18,10 @@ export default async function handler(
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const user = await findUser(session.user.email);
-    if (!user) return res.status(404).json({ message: 'User not found' });
+    if (!user) return res.status(404).json({ message: USER_NOT_FOUND });
 
     if (req.method === 'GET') {
       const items = await getWishlistForUser(user.id);
@@ -44,7 +46,7 @@ export default async function handler(
       return res.status(200).json(item);
     }
 
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to manage wishlist');
   }

--- a/pages/api/vendor/orders.ts
+++ b/pages/api/vendor/orders.ts
@@ -4,6 +4,7 @@ import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { Order, ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, VENDOR_REQUIRED } from '@/constants/messages';
 
 async function handler(
   req: NextApiRequest,
@@ -11,11 +12,11 @@ async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const vendor = getQueryParam(req.query.vendor);
     if (!vendor) {
-      return res.status(400).json({ message: 'vendor required' });
+      return res.status(400).json({ message: VENDOR_REQUIRED });
     }
     const orders = await getOrdersForVendor(vendor);
     return res.status(200).json(orders);

--- a/pages/api/vendors.ts
+++ b/pages/api/vendors.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getVendors } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
 import type { Vendor, ApiMessage } from '../../types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 export interface VendorsResponse {
   vendors: Vendor[];
@@ -13,7 +14,7 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'GET') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const { search = '', page, limit } = req.query;
     const pageNum = parseInt(String(page || '1'), 10);

--- a/pages/api/vendors/check-or-create.ts
+++ b/pages/api/vendors/check-or-create.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { findVendorByName, createVendor } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
 import type { Vendor, ApiMessage } from '../../../types';
+import { METHOD_NOT_ALLOWED, NAME_REQUIRED } from '@/constants/messages';
 
 interface CheckCreateResponse {
   exists?: boolean;
@@ -15,15 +16,13 @@ export default async function handler(
 ): Promise<void> {
   try {
     if (req.method !== 'POST') {
-      return res.status(405).json({ message: 'Method Not Allowed' });
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const { name } = req.body || {};
-    if (!name) return res.status(400).json({ message: 'name required' });
+    if (!name) return res.status(400).json({ message: NAME_REQUIRED });
     const existing = await findVendorByName(String(name));
     if (existing) {
-      return res
-        .status(200)
-        .json({ exists: true, vendor: existing as Vendor });
+      return res.status(200).json({ exists: true, vendor: existing as Vendor });
     }
     const vendor = await createVendor(String(name));
     return res.status(201).json({ success: true, vendor });

--- a/pages/api/wishlist.ts
+++ b/pages/api/wishlist.ts
@@ -4,6 +4,12 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
 import type { Product, ApiMessage } from '../../types';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  SAVED,
+  ITEMS_REQUIRED,
+} from '@/constants/messages';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,7 +18,7 @@ export default async function handler(
   try {
     const session = await getServerSession(req, res, authOptions);
     if (!session?.user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return res.status(401).json({ message: UNAUTHORIZED });
     }
     const email = session.user.email;
     if (req.method === 'GET') {
@@ -22,12 +28,12 @@ export default async function handler(
     if (req.method === 'POST') {
       const { items } = (req.body as { items?: Product[] }) || {};
       if (!Array.isArray(items)) {
-        return res.status(400).json({ message: 'items required' });
+        return res.status(400).json({ message: ITEMS_REQUIRED });
       }
       setWishlist(email, items);
-      return res.status(200).json({ message: 'saved' });
+      return res.status(200).json({ message: SAVED });
     }
-    return res.status(405).json({ message: 'Method Not Allowed' });
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     return handleApiError(res, error, 'Failed to manage wishlist');
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -112,6 +112,7 @@
       "@styles/*": ["styles/*"],
       "@contexts/*": ["contexts/*"],
       "@/types/*": ["types/*"],
+      "@/constants/*": ["constants/*"],
       "@test-utils/*": ["test-utils/*"],
       "@lib/prisma": ["lib/prisma"]
     }


### PR DESCRIPTION
## Summary
- add `constants/messages.ts` with shared messages
- map new `@/constants/*` alias in tsconfig and Jest config
- replace inline strings in API routes with constants

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: Cannot find type definition file for 'jest' and 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68661c8006f0832fbcba84cfe63c1e90