### PR TITLE
Fix prisma imports and add missing type placeholders

### DIFF
--- a/pages/api/admin/analytics.ts
+++ b/pages/api/admin/analytics.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
-import { AnalyticsData, ApiMessage } from '../@/types';
+import { AnalyticsData, ApiMessage } from '@/types';
 import { getDb } from '@lib/db';
 import { getQueryParam } from '@utils/getQueryParam';
 import { METHOD_NOT_ALLOWED } from '@/constants/messages';

--- a/pages/api/admin/categories.ts
+++ b/pages/api/admin/categories.ts
@@ -9,7 +9,7 @@ import { withRole } from '@lib/withRole';
 import { logAudit } from '@lib/audit';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import { Category, CategoryInput, ApiMessage } from '../@/types';
+import { Category, CategoryInput, ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   UUID_REQUIRED,

--- a/pages/api/admin/coupons.ts
+++ b/pages/api/admin/coupons.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { createCoupon, listCoupons, updateCoupon } from '@lib/coupons';
-import type { Coupon, ApiMessage } from '../@/types';
+import type { Coupon, ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, ID_REQUIRED } from '@/constants/messages';
 
 async function handler(

--- a/pages/api/admin/low-stock.ts
+++ b/pages/api/admin/low-stock.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getDb } from '@lib/db';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
-import type { ApiMessage, LowStockProduct } from '../@/types';
+import type { ApiMessage, LowStockProduct } from '@/types';
 import { DEFAULT_LOW_STOCK_THRESHOLD } from '@lib/config';
 import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 

--- a/pages/api/admin/orders.ts
+++ b/pages/api/admin/orders.ts
@@ -3,7 +3,7 @@ import { getAllOrdersFiltered, updateOrderStatus } from '@lib/orders';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { Order, ApiMessage } from '../@/types';
+import type { Order, ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, UPDATED } from '@/constants/messages';
 
 async function handler(

--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -8,7 +8,7 @@ import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import { slugify } from '@lib/slugify';
-import { Product, ApiMessage, Variant } from '../@/types';
+import { Product, ApiMessage, Variant } from '@/types';
 import { mapDbRowToProduct } from '@lib/products';
 import {
   METHOD_NOT_ALLOWED,

--- a/pages/api/admin/search-analytics.ts
+++ b/pages/api/admin/search-analytics.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { SearchAnalyticsResponse, ApiMessage } from '../@/types';
+import { SearchAnalyticsResponse, ApiMessage } from '@/types';
 import { getDb } from '@lib/db';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -16,7 +16,7 @@ import {
   UserDisabledUpdateRequest,
   CreateUserRequest,
   ApiMessage,
-} from '../@/types';
+} from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   MISSING_REQUIRED_FIELDS,

--- a/pages/api/admin/vendor-products.ts
+++ b/pages/api/admin/vendor-products.ts
@@ -6,7 +6,7 @@ import {
 } from '@lib/products';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
-import { PendingProduct, ApiMessage } from '../@/types';
+import { PendingProduct, ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 async function handler(

--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendorId } from '@lib/orders';
 import { handleApiError } from '@utils/handleApiError';
-import type { AnalyticsData, ApiMessage } from '../@/types';
+import type { AnalyticsData, ApiMessage } from '@/types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoriesFlat, createCategory } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
-import type { ApiMessage, Category } from '../@/types';
+import type { ApiMessage, Category } from '@/types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import {

--- a/pages/api/brand/earnings.ts
+++ b/pages/api/brand/earnings.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendorId } from '@lib/orders';
 import { handleApiError } from '@utils/handleApiError';
-import type { EarningsData, ApiMessage } from '../@/types';
+import type { EarningsData, ApiMessage } from '@/types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';

--- a/pages/api/brand/low-stock.ts
+++ b/pages/api/brand/low-stock.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { loadAndIndexProducts } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { Product, ApiMessage } from '../@/types';
+import type { Product, ApiMessage } from '@/types';
 import { VENDOR_REQUIRED } from '@/constants/messages';
 
 export default async function handler(

--- a/pages/api/brand/notifications.ts
+++ b/pages/api/brand/notifications.ts
@@ -7,7 +7,7 @@ import {
 } from '@lib/notifications';
 import { findUser } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
-import type { Notification, ApiMessage } from '../@/types';
+import type { Notification, ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   UNAUTHORIZED,

--- a/pages/api/brand/orders.ts
+++ b/pages/api/brand/orders.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getOrdersForVendorId } from '@lib/orders';
 import { handleApiError } from '@utils/handleApiError';
-import type { Order, ApiMessage } from '../@/types';
+import type { Order, ApiMessage } from '@/types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { METHOD_NOT_ALLOWED } from '@/constants/messages';

--- a/pages/api/brand/products/[uuid].ts
+++ b/pages/api/brand/products/[uuid].ts
@@ -8,7 +8,7 @@ import { getProductByUuid } from '@lib/db';
 import { hasOrdersForProduct } from '@lib/orders';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { ApiMessage, ProductInput } from '../../@/types';
+import type { ApiMessage, ProductInput } from '@/types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import { uploadFileToS3 } from '@lib/s3';
 import path from 'path';

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import { slugify } from '@lib/slugify';
-import type { Product, ProductInput, ApiMessage } from '../../@/types';
+import type { Product, ProductInput, ApiMessage } from '@/types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import { uploadFileToS3 } from '@lib/s3';
 import path from 'path';

--- a/pages/api/brand/profile.ts
+++ b/pages/api/brand/profile.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateUserProfile, findUser } from '@lib/users';
-import type { Vendor, ApiMessage } from '../@/types';
+import type { Vendor, ApiMessage } from '@/types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';

--- a/pages/api/categories/check-or-create.ts
+++ b/pages/api/categories/check-or-create.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoriesFlat, createCategory } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
-import type { ApiMessage, Category } from '../@/types';
+import type { ApiMessage, Category } from '@/types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import {

--- a/pages/api/categories/check.ts
+++ b/pages/api/categories/check.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getCategoriesFlat } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
-import type { ApiMessage, Category } from '../@/types';
+import type { ApiMessage, Category } from '@/types';
 import { METHOD_NOT_ALLOWED, NAME_REQUIRED } from '@/constants/messages';
 
 interface CheckResponse {

--- a/pages/api/chat/upload.ts
+++ b/pages/api/chat/upload.ts
@@ -3,7 +3,7 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import formidable, { File } from 'formidable';
 import { uploadFileToS3 } from '@/lib/s3';
-import type { ApiMessage } from '../@/types';
+import type { ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   UNAUTHORIZED,

--- a/pages/api/checkout/complete.ts
+++ b/pages/api/checkout/complete.ts
@@ -3,7 +3,7 @@ import Stripe from 'stripe';
 import { addOrder } from '@lib/orders';
 import { sendOrderConfirmation } from '@lib/email';
 import { handleApiError } from '@utils/handleApiError';
-import type { OrderIdResponse, ApiMessage } from '../@/types';
+import type { OrderIdResponse, ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {

--- a/pages/api/checkout/create-session.ts
+++ b/pages/api/checkout/create-session.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
 import { handleApiError } from '@utils/handleApiError';
-import type { CheckoutSessionResponse, ApiMessage } from '../@/types';
+import type { CheckoutSessionResponse, ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {

--- a/pages/api/coupons/[code].ts
+++ b/pages/api/coupons/[code].ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getQueryParam } from '@utils/getQueryParam';
 import { handleApiError } from '@utils/handleApiError';
 import { findCouponByCode } from '@lib/coupons';
-import type { Coupon, ApiMessage } from '../@/types';
+import type { Coupon, ApiMessage } from '@/types';
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/dashboard/best-sellers.ts
+++ b/pages/api/dashboard/best-sellers.ts
@@ -3,7 +3,7 @@ import { getDb } from '@lib/db';
 import { withRole, type AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { ApiMessage } from '../@/types';
+import type { ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(

--- a/pages/api/dashboard/inventory-alerts.ts
+++ b/pages/api/dashboard/inventory-alerts.ts
@@ -3,7 +3,7 @@ import { getDb } from '@lib/db';
 import { withRole, type AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { ApiMessage } from '../@/types';
+import type { ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(

--- a/pages/api/dashboard/orders-this-month.ts
+++ b/pages/api/dashboard/orders-this-month.ts
@@ -4,7 +4,7 @@ import { getSalesMetrics } from '@lib/analytics';
 import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { ApiMessage } from '../@/types';
+import type { ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(

--- a/pages/api/dashboard/total-products.ts
+++ b/pages/api/dashboard/total-products.ts
@@ -3,7 +3,7 @@ import { getDb } from '@lib/db';
 import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { ApiMessage } from '../@/types';
+import type { ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(

--- a/pages/api/dashboard/total-sales.ts
+++ b/pages/api/dashboard/total-sales.ts
@@ -3,7 +3,7 @@ import { getSalesMetrics } from '@lib/analytics';
 import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { ApiMessage } from '../@/types';
+import type { ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(

--- a/pages/api/dashboard/weekly-summary.ts
+++ b/pages/api/dashboard/weekly-summary.ts
@@ -4,7 +4,7 @@ import { getSalesMetrics } from '@lib/analytics';
 import { withRole, AuthedNextApiRequest } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { ApiMessage } from '../@/types';
+import type { ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 async function handler(

--- a/pages/api/messages/[orderId].ts
+++ b/pages/api/messages/[orderId].ts
@@ -6,7 +6,7 @@ import { getOrderByUuid } from '@lib/orders';
 import { findUser } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { Message, ApiMessage } from '../@/types';
+import type { Message, ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   UNAUTHORIZED,

--- a/pages/api/orders/[uuid].ts
+++ b/pages/api/orders/[uuid].ts
@@ -4,7 +4,7 @@ import { sendOrderStatusUpdate } from '@lib/email';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { Order, ApiMessage } from '../@/types';
+import type { Order, ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   NOT_FOUND,

--- a/pages/api/orders/[uuid]/cancel.ts
+++ b/pages/api/orders/[uuid]/cancel.ts
@@ -5,7 +5,7 @@ import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import { logAudit } from '@lib/audit';
-import type { ApiMessage } from '../../@/types';
+import type { ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   NOT_FOUND,

--- a/pages/api/products/[uuid].ts
+++ b/pages/api/products/[uuid].ts
@@ -4,7 +4,7 @@ import { mapDbRowToProduct } from '@lib/products';
 import { Product } from '@/types';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { ApiMessage } from '../@/types';
+import type { ApiMessage } from '@/types';
 import { NOT_FOUND, UUID_REQUIRED } from '@/constants/messages';
 
 export interface ProductParams {

--- a/pages/api/products/[uuid]/reviews.ts
+++ b/pages/api/products/[uuid]/reviews.ts
@@ -8,7 +8,7 @@ import type {
   ReviewsResponse,
   ReviewAddedResponse,
 } from '@/types';
-import type { ApiMessage } from '../../@/types';
+import type { ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, UUID_REQUIRED } from '@/constants/messages';
 
 export default async function handler(

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -3,7 +3,7 @@ import { getProductsPaginated } from '@lib/products';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { Product } from '@/types';
-import type { ApiMessage } from '../@/types';
+import type { ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED } from '@/constants/messages';
 
 export interface ProductsQuery {

--- a/pages/api/signup/brand.ts
+++ b/pages/api/signup/brand.ts
@@ -3,7 +3,7 @@ import { addUser, findUser } from '@lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '@utils/handleApiError';
-import type { SignupTokenResponse, ApiMessage } from '../@/types';
+import type { SignupTokenResponse, ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   MISSING_REQUIRED_FIELDS,

--- a/pages/api/signup/user.ts
+++ b/pages/api/signup/user.ts
@@ -3,7 +3,7 @@ import { addUser, findUser } from '@lib/users';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import { handleApiError } from '@utils/handleApiError';
-import type { SignupTokenResponse, ApiMessage } from '../@/types';
+import type { SignupTokenResponse, ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   MISSING_REQUIRED_FIELDS,

--- a/pages/api/user/orders.ts
+++ b/pages/api/user/orders.ts
@@ -3,7 +3,7 @@ import { getOrdersForUser } from '@lib/orders';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
-import type { Order, ApiMessage } from '../@/types';
+import type { Order, ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
 
 export default async function handler(

--- a/pages/api/user/orders/[uuid].ts
+++ b/pages/api/user/orders/[uuid].ts
@@ -3,7 +3,7 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { getOrderByUuid } from '@lib/orders';
 import { handleApiError } from '@utils/handleApiError';
-import type { Order, ApiMessage } from '../../@/types';
+import type { Order, ApiMessage } from '@/types';
 import { UNAUTHORIZED, NOT_FOUND, UUID_REQUIRED } from '@/constants/messages';
 
 export default async function handler(

--- a/pages/api/user/orders/[uuid]/cancel.ts
+++ b/pages/api/user/orders/[uuid]/cancel.ts
@@ -6,7 +6,7 @@ import { stripe } from '@lib/stripe';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import { logAudit } from '@lib/audit';
-import type { ApiMessage } from '../../../../@/types';
+import type { ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   UNAUTHORIZED,

--- a/pages/api/user/orders/[uuid]/reorder.ts
+++ b/pages/api/user/orders/[uuid]/reorder.ts
@@ -4,7 +4,7 @@ import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { getOrderByUuid } from '@lib/orders';
 import { getProductByUuid, getCart, setCart } from '@lib/db';
 import { handleApiError } from '@utils/handleApiError';
-import type { ApiMessage } from '../../../@/types';
+import type { ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   UNAUTHORIZED,

--- a/pages/api/user/profile.ts
+++ b/pages/api/user/profile.ts
@@ -4,7 +4,7 @@ import bcrypt from 'bcryptjs';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { handleApiError } from '@utils/handleApiError';
-import type { User, ApiMessage } from '../@/types';
+import type { User, ApiMessage } from '@/types';
 import formidable, { type Fields, type Files, type File } from 'formidable';
 import { uploadFileToS3 } from '@lib/s3';
 import {

--- a/pages/api/user/wishlist/[id].ts
+++ b/pages/api/user/wishlist/[id].ts
@@ -4,7 +4,7 @@ import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { findUser } from '@lib/users';
 import { removeWishlistItem } from '@lib/wishlist';
 import { handleApiError } from '@utils/handleApiError';
-import type { ApiMessage } from '../../@/types';
+import type { ApiMessage } from '@/types';
 import {
   METHOD_NOT_ALLOWED,
   UNAUTHORIZED,

--- a/pages/api/user/wishlist/index.ts
+++ b/pages/api/user/wishlist/index.ts
@@ -3,7 +3,7 @@ import { getServerSession } from 'next-auth/next';
 import { findUser } from '@lib/users';
 import { addWishlistItem, getWishlistForUser } from '@lib/wishlist';
 import { handleApiError } from '@utils/handleApiError';
-import type { WishlistItem, ApiMessage } from '../../@/types';
+import type { WishlistItem, ApiMessage } from '@/types';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import {
   METHOD_NOT_ALLOWED,

--- a/pages/api/vendor/orders.ts
+++ b/pages/api/vendor/orders.ts
@@ -3,7 +3,7 @@ import { getOrdersForVendor } from '@lib/orders';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
-import type { Order, ApiMessage } from '../@/types';
+import type { Order, ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, VENDOR_REQUIRED } from '@/constants/messages';
 
 async function handler(

--- a/pages/api/vendors/check-or-create.ts
+++ b/pages/api/vendors/check-or-create.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { findVendorByName, createVendor } from '@lib/users';
 import { handleApiError } from '@utils/handleApiError';
-import type { Vendor, ApiMessage } from '../@/types';
+import type { Vendor, ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, NAME_REQUIRED } from '@/constants/messages';
 
 interface CheckCreateResponse {

--- a/pages/categories/[slug]/index.tsx
+++ b/pages/categories/[slug]/index.tsx
@@ -4,7 +4,7 @@ import ProductCard from '@components/Product/ProductCard';
 import Head from 'next/head';
 import React from 'react';
 import { getPageTitle } from '@lib/pageTitle';
-import { Category, Product } from '../@/types';
+import { Category, Product } from '@/types';
 
 const CategoryPage: React.FC = () => {
   const router = useRouter();

--- a/pages/categories/[slug]/products.tsx
+++ b/pages/categories/[slug]/products.tsx
@@ -4,7 +4,7 @@ import { getPageTitle } from '@lib/pageTitle';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import ProductCard from '@components/Product/ProductCard';
-import type { Product, Category } from '../@/types';
+import type { Product, Category } from '@/types';
 import {
   getCategoryBySlug,
   getProductsByCategorySlug,

--- a/pages/user/orders/[uuid].tsx
+++ b/pages/user/orders/[uuid].tsx
@@ -6,8 +6,8 @@ import dayjs from 'dayjs';
 import OrderChatWindow from '@components/Chat/OrderChatWindow';
 import { StatusLabel } from '@components/UI';
 import { getPageTitle } from '@lib/pageTitle';
-import type { Order } from '../@/types';
-import { OrderStatus } from '../@/types';
+import type { Order } from '@/types';
+import { OrderStatus } from '@/types';
 
 export default function UserOrderDetail() {
   const router = useRouter();

--- a/types/custom/prisma-stub.d.ts
+++ b/types/custom/prisma-stub.d.ts
@@ -16,10 +16,18 @@ declare module '@prisma/client' {
     export interface Product {
       [key: string]: any;
     }
+    export interface ProductWhereInput {
+      [key: string]: any;
+    }
   }
   export type Role = any;
   export interface Product extends Record<string, any> {}
   export interface User extends Record<string, any> {}
   export interface Order extends Record<string, any> {}
   export interface Category extends Record<string, any> {}
+  export interface Payment extends Record<string, any> {}
+  export interface PaymentMethod extends Record<string, any> {}
+  export interface PolicyDocument extends Record<string, any> {}
+  export interface SupportTicket extends Record<string, any> {}
+  export interface WishlistItem extends Record<string, any> {}
 }

--- a/types/product.ts
+++ b/types/product.ts
@@ -30,6 +30,8 @@ type ProductBase = Pick<
 export interface Product extends ProductBase {
   vendor: Vendor;
   category: Category;
+  /** Associated category id */
+  categoryId?: number;
   brand?: Brand;
   images?: Image[];
   variants?: Variant[];

--- a/types/user.ts
+++ b/types/user.ts
@@ -4,6 +4,8 @@ export interface User {
   id?: number | string;
   uuid?: string;
   email: string;
+  /** Optional display name from auth providers */
+  name?: string;
   firstName?: string;
   lastName?: string;
   role?: Role;


### PR DESCRIPTION
## Summary
- add placeholder types in `prisma-stub.d.ts`
- include optional `name` field on `User` type
- expose `categoryId` on `Product` type
- fix imports to use `@/types` alias

## Testing
- `npm run type-check` *(fails: multiple unrelated TS errors remain)*
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68662921f6b4832fb5202cbeb2e793dd