### PR TITLE
Fix Jest path aliasing and update tests

### DIFF
--- a/__tests__/Header.test.tsx
+++ b/__tests__/Header.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 // Update the import path below if your Header component is located elsewhere
-import Header from '../components/Layout/Header';
+import Header from '@components/Layout/Header';
 // Update the path below to the correct relative path where AppContext is defined
-import { AppContext } from '../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 
 let mockPathname = '/';
 jest.mock('next/router', () => ({

--- a/__tests__/ThemeToggle.test.tsx
+++ b/__tests__/ThemeToggle.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import Layout from '../components/Layout/Layout';
+import Layout from '@components/Layout/Layout';
 // Update the import path below if your AppContext is located elsewhere
-import { AppContext } from '../contexts/AppContext';
+import { AppContext } from '@contexts/AppContext';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({

--- a/__tests__/order.detail.test.tsx
+++ b/__tests__/order.detail.test.tsx
@@ -1,14 +1,14 @@
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
-import OrderDetail from '../pages/orders/[orderId]';
-// Update the import path below to the correct relative path if needed
-import { AppContext } from '../contexts/AppContext';
+import OrderDetail from '@pages/orders/[orderId]';
+import { AppContext } from '@contexts/AppContext';
+import { UserRole } from '@/types';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({ query: { orderId: 'abc' } }),
 }));
 
-const renderWithUser = (userRole: string) => {
+const renderWithUser = (userRole: UserRole) => {
   const value: any = { user: { role: userRole } };
   return render(
     <AppContext.Provider value={value}>
@@ -39,7 +39,7 @@ describe('OrderDetail page', () => {
           total: 20,
         }),
     });
-    renderWithUser('user');
+    renderWithUser(UserRole.USER);
     expect(global.fetch).toHaveBeenCalledWith('/api/user/orders/abc');
     expect(await screen.findByText('Order #1')).toBeInTheDocument();
   });
@@ -50,14 +50,14 @@ describe('OrderDetail page', () => {
       status: 404,
       json: () => Promise.resolve({ message: 'Not found' }),
     });
-    renderWithUser('brand');
+    renderWithUser(UserRole.BRAND);
     expect(global.fetch).toHaveBeenCalledWith('/api/orders/abc');
     expect(await screen.findByText('Order not found.')).toBeInTheDocument();
   });
 
   it('shows error on network failure', async () => {
     (global.fetch as jest.Mock).mockRejectedValue(new Error('Network'));
-    renderWithUser('brand');
+    renderWithUser(UserRole.BRAND);
     expect(global.fetch).toHaveBeenCalledWith('/api/orders/abc');
     expect(await screen.findByText('Failed to load order')).toBeInTheDocument();
   });

--- a/__tests__/profile.ssr.test.ts
+++ b/__tests__/profile.ssr.test.ts
@@ -1,7 +1,7 @@
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
 jest.mock('@pages/api/auth/[...nextauth]', () => ({ authOptions: {} }));
 
-import { getServerSideProps } from '../pages/profile';
+import { getServerSideProps } from '@pages/profile';
 import { getServerSession } from 'next-auth/next';
 
 const mockedGetServerSession = getServerSession as jest.Mock;

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -18,11 +18,13 @@ const Header: FC<HeaderProps> = ({
 }) => {
   const app = useContext(AppContext);
   const { data: session } = useSession();
-  const role =
-    app?.user?.role?.toLowerCase() ||
-    (
-      (session?.user as { role?: string } | undefined)?.role || ''
-    ).toLowerCase();
+  const role = (
+    app?.user?.role ||
+    (session?.user as { role?: string } | undefined)?.role ||
+    ''
+  )
+    .toString()
+    .toUpperCase();
   if (role === UserRole.BRAND) {
     return (
       <BrandHeader

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,8 +14,10 @@ module.exports = {
     '^@styles/(.*)$': '<rootDir>/styles/$1',
     '^@contexts/(.*)$': '<rootDir>/contexts/$1',
     '^@/constants/(.*)$': '<rootDir>/constants/$1',
+    '^@/types$': '<rootDir>/types/index.ts',
     '^@/types/(.*)$': '<rootDir>/types/$1',
     '^@test-utils/(.*)$': '<rootDir>/test-utils/$1',
+    '^@/(.*)$': '<rootDir>/$1',
   },
   transform: {
     '^.+\\.[jt]sx?$': ['babel-jest', { configFile: './babel-jest.config.js' }],

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import { Response } from 'node-fetch';
 
 // jsdom doesn't provide TextEncoder/TextDecoder which are required by some libs
 // so we polyfill them using Node's util implementation
@@ -8,3 +9,9 @@ import { TextEncoder, TextDecoder } from 'util';
 if (!global.TextEncoder) global.TextEncoder = TextEncoder;
 // @ts-ignore
 if (!global.TextDecoder) global.TextDecoder = TextDecoder;
+// Polyfill fetch Response in jsdom environment
+// @ts-ignore
+if (typeof global.Response === 'undefined') {
+  // @ts-ignore
+  global.Response = Response;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "eslint-import-resolver-typescript": "^3.6.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
+        "node-fetch": "^2.7.0",
         "postcss": "^8.4.38",
         "prettier": "^3.5.3",
         "prisma": "^6.10.1",
@@ -13725,6 +13726,52 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
+    "node-fetch": "^2.7.0",
     "postcss": "^8.4.38",
     "prettier": "^3.5.3",
     "prisma": "^6.10.1",


### PR DESCRIPTION
## Summary
- map `@` and `@/types` in Jest configuration
- polyfill `Response` for jsdom tests
- normalise role casing in `Header` component
- use path aliases in tests and fix role usage
- add `node-fetch` dev dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686777764ec4832fa2bc8fb1ecc9e836