### PR TITLE
Fix style import alias

### DIFF
--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -22,7 +22,7 @@ import DEFAULT_CATEGORIES from '@lib/defaultCategories';
 import TrashIcon from '../icons/TrashIcon';
 import SearchBar from './SearchBar';
 import DropdownMenu from '@components/common/DropdownMenu';
-import '@/styles/category-dropdown.css';
+import '@styles/category-dropdown.css';
 import type { Category } from '@/types';
 import type { User } from '@/types';
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     '^@hooks/(.*)$': '<rootDir>/hooks/$1',
     '^@pages/(.*)$': '<rootDir>/pages/$1',
     '^@styles/(.*)$': '<rootDir>/styles/$1',
+    '^@/styles/(.*)$': '<rootDir>/styles/$1',
     '^@contexts/(.*)$': '<rootDir>/contexts/$1',
     '^@/constants/(.*)$': '<rootDir>/constants/$1',
     '^@/types$': '<rootDir>/types/index.ts',

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,5 @@
 /** @type {import('next').NextConfig} */
+const path = require('path');
 const s3Domain = process.env.AWS_S3_BUCKET_NAME
   ? `${process.env.AWS_S3_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com`
   : null;
@@ -12,6 +13,10 @@ const nextConfig = {
       'picsum.photos',
       ...(s3Domain ? [s3Domain] : []),
     ],
+  },
+  webpack: (config) => {
+    config.resolve.alias['@/styles'] = path.join(__dirname, 'styles');
+    return config;
   },
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -110,6 +110,7 @@
       "@hooks/*": ["hooks/*"],
       "@pages/*": ["pages/*"],
       "@styles/*": ["styles/*"],
+      "@/styles/*": ["styles/*"],
       "@contexts/*": ["contexts/*"],
       "@/types": ["types/index.ts"],
       "@/constants/*": ["constants/*"],


### PR DESCRIPTION
## Summary
- revert Header stylesheet path to `@styles/category-dropdown.css`
- map `@/styles` alias for Next.js and Jest
- update TS config for `@/styles/*`

## Testing
- `npm test --silent` *(fails: SyntaxError due to CSS parsing)*

------
https://chatgpt.com/codex/tasks/task_e_68690b70a910832f8354348e27e02d8e