### PR TITLE
Add profile picture uploader to settings

### DIFF
--- a/components/ProfileAvatarUploader.tsx
+++ b/components/ProfileAvatarUploader.tsx
@@ -1,0 +1,133 @@
+import { useState, useRef, useEffect, useContext } from 'react';
+import useRequireAuth from '@hooks/useRequireAuth';
+import { NotificationContext } from '@contexts/NotificationContext';
+import type { User } from '@/types';
+
+const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+
+const ProfileAvatarUploader: React.FC = () => {
+  const user = useRequireAuth();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const { addNotification } = useContext(NotificationContext);
+  const [current, setCurrent] = useState<string | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    fetch('/api/user/profile')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: User | null) => {
+        if (data?.profileImage) setCurrent(data.profileImage);
+      })
+      .catch(() => {});
+  }, []);
+
+  if (!user) return null;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    if (!allowedTypes.includes(f.type)) {
+      addNotification('Only JPG, PNG or WebP images allowed', 'error');
+      return;
+    }
+    if (f.size > 2 * 1024 * 1024) {
+      addNotification('File must be under 2MB', 'error');
+      return;
+    }
+    setFile(f);
+    setPreview(URL.createObjectURL(f));
+  };
+
+  const upload = async () => {
+    if (!file) return;
+    const form = new FormData();
+    form.append('profileImage', file);
+    const res = await fetch('/api/user/profile-picture', {
+      method: 'PATCH',
+      body: form,
+    });
+    if (res.ok) {
+      setFile(null);
+      setPreview(null);
+      const data = await res.json().catch(() => null);
+      setCurrent(data?.profileImage || null);
+      addNotification('Profile image updated', 'success');
+    } else {
+      addNotification('Upload failed', 'error');
+    }
+  };
+
+  const remove = async () => {
+    const res = await fetch('/api/user/profile-picture', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ remove: true }),
+    });
+    if (res.ok) {
+      setCurrent(null);
+      setPreview(null);
+      addNotification('Profile image removed', 'success');
+    } else {
+      addNotification('Remove failed', 'error');
+    }
+  };
+
+  const initials = `${(user.firstName?.[0] || '').toUpperCase()}${(user.lastName?.[0] || '').toUpperCase()}`;
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className="relative cursor-pointer"
+        onClick={() => inputRef.current?.click()}
+      >
+        {preview ? (
+          <img
+            src={preview}
+            alt="preview"
+            className="w-24 h-24 rounded-full object-cover"
+          />
+        ) : current ? (
+          <img
+            src={current}
+            alt="avatar"
+            className="w-24 h-24 rounded-full object-cover"
+          />
+        ) : (
+          <div className="w-24 h-24 rounded-full bg-gray-300 flex items-center justify-center text-white font-semibold text-xl">
+            {initials}
+          </div>
+        )}
+        <input
+          type="file"
+          ref={inputRef}
+          accept="image/jpeg,image/png,image/webp"
+          className="hidden"
+          onChange={handleChange}
+        />
+      </div>
+      {preview ? (
+        <div className="flex gap-2">
+          <button onClick={upload} className="btn btn-primary btn-sm">
+            Save
+          </button>
+          <button
+            onClick={() => {
+              setPreview(null);
+              setFile(null);
+            }}
+            className="btn btn-sm"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : current ? (
+        <button onClick={remove} className="btn btn-sm">
+          Remove
+        </button>
+      ) : null}
+    </div>
+  );
+};
+
+export default ProfileAvatarUploader;

--- a/components/Settings/UpdateProfileSection.tsx
+++ b/components/Settings/UpdateProfileSection.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { TextInput, EmailInput } from '@components/form-fields';
 import { NotificationContext } from '@contexts/NotificationContext';
+import ProfileAvatarUploader from '@components/ProfileAvatarUploader';
 
 interface ProfileFormValues {
   firstName: string;
@@ -49,9 +50,12 @@ const UpdateProfileSection: React.FC = () => {
   return (
     <form
       onSubmit={profileForm.handleSubmit(submitProfile)}
-      className="space-y-2 max-w-md mx-auto"
+      className="space-y-4 max-w-md mx-auto"
     >
       <h2 className="text-xl font-bold mb-2">Update Profile</h2>
+      <div className="flex justify-center">
+        <ProfileAvatarUploader />
+      </div>
       <TextInput
         label="First Name"
         register={profileForm.register}

--- a/pages/api/user/profile-picture.ts
+++ b/pages/api/user/profile-picture.ts
@@ -1,0 +1,88 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { updateUserProfile } from '@lib/users';
+import { uploadFileToS3 } from '@lib/s3';
+import { handleApiError } from '@utils/handleApiError';
+import formidable, { type Fields, type Files, type File } from 'formidable';
+import {
+  METHOD_NOT_ALLOWED,
+  UNAUTHORIZED,
+  UPDATED,
+} from '@/constants/messages';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function parseBody(
+  req: NextApiRequest
+): Promise<{ fields: Fields; files: Files }> {
+  const type = req.headers['content-type'] || '';
+  if (type.includes('application/json')) {
+    const buffers: Uint8Array[] = [];
+    for await (const chunk of req) buffers.push(chunk);
+    const body = Buffer.concat(buffers).toString();
+    return { fields: JSON.parse(body || '{}') as Fields, files: {} as Files };
+  }
+  return new Promise<{ fields: Fields; files: Files }>((resolve, reject) => {
+    const form = formidable({ multiples: true });
+    form.parse(req, (err, fields, files) => {
+      if (err) reject(err);
+      else resolve({ fields, files });
+    });
+  });
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  try {
+    if (req.method !== 'PATCH')
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
+
+    const { fields, files } = await parseBody(req);
+    const remove = fields.remove === 'true';
+    const update: any = {};
+
+    const profileImageFile = files.profileImage as File | File[] | undefined;
+    if (profileImageFile) {
+      const file = Array.isArray(profileImageFile)
+        ? profileImageFile[0]
+        : profileImageFile;
+      if (
+        file.mimetype &&
+        !['image/jpeg', 'image/png', 'image/webp'].includes(file.mimetype)
+      ) {
+        return res
+          .status(400)
+          .json({ message: 'Only JPG/PNG/WebP images are allowed' });
+      }
+      if (file.size && file.size > 2 * 1024 * 1024) {
+        return res.status(400).json({ message: 'File size exceeds 2MB' });
+      }
+      const name = Date.now() + '-' + (file.originalFilename || 'avatar');
+      const key = `users/${session.user.id}/${name}`;
+      const url = await uploadFileToS3(
+        file.filepath,
+        key,
+        file.mimetype || undefined
+      );
+      update.profileImage = url;
+    } else if (remove) {
+      update.profileImage = null;
+    } else {
+      return res.status(400).json({ message: 'No image provided' });
+    }
+
+    await updateUserProfile(session.user.email, update);
+    return res.status(200).json({ message: UPDATED, profileImage: update.profileImage });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to update profile picture');
+  }
+}


### PR DESCRIPTION
## Summary
- upload and remove profile pictures from settings
- show avatar uploader UI on the Update Profile tab
- support PATCH `/api/user/profile-picture` for avatar updates

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867832a896c832fba861c3d1ccde75c