### PR TITLE
Improve fetchJson error handling

### DIFF
--- a/lib/utils/ApiError.ts
+++ b/lib/utils/ApiError.ts
@@ -1,0 +1,13 @@
+export default class ApiError extends Error {
+  status: number;
+  info?: any;
+
+  constructor(message: string, status: number, info?: any) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    if (info !== undefined) {
+      this.info = info;
+    }
+  }
+}

--- a/lib/utils/fetchJson.ts
+++ b/lib/utils/fetchJson.ts
@@ -1,11 +1,23 @@
+import ApiError from './ApiError';
+
 export async function fetchJson<T>(
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<T> {
   const res = await fetch(input, init);
   if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || res.statusText);
+    let message = res.statusText;
+    let info: any = undefined;
+    try {
+      info = await res.json();
+      if (info && typeof info === 'object' && 'message' in info) {
+        message = (info as any).message as string;
+      }
+    } catch {
+      const text = await res.text();
+      if (text) message = text;
+    }
+    throw new ApiError(message || res.statusText, res.status, info);
   }
   return res.json() as Promise<T>;
 }


### PR DESCRIPTION
## Summary
- create `ApiError` class with status and info
- extend `fetchJson` to provide richer error details via `ApiError`

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 12 passed, 13 total)*

------
https://chatgpt.com/codex/tasks/task_e_686912c366a4832fb360a5364cd8cdda