### PR TITLE
Add admin options to user menu

### DIFF
--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -163,6 +163,11 @@ const Header: FC<HeaderProps> = ({
   const itemCount = cart.reduce((sum, item) => sum + (item.qty || 0), 0);
   const logout = () => signOut({ callbackUrl: '/', redirect: true });
 
+  const isSuperAdmin =
+    user &&
+    user.role &&
+    user.role.toLowerCase().replace('_', '-') === 'super-admin';
+
   const menuItems = [
     { label: 'My Orders', href: '/orders' },
     { label: 'Profile', href: '/profile' },
@@ -174,6 +179,15 @@ const Header: FC<HeaderProps> = ({
     { label: 'Notifications', href: '/user/notifications' },
     { label: 'Permissions', href: '/user/permissions' },
     { label: 'Settings', href: '/settings' },
+    ...(isSuperAdmin
+      ? [
+          { divider: true },
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'All Users', href: '/admin/users' },
+          { label: 'All Brands', href: '/admin/brands' },
+          { label: 'All Orders', href: '/admin/orders' },
+        ]
+      : []),
     { label: 'Logout', onClick: logout, isButton: true },
   ];
 

--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -2,10 +2,11 @@ import Link from 'next/link';
 import type { FC } from 'react';
 
 type DropdownItem = {
-  label: string;
+  label?: string;
   href?: string;
   onClick?: () => void;
   isButton?: boolean;
+  divider?: boolean;
 };
 
 interface DropdownMenuProps {
@@ -23,8 +24,15 @@ const DropdownMenu: FC<DropdownMenuProps> = ({ items, onItemClick }) => {
       tabIndex={0}
       className="dropdown-content z-50 menu p-2 shadow bg-base-100 rounded w-40"
     >
-      {items.map((item, index) =>
-        item.isButton ? (
+      {items.map((item, index) => {
+        if (item.divider) {
+          return (
+            <li key={index} className="py-1" role="separator">
+              <hr className="border-t border-base-300" />
+            </li>
+          );
+        }
+        return item.isButton ? (
           <li key={index}>
             <button
               onClick={handleClick(item.onClick)}
@@ -43,8 +51,8 @@ const DropdownMenu: FC<DropdownMenuProps> = ({ items, onItemClick }) => {
               {item.label}
             </Link>
           </li>
-        )
-      )}
+        );
+      })}
     </ul>
   );
 };

--- a/pages/admin/brands.tsx
+++ b/pages/admin/brands.tsx
@@ -1,0 +1,42 @@
+import { useContext, useCallback, useEffect, useState } from 'react';
+import { AppContext } from '@contexts/AppContext';
+import type { Vendor } from '@/types';
+import { fetchJson } from '@utils/fetchJson';
+import Head from 'next/head';
+import { getPageTitle } from '@lib/pageTitle';
+
+export default function ManageBrands() {
+  const { user } = useContext(AppContext)!;
+  const [brands, setBrands] = useState<Vendor[]>([]);
+
+  const load = useCallback(async () => {
+    if (!user) return;
+    const data = await fetchJson<{ vendors: Vendor[] }>('/api/vendors');
+    setBrands(data.vendors);
+  }, [user]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (!user) return <div className="p-4">Please log in to view brands.</div>;
+  if (user.role !== 'super-admin')
+    return <div className="p-4">Admin access required.</div>;
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8">
+      <Head>
+        <title>{getPageTitle('Manage Brands')}</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Brands</h1>
+      <ul className="space-y-2">
+        {brands.map((b) => (
+          <li key={b.id} className="flex justify-between border-b pb-1">
+            <span>{b.brandName || '(no name)'}</span>
+            <span className="text-sm text-gray-500">{b.email}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/api/admin/brands.ts
+++ b/pages/api/admin/brands.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getVendors } from '@lib/users';
+import { withRole } from '@lib/withRole';
+import { handleApiError } from '@utils/handleApiError';
+import type { Vendor, ApiMessage } from '@/types';
+import { METHOD_NOT_ALLOWED } from '@/constants/messages';
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Vendor[] | ApiMessage>
+): Promise<void> {
+  try {
+    if (req.method !== 'GET') {
+      res.status(405).json({ message: METHOD_NOT_ALLOWED });
+      return;
+    }
+    const vendors = await getVendors();
+    res.status(200).json(vendors);
+  } catch (error) {
+    handleApiError(res, error, 'Failed to load brands');
+  }
+}
+
+export default withRole(['SUPER_ADMIN'])(handler);


### PR DESCRIPTION
## Summary
- support dividers in DropdownMenu component
- show admin links in user dropdown when logged in as a super admin
- add basic Brands admin page and API route

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: jest suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68690b64e350832f9b496d5d1102997f