### PR TITLE
Centralize some API utilities

### DIFF
--- a/components/Layout/SearchBar.tsx
+++ b/components/Layout/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { apiFetch } from '@lib/api';
+import { getTrending, getSuggestions } from '@lib/api/search';
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
@@ -45,13 +45,8 @@ const SearchBar: FC<SearchBarProps> = ({
 
   useEffect(() => {
     if (showTrending) {
-      apiFetch('/api/trending')
-        .then((res) =>
-          res.ok ? (res.json() as Promise<TrendingResponse>) : null
-        )
-        .then((data) => {
-          if (data && Array.isArray(data.keywords)) setTrending(data.keywords);
-        })
+      getTrending()
+        .then((keywords) => setTrending(keywords))
         .catch(() => {});
     }
   }, [showTrending]);
@@ -64,14 +59,9 @@ const SearchBar: FC<SearchBarProps> = ({
     }
     if (suggestTimeout.current) clearTimeout(suggestTimeout.current);
     suggestTimeout.current = setTimeout(() => {
-      apiFetch(`/api/suggest?q=${encodeURIComponent(query)}`)
-        .then((res) =>
-          res.ok ? (res.json() as Promise<SuggestionsResponse>) : null
-        )
-        .then((data) => {
-          if (data && Array.isArray(data.suggestions))
-            setSuggestions(data.suggestions);
-          else setSuggestions([]);
+      getSuggestions(query)
+        .then((sugs) => {
+          setSuggestions(sugs);
           setSelectedIdx(-1);
         })
         .catch(() => setSuggestions([]));

--- a/components/form-fields/TagInput.tsx
+++ b/components/form-fields/TagInput.tsx
@@ -1,4 +1,4 @@
-import { apiFetch } from '@lib/api';
+import { searchTags } from '@lib/api/tags';
 import React from 'react';
 import {
   Controller,
@@ -31,11 +31,8 @@ const TagInput = <T extends FieldValues>(props: TagInputProps<T>) => {
   } = props;
 
   const loadOptions = async (inputValue: string) => {
-    const params = new URLSearchParams({ search: inputValue });
-    const res = await apiFetch(`/api/tags?${params.toString()}`);
-    if (!res.ok) return [];
-    const data = await res.json();
-    return (data.tags || []).map((t: string) => ({ label: t, value: t }));
+    const tags = await searchTags(inputValue);
+    return tags.map((t) => ({ label: t, value: t }));
   };
 
   return (

--- a/lib/api/search.ts
+++ b/lib/api/search.ts
@@ -1,0 +1,13 @@
+import { apiFetch } from '../api';
+import type { TrendingResponse, SuggestionsResponse } from '@/types';
+
+export async function getTrending(): Promise<string[]> {
+  const data = await apiFetch<TrendingResponse>('/api/trending');
+  return Array.isArray(data.keywords) ? data.keywords : [];
+}
+
+export async function getSuggestions(query: string): Promise<string[]> {
+  const params = new URLSearchParams({ q: query });
+  const data = await apiFetch<SuggestionsResponse>(`/api/suggest?${params.toString()}`);
+  return Array.isArray(data.suggestions) ? data.suggestions : [];
+}

--- a/lib/api/tags.ts
+++ b/lib/api/tags.ts
@@ -1,0 +1,7 @@
+import { apiFetch } from '../api';
+
+export async function searchTags(query: string): Promise<string[]> {
+  const params = new URLSearchParams({ search: query });
+  const data = await apiFetch<{ tags: string[] }>(`/api/tags?${params.toString()}`);
+  return Array.isArray(data.tags) ? data.tags : [];
+}

--- a/lib/api/user.ts
+++ b/lib/api/user.ts
@@ -1,0 +1,19 @@
+import { apiFetch } from '../api';
+import type { Order } from '@/types';
+
+export async function fetchUserOrders(): Promise<Order[]> {
+  return apiFetch<Order[]>('/api/user/orders');
+}
+
+export async function reorderOrder(uuid: string): Promise<void> {
+  await apiFetch(`/api/user/orders/${uuid}/reorder`, { method: 'POST' });
+}
+
+export async function updateUserProfile(data: Record<string, unknown>): Promise<boolean> {
+  await apiFetch('/api/user/profile', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return true;
+}

--- a/pages/user/orders.tsx
+++ b/pages/user/orders.tsx
@@ -1,4 +1,4 @@
-import { apiFetch } from '@lib/api';
+import { fetchUserOrders, reorderOrder } from '@lib/api/user';
 import { useContext, useEffect, useState } from 'react';
 import { AppContext } from '@contexts/AppContext';
 import type { Order } from '@/types';
@@ -13,9 +13,8 @@ const UserOrders: React.FC = () => {
   useEffect(() => {
     if (!user) return;
     setLoading(true);
-    apiFetch('/api/user/orders')
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data: Order[]) => {
+    fetchUserOrders()
+      .then((data) => {
         setOrders(data);
         setError(null);
       })
@@ -74,9 +73,9 @@ const UserOrders: React.FC = () => {
               <button
                 className="btn btn-sm"
                 onClick={() =>
-                  apiFetch(`/api/user/orders/${o.uuid}/reorder`, {
-                    method: 'POST',
-                  }).then(() => window.location.assign('/cart'))
+                  reorderOrder(o.uuid).then(() =>
+                    window.location.assign('/cart')
+                  )
                 }
               >
                 Reorder

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -1,4 +1,4 @@
-import { apiFetch } from '@lib/api';
+import { updateUserProfile } from '@lib/api/user';
 import React, { useContext, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { CountrySelect } from '@components/form-fields';
@@ -53,13 +53,12 @@ export const UserProfile: React.FC = () => {
 
   const submit: SubmitHandler<ProfileForm> = async (data) => {
     setMessage('');
-    const res = await apiFetch('/api/user/profile', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
-    if (res.ok) setMessage('Profile updated');
-    else setMessage('Update failed');
+    try {
+      await updateUserProfile(data);
+      setMessage('Profile updated');
+    } catch {
+      setMessage('Update failed');
+    }
   };
 
   if (!user) return <div className="p-4">Please log in.</div>;


### PR DESCRIPTION
## Summary
- add api modules for tags, search and user actions
- refactor TagInput to use `searchTags`
- refactor SearchBar to use search api helpers
- refactor user profile and orders pages to use user api helpers

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 12 passed, 13 total)*

------
https://chatgpt.com/codex/tasks/task_e_686788ddb078832fb1d7cddcb8e11906