### PR TITLE
Fix type errors in common components

### DIFF
--- a/components/Layout/NotificationBell.tsx
+++ b/components/Layout/NotificationBell.tsx
@@ -2,8 +2,20 @@ import { useEffect, useState } from 'react';
 import BellIcon from '../icons/BellIcon';
 import type { Notification } from '../../types';
 
-export default function NotificationBell() {
-  const [items, setItems] = useState<Notification[]>([]);
+export interface NotificationBellProps {
+  notifications?: Notification[];
+  onClick?: () => void;
+}
+
+export default function NotificationBell({
+  notifications = [],
+  onClick,
+}: NotificationBellProps) {
+  const [items, setItems] = useState<Notification[]>(notifications);
+
+  useEffect(() => {
+    setItems(notifications);
+  }, [notifications]);
 
   const fetchNotifications = () => {
     fetch('/api/brand/notifications')
@@ -28,7 +40,12 @@ export default function NotificationBell() {
 
   return (
     <div className="dropdown dropdown-end">
-      <div tabIndex={0} role="button" className="btn btn-ghost btn-circle">
+      <div
+        tabIndex={0}
+        role="button"
+        className="btn btn-ghost btn-circle"
+        onClick={onClick}
+      >
         <div className="indicator">
           <BellIcon className="w-5 h-5" />
           {unread > 0 && (

--- a/lib/defaultCategories.ts
+++ b/lib/defaultCategories.ts
@@ -1,6 +1,9 @@
-export const DEFAULT_CATEGORIES = [
+import type { Category } from '@/types/category';
+
+export const DEFAULT_CATEGORIES: Category[] = [
   {
     name: 'Electronics',
+    slug: 'electronics',
     subcategories: [
       { name: 'Phones' },
       { name: 'Computers' },
@@ -9,10 +12,12 @@ export const DEFAULT_CATEGORIES = [
   },
   {
     name: 'Fashion',
+    slug: 'fashion',
     subcategories: [{ name: 'Men' }, { name: 'Women' }, { name: 'Kids' }],
   },
   {
     name: 'Home',
+    slug: 'home',
     subcategories: [
       { name: 'Furniture' },
       { name: 'Kitchen' },
@@ -21,6 +26,7 @@ export const DEFAULT_CATEGORIES = [
   },
   {
     name: 'Toys',
+    slug: 'toys',
     subcategories: [
       { name: 'Games' },
       { name: 'Stuffed Animals' },
@@ -29,6 +35,7 @@ export const DEFAULT_CATEGORIES = [
   },
   {
     name: 'Sports',
+    slug: 'sports',
     subcategories: [
       { name: 'Fitness' },
       { name: 'Outdoor' },
@@ -36,4 +43,5 @@ export const DEFAULT_CATEGORIES = [
     ],
   },
 ];
+
 export default DEFAULT_CATEGORIES;

--- a/types/notification.ts
+++ b/types/notification.ts
@@ -1,3 +1,8 @@
-import type { Notification as PrismaNotification } from '@prisma/client';
-
-export interface Notification extends PrismaNotification {}
+export interface Notification {
+  id: number;
+  userId: number;
+  orderId: number;
+  message: string;
+  read: boolean;
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- add slugs to `DEFAULT_CATEGORIES` and type them
- define `Notification` interface without prisma dependency
- add props to `NotificationBell`

## Testing
- `npm test`
- `npm run type-check` *(fails: Module '@prisma/client' has no exported member 'Payment', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68661fd95918832f9553db330d6d9d43