### PR TITLE
Fix global CSS import

### DIFF
--- a/components/Layout/UserHeader.tsx
+++ b/components/Layout/UserHeader.tsx
@@ -22,7 +22,6 @@ import DEFAULT_CATEGORIES from '@lib/defaultCategories';
 import TrashIcon from '../icons/TrashIcon';
 import SearchBar from './SearchBar';
 import DropdownMenu from '@components/common/DropdownMenu';
-import '@styles/category-dropdown.css';
 import type { Category } from '@/types';
 import type { User } from '@/types';
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import '../styles/globals.css';
 import 'react-quill/dist/quill.snow.css';
+import '@/styles/category-dropdown.css';
 import { AppProvider } from '@contexts/AppContext';
 import Layout from '@components/Layout/Layout';
 import { SessionProvider } from 'next-auth/react';


### PR DESCRIPTION
## Summary
- move `category-dropdown.css` import to `_app`
- remove component-level import

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: unable to fetch prisma binaries due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68690ef16cd0832f8e955e0fde6ee1c6