### PR TITLE
Fix profile tags and edit button styling

### DIFF
--- a/components/UI/StatusLabel.tsx
+++ b/components/UI/StatusLabel.tsx
@@ -15,16 +15,22 @@ const StatusLabel: React.FC<StatusLabelProps> = ({
 }) => {
   const colorClass =
     color === 'success'
-      ? 'badge-success'
+      ? 'bg-green-100 text-green-800'
       : color === 'info'
-      ? 'badge-info'
-      : color === 'warning'
-      ? 'badge-warning'
-      : color === 'error'
-      ? 'badge-error'
-      : '';
-  const sizeClass = size === 'sm' ? 'badge-sm' : '';
-  return <span className={`badge ${sizeClass} ${colorClass} ${className}`}>{children}</span>;
+        ? 'bg-blue-100 text-blue-800'
+        : color === 'warning'
+          ? 'bg-yellow-100 text-yellow-800'
+          : color === 'error'
+            ? 'bg-red-100 text-red-800'
+            : 'bg-gray-100 text-gray-800';
+  const sizeClass = size === 'sm' ? 'text-xs' : 'text-sm';
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 font-medium ${sizeClass} ${colorClass} ${className}`}
+    >
+      {children}
+    </span>
+  );
 };
 
 export default StatusLabel;

--- a/components/pages/ProfilePage.tsx
+++ b/components/pages/ProfilePage.tsx
@@ -127,15 +127,23 @@ const ProfilePage: React.FC = () => {
           </div>
           <div>
             <h1 className="text-2xl font-bold">{renderValue(fullName)}</h1>
-            <p className="text-gray-600">{renderValue(profile?.email || user.email)}</p>
-            <div className="flex gap-2 mt-2">
+            <p className="text-gray-600">
+              {renderValue(profile?.email || user.email)}
+            </p>
+            <div className="flex gap-1 mt-2">
               {profile && (
-                <StatusLabel color={profile.verified ? 'success' : 'default'} size="sm">
+                <StatusLabel
+                  color={profile.verified ? 'success' : 'default'}
+                  size="sm"
+                >
                   {profile.verified ? 'Verified' : 'Not verified'}
                 </StatusLabel>
               )}
               {profile && (
-                <StatusLabel color={profile.disabled ? 'error' : 'success'} size="sm">
+                <StatusLabel
+                  color={profile.disabled ? 'error' : 'success'}
+                  size="sm"
+                >
                   {profile.disabled ? 'Disabled' : 'Active'}
                 </StatusLabel>
               )}
@@ -144,8 +152,8 @@ const ProfilePage: React.FC = () => {
                   {profile.role === UserRole.BRAND
                     ? 'Brand Admin'
                     : profile.role === UserRole.SUPER_ADMIN
-                    ? 'Admin'
-                    : 'Customer'}
+                      ? 'Admin'
+                      : 'Customer'}
                 </StatusLabel>
               )}
             </div>
@@ -157,7 +165,10 @@ const ProfilePage: React.FC = () => {
               Upload
             </button>
           )}
-          <Link href="/settings" className="btn btn-primary btn-sm sm:btn">
+          <Link
+            href="/settings"
+            className="px-4 py-2 font-semibold text-white bg-indigo-600 rounded-md hover:bg-indigo-700"
+          >
             Edit Profile
           </Link>
         </div>
@@ -206,7 +217,8 @@ const ProfilePage: React.FC = () => {
               Account Info
             </h2>
             {renderRow('Role', profile?.role)}
-            {profile?.role === UserRole.BRAND && renderRow('Tax ID', profile?.taxId)}
+            {profile?.role === UserRole.BRAND &&
+              renderRow('Tax ID', profile?.taxId)}
             {renderRow('Last updated', lastUpdated)}
           </div>
         </section>


### PR DESCRIPTION
## Summary
- restyle StatusLabel component with rounded pills
- adjust profile status tags layout
- update Edit Profile button styling

## Testing
- `npx prettier --write components/UI/StatusLabel.tsx components/pages/ProfilePage.tsx`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677f1cf314832f8b229150e7040667