### PR TITLE
Add super admin user management

### DIFF
--- a/lib/auth/checkSuperAdmin.ts
+++ b/lib/auth/checkSuperAdmin.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@pages/api/auth/[...nextauth]';
+
+export async function checkSuperAdmin(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<boolean> {
+  const session = await getServerSession(req, res, authOptions(req, res));
+  return session?.user?.role === 'SUPER_ADMIN';
+}

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -66,6 +66,7 @@ export function findUserById(id: number | string) {
 export function getAllUsers() {
   return prisma.user.findMany({
     select: {
+      id: true,
       email: true,
       firstName: true,
       lastName: true,
@@ -87,6 +88,10 @@ export function setUserDisabled(email: string, disabled: boolean) {
 
 export function deleteUser(email: string) {
   return prisma.user.delete({ where: { email } });
+}
+
+export function deleteUserById(id: number) {
+  return prisma.user.delete({ where: { id } });
 }
 
 export function verifyUser(token: string) {

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -26,7 +26,7 @@ export default function ManageUsers() {
   }, [fetchUsers]);
 
   const changeRole = async (email: string, role: string) => {
-    const payload: UserRoleUpdateRequest = { email, role };
+    const payload: UserRoleUpdateRequest = { email, role: role.toUpperCase() };
     await fetchJson<ApiMessage>('/api/admin/users', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -47,11 +47,11 @@ export default function ManageUsers() {
     fetchUsers();
   };
 
-  const remove = async (email: string) => {
-    await fetchJson<ApiMessage>(
-      `/api/admin/users?email=${encodeURIComponent(email)}`,
-      { method: 'DELETE' }
-    );
+  const remove = async (id: number, email: string) => {
+    if (!confirm(`Delete user ${email}?`)) return;
+    await fetchJson<ApiMessage>(`/api/admin/users/${id}`, {
+      method: 'DELETE',
+    });
     setMessage('User deleted');
     fetchUsers();
   };
@@ -69,12 +69,18 @@ export default function ManageUsers() {
       {message && <div className="mb-4 text-green-600">{message}</div>}
       <ul className="space-y-2">
         {users.map((u) => (
-          <li key={u.email} className="flex items-center gap-2">
-            <span className="flex-1">{u.email}</span>
+          <li key={u.id} className="flex items-center gap-2">
+            <span className="flex-1">
+              {u.email}
+              {u.role === 'SUPER_ADMIN' && (
+                <span className="ml-2 badge badge-secondary">Super Admin</span>
+              )}
+            </span>
             <select
               className="select select-bordered"
-              value={u.role}
+              value={u.role.toLowerCase()}
               onChange={(e) => changeRole(u.email, e.target.value)}
+              disabled={u.role === 'SUPER_ADMIN'}
             >
               <option value="user">user</option>
               <option value="brand">brand</option>
@@ -87,9 +93,14 @@ export default function ManageUsers() {
                 className="checkbox"
                 checked={u.disabled}
                 onChange={(e) => toggleDisabled(u.email, e.target.checked)}
+                disabled={u.role === 'SUPER_ADMIN'}
               />
             </label>
-            <button onClick={() => remove(u.email)} className="btn btn-sm">
+            <button
+              onClick={() => remove(u.id, u.email)}
+              className="btn btn-sm"
+              disabled={u.role === 'SUPER_ADMIN'}
+            >
               Delete
             </button>
           </li>

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -5,6 +5,7 @@ import {
   deleteUser,
   addUser,
   setUserDisabled,
+  findUser,
 } from '@lib/users';
 import type { Role } from '@prisma/client';
 import { withRole } from '@lib/withRole';
@@ -37,6 +38,10 @@ async function handler(
       const { email, role } = req.body as UserRoleUpdateRequest;
       if (!email || !role)
         return res.status(400).json({ message: 'email and role required' });
+      const target = await findUser(email);
+      if (target?.role === 'SUPER_ADMIN') {
+        return res.status(403).json({ message: 'cannot modify super admin' });
+      }
       await updateUserRole(email, role as Role);
       res.status(200).json({ message: 'role updated' });
       return;
@@ -45,6 +50,10 @@ async function handler(
       const { email, disabled } = req.body as UserDisabledUpdateRequest;
       if (typeof disabled !== 'boolean' || !email)
         return res.status(400).json({ message: 'email and disabled required' });
+      const target = await findUser(email);
+      if (target?.role === 'SUPER_ADMIN') {
+        return res.status(403).json({ message: 'cannot modify super admin' });
+      }
       await setUserDisabled(email, disabled);
       res.status(200).json({ message: 'status updated' });
       return;
@@ -52,6 +61,10 @@ async function handler(
     if (req.method === 'DELETE') {
       const email = getQueryParam(req.query.email);
       if (!email) return res.status(400).json({ message: EMAIL_REQUIRED });
+      const target = await findUser(email);
+      if (target?.role === 'SUPER_ADMIN') {
+        return res.status(403).json({ message: 'cannot delete super admin' });
+      }
       await deleteUser(email);
       res.status(200).json({ message: 'user deleted' });
       return;

--- a/pages/api/admin/users/[id].ts
+++ b/pages/api/admin/users/[id].ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { deleteUserById, findUserById } from '@lib/users';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import { ID_REQUIRED, METHOD_NOT_ALLOWED } from '@/constants/messages';
+import type { ApiMessage } from '@/types';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'DELETE') {
+      return res.status(405).json({ message: METHOD_NOT_ALLOWED });
+    }
+    const idParam = req.query.id as string | undefined;
+    if (!idParam) return res.status(400).json({ message: ID_REQUIRED });
+    const id = parseInt(idParam, 10);
+    if (isNaN(id)) return res.status(400).json({ message: ID_REQUIRED });
+
+    const target = await findUserById(id);
+    if (target?.role === 'SUPER_ADMIN') {
+      return res.status(403).json({ message: 'cannot delete super admin' });
+    }
+
+    await deleteUserById(id);
+    return res.status(200).json({ message: 'user deleted' });
+  } catch (e) {
+    return handleApiError(res, e, 'Failed to delete user');
+  }
+}
+
+export default withRole(['SUPER_ADMIN'])(handler);

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,33 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const email = process.env.SUPER_ADMIN_EMAIL || 'admin@example.com';
+  const password = process.env.SUPER_ADMIN_PASSWORD || 'admin123';
+  const hashed = await bcrypt.hash(password, 10);
+
+  await prisma.user.upsert({
+    where: { email },
+    update: {},
+    create: {
+      email,
+      password: hashed,
+      firstName: 'Super',
+      lastName: 'Admin',
+      gender: 'OTHER',
+      role: 'SUPER_ADMIN',
+      verified: true,
+    },
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -1,4 +1,5 @@
 export interface AdminUser {
+  id: number;
   email: string;
   firstName?: string;
   lastName?: string;


### PR DESCRIPTION
## Summary
- seed a SUPER_ADMIN account
- expose super admin check helper
- return user IDs for admin use
- block changes on the SUPER_ADMIN account
- add `/api/admin/users/[id]` delete route
- update user management UI to use new API and show badge

## Testing
- `npm run type-check` *(fails: Could not find prisma binaries & many TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68690324af38832f85762d84c1d3cf6a