### PR TITLE
Fix Jest alias for types imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
     '^@styles/(.*)$': '<rootDir>/styles/$1',
     '^@contexts/(.*)$': '<rootDir>/contexts/$1',
     '^@/constants/(.*)$': '<rootDir>/constants/$1',
+    '^@/types$': '<rootDir>/types/index.ts',
     '^@/types/(.*)$': '<rootDir>/types/$1',
     '^@test-utils/(.*)$': '<rootDir>/test-utils/$1',
   },


### PR DESCRIPTION
## Summary
- update moduleNameMapper in jest config to correctly map `@/types` alias

## Testing
- `npm test --silent` *(fails: OrderDetail page tests, ThemeToggle tests)*

------
https://chatgpt.com/codex/tasks/task_e_68677770c17c832fbe4abb336889fa06