### PR TITLE
Fix category slug types and state update enums

### DIFF
--- a/lib/defaultCategories.ts
+++ b/lib/defaultCategories.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_CATEGORIES = [
   {
     name: 'Electronics',
+    slug: 'electronics',
     subcategories: [
       { name: 'Phones' },
       { name: 'Computers' },
@@ -9,10 +10,12 @@ export const DEFAULT_CATEGORIES = [
   },
   {
     name: 'Fashion',
+    slug: 'fashion',
     subcategories: [{ name: 'Men' }, { name: 'Women' }, { name: 'Kids' }],
   },
   {
     name: 'Home',
+    slug: 'home',
     subcategories: [
       { name: 'Furniture' },
       { name: 'Kitchen' },
@@ -21,6 +24,7 @@ export const DEFAULT_CATEGORIES = [
   },
   {
     name: 'Toys',
+    slug: 'toys',
     subcategories: [
       { name: 'Games' },
       { name: 'Stuffed Animals' },
@@ -29,6 +33,7 @@ export const DEFAULT_CATEGORIES = [
   },
   {
     name: 'Sports',
+    slug: 'sports',
     subcategories: [
       { name: 'Fitness' },
       { name: 'Outdoor' },

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -1,4 +1,4 @@
-import type { NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 import {
   updateProduct,
   deleteProduct,
@@ -122,6 +122,8 @@ export default async function handler(
         tags: String(tags ?? existing.tags),
         category: {
           id: parseInt(String(category_id ?? existing.categoryId ?? '0'), 10),
+          name: '',
+          slug: '',
         },
         quantity:
           typeof quantity !== 'undefined'

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -198,7 +198,11 @@ async function handler(
         description: String(description || ''),
         productType: String(product_type || ''),
         tags: String(tags || ''),
-        category: { id: parseInt(String(category_id || '0'), 10), name: '' },
+        category: {
+          id: parseInt(String(category_id || '0'), 10),
+          name: '',
+          slug: ''
+        },
         quantity: quantity ? parseInt(String(quantity), 10) : 0,
         minPrice: parseFloat(String(min_price || '0')),
         maxPrice: parseFloat(String(max_price || '0')),

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -2,6 +2,7 @@ import OrderChatWindow from '@components/Chat/OrderChatWindow';
 import { useEffect, useState, useMemo, Fragment, useContext } from 'react';
 import useRequireAuth from '@hooks/useRequireAuth';
 import type { Order } from '../types';
+import { OrderStatus } from '../types';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
 import { NotificationContext } from '@contexts/NotificationContext';
@@ -63,7 +64,11 @@ const Orders: React.FC<OrdersProps> = (_props) => {
     const data = await res.json().catch(() => null);
     if (res.ok) {
       addNotification('Order cancelled', 'success');
-      setOrders((prev) => prev.map((o) => (o.uuid === uuid ? { ...o, status: 'cancelled' } : o)));
+      setOrders((prev) =>
+        prev.map((o) =>
+          o.uuid === uuid ? { ...o, status: OrderStatus.CANCELLED } : o
+        )
+      );
     } else {
       addNotification(data?.message || 'Cancellation failed', 'error');
     }

--- a/pages/user/orders/[uuid].tsx
+++ b/pages/user/orders/[uuid].tsx
@@ -7,6 +7,7 @@ import OrderChatWindow from '@components/Chat/OrderChatWindow';
 import { StatusLabel } from '@components/UI';
 import { getPageTitle } from '@lib/pageTitle';
 import type { Order } from '../../../types';
+import { OrderStatus } from '../../../types';
 
 export default function UserOrderDetail() {
   const router = useRouter();
@@ -47,7 +48,7 @@ export default function UserOrderDetail() {
       method: 'POST',
     });
     if (res.ok) {
-      setOrder({ ...order, status: 'cancelled' });
+      setOrder({ ...order, status: OrderStatus.CANCELLED });
     } else {
       const d = await res.json().catch(() => null);
       alert(d?.message || 'Failed to cancel');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -112,6 +112,7 @@
       "@styles/*": ["styles/*"],
       "@contexts/*": ["contexts/*"],
       "@/types/*": ["types/*"],
+      "@/types": ["types/index.ts"],
       "@test-utils/*": ["test-utils/*"],
       "@lib/prisma": ["lib/prisma"]
     }


### PR DESCRIPTION
## Summary
- add slug properties to the built-in category list
- allow importing `@/types` directly via tsconfig path alias
- keep product API category objects type-safe
- use `OrderStatus` enum when updating state after cancelling orders
- import `NextApiRequest` where used

## Testing
- `npm run type-check` *(fails: Module '@prisma/client' has no exported member 'Notification', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68661d4fe248832fa87967f94ad7b3f9