### PR TITLE
Add user profile sections

### DIFF
--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -148,6 +148,13 @@ const Header: FC<HeaderProps> = ({
   const menuItems = [
     { label: 'My Orders', href: '/orders' },
     { label: 'Profile', href: '/profile' },
+    { label: 'Reviews', href: '/user/reviews' },
+    { label: 'Coupons', href: '/user/coupons' },
+    { label: 'Credit', href: '/user/credit' },
+    { label: 'Stores', href: '/user/stores' },
+    { label: 'History', href: '/user/history' },
+    { label: 'Notifications', href: '/user/notifications' },
+    { label: 'Permissions', href: '/user/permissions' },
     { label: 'Settings', href: '/settings' },
     { label: 'Logout', onClick: logout, isButton: true },
   ];

--- a/components/User/ProfileSidebar.tsx
+++ b/components/User/ProfileSidebar.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+
+interface ProfileSidebarProps {
+  active: string;
+}
+
+const links = [
+  { href: '/user/profile', label: 'Profile' },
+  { href: '/user/orders', label: 'Orders' },
+  { href: '/user/wishlist', label: 'Wishlist' },
+  { href: '/user/reviews', label: 'Your Reviews' },
+  { href: '/user/coupons', label: 'Coupons & Offers' },
+  { href: '/user/credit', label: 'Credit Balance' },
+  { href: '/user/stores', label: 'Followed Stores' },
+  { href: '/user/history', label: 'Browsing History' },
+  { href: '/user/notifications', label: 'Notifications' },
+  { href: '/user/permissions', label: 'Permissions' },
+];
+
+const ProfileSidebar: React.FC<ProfileSidebarProps> = ({ active }) => {
+  const linkClass = (href: string) =>
+    `block px-2 py-2 rounded transition-colors hover:bg-base-200 ${
+      active === href ? 'text-primary underline font-semibold' : ''
+    }`;
+  return (
+    <aside className="md:w-48 w-full">
+      <ul className="menu menu-vertical bg-base-100 rounded-box p-2 space-y-1">
+        {links.map((link) => (
+          <li key={link.href}>
+            <Link href={link.href} className={linkClass(link.href)}>
+              {link.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+};
+
+export default ProfileSidebar;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -78,3 +78,8 @@ export function getAverageRating(productId: string): {
   const sum = reviews.reduce((acc, r) => acc + r.rating, 0);
   return { average: sum / reviews.length, count: reviews.length };
 }
+
+export function getReviewsByUser(email: string): Review[] {
+  const all = Array.from(reviewsStore.values()).flat();
+  return all.filter((r) => r.userEmail === email);
+}

--- a/pages/api/user/coupons.ts
+++ b/pages/api/user/coupons.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+import type { Coupon, ApiMessage } from '@/types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
+
+const sample: Coupon[] = [
+  { code: 'WELCOME10', discountType: 'percent', amount: 10 },
+  { code: 'FREESHIP', discountType: 'amount', amount: 5 },
+];
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Coupon[] | ApiMessage>
+): Promise<void> {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
+  if (req.method !== 'GET')
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
+  res.status(200).json(sample);
+}

--- a/pages/api/user/credit.ts
+++ b/pages/api/user/credit.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
+
+const balanceStore = new Map<string, { balance: number; history: { amount: number; date: string; type: string }[] }>();
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<any>
+): Promise<void> {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
+
+  if (req.method !== 'GET')
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
+
+  if (!balanceStore.has(session.user.email))
+    balanceStore.set(session.user.email, { balance: 0, history: [] });
+
+  res.status(200).json(balanceStore.get(session.user.email));
+}

--- a/pages/api/user/history.ts
+++ b/pages/api/user/history.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
+
+const history: Record<string, { id: string; title: string }[]> = {};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<any>
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
+  if (req.method !== 'GET')
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
+  res.status(200).json(history[session.user.email] || []);
+}

--- a/pages/api/user/notifications.ts
+++ b/pages/api/user/notifications.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+import {
+  getNotificationsForUser,
+  markNotificationsRead,
+} from '@lib/notifications';
+import { findUser } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
+import type { Notification, ApiMessage } from '@/types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED, USER_NOT_FOUND } from '@/constants/messages';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Notification[] | ApiMessage>
+): Promise<void> {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
+    const user = await findUser(session.user.email);
+    if (!user) return res.status(404).json({ message: USER_NOT_FOUND });
+
+    if (req.method === 'GET') {
+      const notes = await getNotificationsForUser(user.id);
+      return res.status(200).json(notes);
+    }
+
+    if (req.method === 'PATCH') {
+      await markNotificationsRead(user.id);
+      const notes = await getNotificationsForUser(user.id);
+      return res.status(200).json(notes);
+    }
+
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
+  } catch (error) {
+    return handleApiError(res, error, 'Failed to manage notifications');
+  }
+}

--- a/pages/api/user/permissions.ts
+++ b/pages/api/user/permissions.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<any>
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
+  if (req.method !== 'GET')
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED });
+  res.status(200).json({});
+}

--- a/pages/api/user/reviews.ts
+++ b/pages/api/user/reviews.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { getReviewsByUser } from '@lib/db';
+import type { Review, ApiMessage } from '@/types';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Review[] | ApiMessage>
+): Promise<void> {
+  try {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED });
+
+    if (req.method !== 'GET')
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
+
+    const reviews = getReviewsByUser(session.user.email);
+    return res.status(200).json(reviews);
+  } catch (err) {
+    res.status(500).json({ message: 'Failed to fetch reviews' });
+  }
+}

--- a/pages/api/user/stores.ts
+++ b/pages/api/user/stores.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
+
+const storeFollow: Record<string, string[]> = {};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<string[]>
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user) return res.status(401).json({ message: UNAUTHORIZED } as any);
+  if (req.method !== 'GET')
+    return res.status(405).json({ message: METHOD_NOT_ALLOWED } as any);
+  const stores = storeFollow[session.user.email] || [];
+  res.status(200).json(stores);
+}

--- a/pages/user/coupons.tsx
+++ b/pages/user/coupons.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { getPageTitle } from '@lib/pageTitle';
+import type { Coupon } from '@/types';
+
+const UserCoupons: React.FC = () => {
+  const [coupons, setCoupons] = useState<Coupon[]>([]);
+  useEffect(() => {
+    fetch('/api/user/coupons')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setCoupons(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Coupons & Offers')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Coupons & Offers</h1>
+      <ul className="space-y-2">
+        {coupons.map((c) => (
+          <li key={c.code} className="border p-2">
+            <p className="font-semibold">{c.code}</p>
+            <p>
+              {c.discountType === 'percent' ? `${c.amount}% off` : `£${c.amount} off`}
+            </p>
+          </li>
+        ))}
+        {coupons.length === 0 && <li>No coupons available.</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default UserCoupons;

--- a/pages/user/credit.tsx
+++ b/pages/user/credit.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { getPageTitle } from '@lib/pageTitle';
+
+interface CreditData {
+  balance: number;
+  history: { amount: number; date: string; type: string }[];
+}
+
+const CreditBalance: React.FC = () => {
+  const [credit, setCredit] = useState<CreditData>({ balance: 0, history: [] });
+  useEffect(() => {
+    fetch('/api/user/credit')
+      .then((res) => (res.ok ? res.json() : { balance: 0, history: [] }))
+      .then((data) => setCredit(data))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Credit Balance')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Credit Balance</h1>
+      <p className="mb-2">Current Balance: £{credit.balance.toFixed(2)}</p>
+      <ul className="space-y-2">
+        {credit.history.map((h, idx) => (
+          <li key={idx} className="border p-2">
+            <span className="mr-2">{h.date}</span>
+            {h.type} £{h.amount}
+          </li>
+        ))}
+        {credit.history.length === 0 && <li>No history available.</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default CreditBalance;

--- a/pages/user/history.tsx
+++ b/pages/user/history.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { getPageTitle } from '@lib/pageTitle';
+
+interface HistoryItem {
+  id: string;
+  title: string;
+}
+
+const BrowsingHistory: React.FC = () => {
+  const [items, setItems] = useState<HistoryItem[]>([]);
+  useEffect(() => {
+    fetch('/api/user/history')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setItems(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Browsing History')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Browsing History</h1>
+      <ul className="space-y-2">
+        {items.map((i) => (
+          <li key={i.id} className="border p-2">
+            {i.title}
+          </li>
+        ))}
+        {items.length === 0 && <li>No history available.</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default BrowsingHistory;

--- a/pages/user/notifications.tsx
+++ b/pages/user/notifications.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { getPageTitle } from '@lib/pageTitle';
+import type { Notification } from '@/types';
+
+const UserNotifications: React.FC = () => {
+  const [notes, setNotes] = useState<Notification[]>([]);
+  useEffect(() => {
+    fetch('/api/user/notifications')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setNotes(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Notifications')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Notifications</h1>
+      <ul className="space-y-2">
+        {notes.map((n) => (
+          <li key={n.id} className="border p-2">
+            {n.message}
+          </li>
+        ))}
+        {notes.length === 0 && <li>No notifications.</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default UserNotifications;

--- a/pages/user/permissions.tsx
+++ b/pages/user/permissions.tsx
@@ -1,0 +1,14 @@
+import Head from 'next/head';
+import { getPageTitle } from '@lib/pageTitle';
+
+const Permissions: React.FC = () => (
+  <div className="max-w-2xl mx-auto">
+    <Head>
+      <title>{getPageTitle('Permissions')}</title>
+    </Head>
+    <h1 className="text-2xl font-bold mb-4">Permissions</h1>
+    <p>Manage your permissions and marketing preferences here.</p>
+  </div>
+);
+
+export default Permissions;

--- a/pages/user/reviews.tsx
+++ b/pages/user/reviews.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { getPageTitle } from '@lib/pageTitle';
+import type { Review } from '@/types';
+
+const UserReviews: React.FC = () => {
+  const [reviews, setReviews] = useState<Review[]>([]);
+  useEffect(() => {
+    fetch('/api/user/reviews')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setReviews(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Your Reviews')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Your Reviews</h1>
+      <ul className="space-y-2">
+        {reviews.map((r, idx) => (
+          <li key={idx} className="border p-2">
+            <p className="font-semibold">Product: {r.productId}</p>
+            <p>Rating: {r.rating}</p>
+            <p className="text-sm text-gray-600">{r.comment}</p>
+          </li>
+        ))}
+        {reviews.length === 0 && <li>No reviews yet.</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default UserReviews;

--- a/pages/user/stores.tsx
+++ b/pages/user/stores.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { getPageTitle } from '@lib/pageTitle';
+
+const FollowedStores: React.FC = () => {
+  const [stores, setStores] = useState<string[]>([]);
+  useEffect(() => {
+    fetch('/api/user/stores')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setStores(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <Head>
+        <title>{getPageTitle('Followed Stores')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Followed Stores</h1>
+      <ul className="space-y-2">
+        {stores.map((s) => (
+          <li key={s} className="border p-2">
+            {s}
+          </li>
+        ))}
+        {stores.length === 0 && <li>No followed stores.</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default FollowedStores;


### PR DESCRIPTION
## Summary
- add ProfileSidebar component with additional navigation links
- create pages for reviews, coupons, credit, stores, browsing history, notifications and permissions
- implement matching API routes with placeholder data
- extend user dropdown menu with new sections
- expose helper to fetch reviews by user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686783e3457c832fb16da722c19919aa