### PR TITLE
Add fetchJsonSafe helper and refactor API calls

### DIFF
--- a/components/ProfileAvatarUploader.tsx
+++ b/components/ProfileAvatarUploader.tsx
@@ -1,5 +1,6 @@
 import { apiFetch } from '@lib/api';
 import { useState, useRef, useEffect, useContext } from 'react';
+import { fetchJsonSafe } from '@utils/fetchJson';
 import useRequireAuth from '@hooks/useRequireAuth';
 import { NotificationContext } from '@contexts/NotificationContext';
 import type { User } from '@/types';
@@ -15,12 +16,10 @@ const ProfileAvatarUploader: React.FC = () => {
   const [file, setFile] = useState<File | null>(null);
 
   useEffect(() => {
-    apiFetch('/api/user/profile')
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data: User | null) => {
+    fetchJsonSafe<User | null>('/api/user/profile', null)
+      .then((data) => {
         if (data?.profileImage) setCurrent(data.profileImage);
-      })
-      .catch(() => {});
+      });
   }, []);
 
   if (!user) return null;

--- a/components/form-fields/AddressAutocomplete.tsx
+++ b/components/form-fields/AddressAutocomplete.tsx
@@ -1,4 +1,5 @@
 import { apiFetch } from '@lib/api';
+import { fetchJsonSafe } from '@utils/fetchJson';
 import React, { useState, useEffect } from 'react';
 
 interface Suggestion {
@@ -22,12 +23,13 @@ const AddressAutocomplete: React.FC<Props> = ({
   useEffect(() => {
     if (!value) return setSuggestions([]);
     const controller = new AbortController();
-    apiFetch(`/api/address-autocomplete?input=${encodeURIComponent(value)}`, {
-      signal: controller.signal,
-    })
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data) => setSuggestions(data.predictions || []))
-      .catch(() => {});
+    fetchJsonSafe<{ predictions: Suggestion[] }>(
+      `/api/address-autocomplete?input=${encodeURIComponent(value)}`,
+      { predictions: [] },
+      {
+        signal: controller.signal,
+      }
+    ).then((data) => setSuggestions(data.predictions || []));
     return () => controller.abort();
   }, [value]);
 

--- a/lib/utils/fetchJson.ts
+++ b/lib/utils/fetchJson.ts
@@ -9,3 +9,15 @@ export async function fetchJson<T>(
   }
   return res.json() as Promise<T>;
 }
+
+export async function fetchJsonSafe<T>(
+  input: RequestInfo | URL,
+  fallback: T,
+  init?: RequestInit
+): Promise<T> {
+  try {
+    return await fetchJson<T>(input, init);
+  } catch {
+    return fallback;
+  }
+}

--- a/pages/admin/coupons.tsx
+++ b/pages/admin/coupons.tsx
@@ -1,4 +1,5 @@
 import { apiFetch } from '@lib/api';
+import { fetchJsonSafe } from '@utils/fetchJson';
 import { useEffect, useState, useContext, ChangeEvent } from 'react';
 import Head from 'next/head';
 import { AppContext } from '@contexts/AppContext';
@@ -19,10 +20,8 @@ export default function AdminCoupons() {
   const [message, setMessage] = useState('');
 
   const fetchCoupons = () => {
-    apiFetch('/api/admin/coupons')
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data: Coupon[]) => setCoupons(data))
-      .catch(() => setCoupons([]));
+    fetchJsonSafe<Coupon[]>('/api/admin/coupons', [])
+      .then((data) => setCoupons(data));
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add new `fetchJsonSafe` helper for error tolerant API calls
- refactor several components/pages to use the new helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686787be9000832fbb06e48a48ecb19f