### PR TITLE
Improve typings across lib files

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,4 +1,5 @@
 import { getDb } from './db';
+import type { Prisma } from '@prisma/client';
 
 export const ORDER_SUCCESS_STATUSES = ['shipped', 'delivered', 'completed'] as const;
 
@@ -8,16 +9,20 @@ export interface SalesMetricsParams {
   vendorId?: number;
 }
 
-export async function getSalesMetrics({ start, end, vendorId }: SalesMetricsParams = {}) {
+export async function getSalesMetrics(
+  { start, end, vendorId }: SalesMetricsParams = {}
+): Promise<{ count: number; revenue: number }> {
   const db = getDb();
-  const where: any = { status: { in: ORDER_SUCCESS_STATUSES } };
+  const where: Prisma.OrderWhereInput = {
+    status: { in: ORDER_SUCCESS_STATUSES },
+  };
   if (start || end) {
     where.createdAt = {};
-    if (start) where.createdAt.gte = start;
-    if (end) where.createdAt.lte = end;
+    if (start) (where.createdAt as Prisma.DateTimeFilter).gte = start;
+    if (end) (where.createdAt as Prisma.DateTimeFilter).lte = end;
   }
   if (vendorId) {
-    where.product = { vendorId };
+    where.product = { vendorId } as unknown as Prisma.ProductWhereInput;
   }
   const count = await db.order.count({ where });
   const agg = await db.order.aggregate({ where, _sum: { total: true } });

--- a/lib/guestOrders.ts
+++ b/lib/guestOrders.ts
@@ -1,25 +1,28 @@
 import { v4 as uuidv4 } from 'uuid';
 import { sendOrderConfirmation } from './email';
+import type { CartItem } from '@/types/cart';
 
 export interface GuestOrder {
   id: string;
   name: string;
   email: string;
   address: string;
-  items: any[];
+  items: CartItem[];
   total: number;
   status: string;
 }
 
 const store = new Map<string, GuestOrder>();
 
-export async function addGuestOrder(data: Omit<GuestOrder, 'id' | 'status'>) {
+export async function addGuestOrder(
+  data: Omit<GuestOrder, 'id' | 'status'>
+): Promise<GuestOrder> {
   const order: GuestOrder = { ...data, id: uuidv4(), status: 'pending' };
   store.set(order.id, order);
   await sendOrderConfirmation(order.email, { id: order.id });
   return order;
 }
 
-export function getGuestOrder(id: string) {
+export function getGuestOrder(id: string): GuestOrder | undefined {
   return store.get(id);
 }

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -5,7 +5,7 @@ import type { Variant } from '@/types/variant';
 import { parseImages } from './utils/parseImages';
 import type { Category } from '@/types/category';
 import type { Vendor } from '@/types/vendor';
-import { Prisma } from '@prisma/client';
+import type { Prisma } from '@prisma/client';
 import client from './typesenseClient';
 import { getBestSellingProducts } from './orders';
 import { slugify } from './slugify';
@@ -177,7 +177,9 @@ export function mapDbRowToProduct(row: ProductRow): Product {
           brandName: row.vendor.brandName ?? '',
           phoneNumber: row.vendor.phoneNumber ?? undefined,
           address: row.vendor.address ?? null,
-          paymentMethods: (row.vendor.paymentMethods as any) ?? null,
+          paymentMethods:
+            (row.vendor.paymentMethods as import('@/types/vendor').BrandPaymentMethod[] | null) ??
+            null,
         }
       : null,
     category: row.category ?? null,
@@ -453,9 +455,11 @@ export async function getProductsPaginated(
   options: PaginatedOptions
 ): Promise<PaginatedResult> {
   const db = getDb();
-  const where: Record<string, any> = { status: 'approved' };
+  const where: Prisma.ProductWhereInput = { status: 'approved' };
   if (options.categorySlugs && options.categorySlugs.length > 0) {
-    where.category = { slug: { in: options.categorySlugs } };
+    where.category = {
+      slug: { in: options.categorySlugs },
+    } as Prisma.CategoryRelationFilter;
   }
   if (options.inStock) {
     where.quantity = { gt: 0 };


### PR DESCRIPTION
## Summary
- tighten types for analytics metrics queries
- add explicit guest order types
- enforce Prisma types in product queries

## Testing
- `npx tsc --noEmit lib/*.ts lib/utils/*.ts` *(fails: Module '@types/react/index' can only be default-imported using the 'esModuleInterop' flag)*

------
https://chatgpt.com/codex/tasks/task_e_68662588457c832fad5ee83105f32bd8