### PR TITLE
Fix role comparison after Google signup

### DIFF
--- a/pages/orders/[orderId].tsx
+++ b/pages/orders/[orderId].tsx
@@ -20,7 +20,7 @@ export default function OrderDetail() {
   useEffect(() => {
     if (!orderId) return;
     const endpoint =
-      user?.role === UserRole.USER
+      user?.role?.toUpperCase() === UserRole.USER
         ? `/api/user/orders/${orderId}`
         : `/api/orders/${orderId}`;
     setLoading(true);

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -62,7 +62,7 @@ export const UserProfile: React.FC = () => {
   };
 
   if (!user) return <div className="p-4">Please log in.</div>;
-  if (user.role !== UserRole.USER)
+  if (user.role?.toUpperCase() !== UserRole.USER)
     return <div className="p-4">User access required.</div>;
 
   return (


### PR DESCRIPTION
## Summary
- ensure role comparison isn't case-sensitive when viewing user pages

## Testing
- `npx jest --runInBand` *(fails: Test Suites: 1 failed, 12 passed, 13 total)*

------
https://chatgpt.com/codex/tasks/task_e_6868f7564198832f860cecc50c911a82