### PR TITLE
Fix super admin authorization for vendor features

### DIFF
--- a/components/brand/BrandProductsPage.tsx
+++ b/components/brand/BrandProductsPage.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 import { AppContext } from '@contexts/AppContext';
 import type { User } from '@/types';
 import type { Product } from '@/types';
+import { UserRole } from '@/types';
 import { getPageTitle } from '@lib/pageTitle';
 import ProductTable from './ProductTable';
 import ProductDetailsModal from './ProductDetailsModal';
@@ -121,7 +122,7 @@ const BrandProductsPage: React.FC = () => {
   if (!user) {
     return <div className="p-4">Please log in to manage products.</div>;
   }
-  if (user.role !== 'brand') {
+  if (user.role !== 'brand' && user.role !== UserRole.SUPER_ADMIN) {
     return <div className="p-4">Brand access required.</div>;
   }
 

--- a/lib/auth/checkSuperAdmin.ts
+++ b/lib/auth/checkSuperAdmin.ts
@@ -1,11 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { UserRole } from '@/types';
 
 export async function checkSuperAdmin(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<boolean> {
   const session = await getServerSession(req, res, authOptions(req, res));
-  return session?.user?.role === 'SUPER_ADMIN';
+  return session?.user?.role === UserRole.SUPER_ADMIN;
 }

--- a/lib/withRole.ts
+++ b/lib/withRole.ts
@@ -2,16 +2,17 @@ import { getServerSession } from 'next-auth/next';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import type { Session } from 'next-auth';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
+import { UserRole } from '@/types';
 
 export interface AuthedNextApiRequest extends NextApiRequest {
   user?: Session['user'];
 }
 
-export function withRole(roles: string[]) {
+export function withRole(roles: (string | UserRole)[]) {
   return (handler: NextApiHandler) =>
     async (req: AuthedNextApiRequest, res: NextApiResponse) => {
-      const session = await getServerSession(req, res, authOptions);
-      const role = session?.user?.role;
+      const session = await getServerSession(req, res, authOptions(req, res));
+      const role = session?.user?.role as UserRole | undefined;
       if (!session || !role || !roles.includes(role)) {
         return res.status(403).json({ message: 'Forbidden' });
       }

--- a/pages/api/brand/analytics.ts
+++ b/pages/api/brand/analytics.ts
@@ -5,6 +5,7 @@ import type { AnalyticsData, ApiMessage } from '@/types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
+import { UserRole } from '@/types';
 
 export default async function handler(
   req: NextApiRequest,
@@ -19,7 +20,11 @@ export default async function handler(
       typeof session?.user?.brandId === 'number'
         ? session.user.brandId
         : undefined;
-    if (!session?.user || session.user.role !== 'BRAND' || !brandId) {
+    if (
+      !session?.user ||
+      (session.user.role !== 'BRAND' && session.user.role !== UserRole.SUPER_ADMIN) ||
+      !brandId
+    ) {
       return res.status(401).json({ message: UNAUTHORIZED });
     }
     const orders = await getOrdersForVendorId(brandId);

--- a/pages/api/brand/categories.ts
+++ b/pages/api/brand/categories.ts
@@ -9,6 +9,7 @@ import {
   UNAUTHORIZED,
   NAME_REQUIRED,
 } from '@/constants/messages';
+import { UserRole } from '@/types';
 
 export default async function handler(
   req: NextApiRequest,
@@ -19,7 +20,10 @@ export default async function handler(
       return res.status(405).json({ message: METHOD_NOT_ALLOWED });
     }
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user || session.user.role !== 'BRAND') {
+    if (
+      !session?.user ||
+      (session.user.role !== 'BRAND' && session.user.role !== UserRole.SUPER_ADMIN)
+    ) {
       return res.status(401).json({ message: UNAUTHORIZED });
     }
     const { name, slug } = req.body || {};

--- a/pages/api/brand/earnings.ts
+++ b/pages/api/brand/earnings.ts
@@ -5,6 +5,7 @@ import type { EarningsData, ApiMessage } from '@/types';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { METHOD_NOT_ALLOWED, UNAUTHORIZED } from '@/constants/messages';
+import { UserRole } from '@/types';
 
 export default async function handler(
   req: NextApiRequest,
@@ -19,7 +20,11 @@ export default async function handler(
       typeof session?.user?.brandId === 'number'
         ? session.user.brandId
         : undefined;
-    if (!session?.user || session.user.role !== 'BRAND' || !brandId) {
+    if (
+      !session?.user ||
+      (session.user.role !== 'BRAND' && session.user.role !== UserRole.SUPER_ADMIN) ||
+      !brandId
+    ) {
       return res.status(401).json({ message: UNAUTHORIZED });
     }
     const orders = await getOrdersForVendorId(brandId);

--- a/pages/api/brand/products/index.ts
+++ b/pages/api/brand/products/index.ts
@@ -19,6 +19,7 @@ import {
   UNAUTHORIZED,
   PERCENTAGE_DISCOUNT_BETWEEN_1_AND_99,
 } from '@/constants/messages';
+import { UserRole } from '@/types';
 
 export const config = {
   api: {
@@ -52,7 +53,10 @@ async function handler(
   try {
     if (req.method === 'GET') {
       const session = await getServerSession(req, res, authOptions);
-      if (!session?.user || session.user.role !== 'BRAND') {
+      if (
+        !session?.user ||
+        (session.user.role !== 'BRAND' && session.user.role !== UserRole.SUPER_ADMIN)
+      ) {
         return res.status(401).json({ message: UNAUTHORIZED });
       }
 

--- a/pages/api/vendor/orders.ts
+++ b/pages/api/vendor/orders.ts
@@ -1,10 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getOrdersForVendor } from '@lib/orders';
+import { getOrdersForVendor, getAllOrders } from '@lib/orders';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import { getQueryParam } from '@utils/getQueryParam';
 import type { Order, ApiMessage } from '@/types';
 import { METHOD_NOT_ALLOWED, VENDOR_REQUIRED } from '@/constants/messages';
+import { UserRole } from '@/types';
 
 async function handler(
   req: NextApiRequest,
@@ -16,6 +17,10 @@ async function handler(
     }
     const vendor = getQueryParam(req.query.vendor);
     if (!vendor) {
+      if ((req as any).user?.role === UserRole.SUPER_ADMIN) {
+        const orders = await getAllOrders();
+        return res.status(200).json(orders);
+      }
       return res.status(400).json({ message: VENDOR_REQUIRED });
     }
     const orders = await getOrdersForVendor(vendor);
@@ -25,4 +30,4 @@ async function handler(
   }
 }
 
-export default withRole(['BRAND'])(handler);
+export default withRole(['BRAND', UserRole.SUPER_ADMIN])(handler);

--- a/pages/brand/analytics.tsx
+++ b/pages/brand/analytics.tsx
@@ -8,6 +8,7 @@ import TopProductsChart from '@components/analytics/TopProductsChart';
 import DashboardCard from '@components/dashboard/DashboardCard';
 import TotalProductsCard from '@components/dashboard/TotalProductsCard';
 import TotalSalesCard from '@components/dashboard/TotalSalesCard';
+import { UserRole } from '@/types';
 import OrdersThisMonthCard from '@components/dashboard/OrdersThisMonthCard';
 import InventoryAlertsCard from '@components/dashboard/InventoryAlertsCard';
 import CartIcon from '@components/icons/CartIcon';
@@ -100,7 +101,7 @@ const BrandAnalytics: React.FC = () => {
   }, [user]);
 
   if (!user) return <div className="p-4">Please log in.</div>;
-  if (user.role !== 'brand')
+  if (user.role !== 'brand' && user.role !== UserRole.SUPER_ADMIN)
     return <div className="p-4">Brand access required.</div>;
 
   if (loading || data === null) return <div className="p-4">Loading...</div>;

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -2,6 +2,7 @@ import { apiFetch } from '@lib/api';
 import React, { useContext, useEffect, useState } from 'react';
 import { AppContext } from '@contexts/AppContext';
 import type { User } from '@/types';
+import { UserRole } from '@/types';
 import ExistingProductsCard from '@components/dashboard/ExistingProductsCard';
 import TotalProductsCard from '@components/dashboard/TotalProductsCard';
 import TotalSalesCard from '@components/dashboard/TotalSalesCard';
@@ -37,7 +38,7 @@ const BrandDashboard: React.FC = () => {
   if (!user) {
     return <div className="p-4">Please log in to manage products.</div>;
   }
-  if (user.role !== 'brand') {
+  if (user.role !== 'brand' && user.role !== UserRole.SUPER_ADMIN) {
     return <div className="p-4">Brand access required.</div>;
   }
 

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -9,6 +9,7 @@ import React, {
 import { AppContext } from '@contexts/AppContext';
 import { useSession } from 'next-auth/react';
 import { Order } from '@/types';
+import { UserRole } from '@/types';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
 import OrderDetailsModal from '@components/brand/OrderDetailsModal';
@@ -79,7 +80,7 @@ const BrandOrders: React.FC = () => {
   if (!user) {
     return <div className="p-4">Please log in to view orders.</div>;
   }
-  if (user.role !== 'brand') {
+  if (user.role !== 'brand' && user.role !== UserRole.SUPER_ADMIN) {
     return <div className="p-4">Brand access required.</div>;
   }
 

--- a/pages/brand/products/new.tsx
+++ b/pages/brand/products/new.tsx
@@ -9,6 +9,7 @@ import { AppContext } from '@contexts/AppContext';
 import { NotificationContext } from '@contexts/NotificationContext';
 import type { User } from '@/types';
 import type { Product, ProductFormValues } from '@/types';
+import { UserRole } from '@/types';
 import { getPageTitle } from '@lib/pageTitle';
 import PageContainer from '@components/Layout/PageContainer';
 
@@ -148,7 +149,7 @@ const NewProductPage: React.FC = () => {
   if (!user) {
     return <div className="p-4">Please log in to manage products.</div>;
   }
-  if (user.role !== 'brand') {
+  if (user.role !== 'brand' && user.role !== UserRole.SUPER_ADMIN) {
     return <div className="p-4">Brand access required.</div>;
   }
 

--- a/pages/brand/profile.tsx
+++ b/pages/brand/profile.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { AppContext } from '@contexts/AppContext';
 import type { User, Vendor } from '@/types';
+import { UserRole } from '@/types';
 import { TextInput, Textarea, CountrySelect } from '@components/form-fields';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
@@ -127,7 +128,7 @@ export const BrandProfile: React.FC = () => {
   };
 
   if (!user) return <div className="p-4">Please log in.</div>;
-  if (user.role !== 'brand')
+  if (user.role !== 'brand' && user.role !== UserRole.SUPER_ADMIN)
     return <div className="p-4">Brand access required.</div>;
   if (loading)
     return (

--- a/pages/vendor/index.tsx
+++ b/pages/vendor/index.tsx
@@ -11,6 +11,7 @@ import { AppContext } from '@contexts/AppContext';
 import { NotificationContext } from '@contexts/NotificationContext';
 import { ConfirmModal } from '@components/UI';
 import type { Product } from '@/types';
+import { UserRole } from '@/types';
 import { TextInput } from '@components/form-fields';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
@@ -198,7 +199,7 @@ export default function VendorDashboard() {
   if (!user) {
     return <div className="p-4">Please log in to manage products.</div>;
   }
-  if (user.role !== 'brand') {
+  if (user.role !== 'brand' && user.role !== UserRole.SUPER_ADMIN) {
     return <div className="p-4">Brand access required.</div>;
   }
 

--- a/pages/vendor/orders.tsx
+++ b/pages/vendor/orders.tsx
@@ -3,6 +3,7 @@ import { useContext, useEffect, useState, useCallback } from 'react';
 import { AppContext } from '@contexts/AppContext';
 import { NotificationContext } from '@contexts/NotificationContext';
 import type { Order } from '@/types';
+import { UserRole } from '@/types';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
 
@@ -49,7 +50,7 @@ export default function VendorOrders() {
   if (!user) {
     return <div className="p-4">Please log in to view orders.</div>;
   }
-  if (user.role !== 'brand') {
+  if (user.role !== 'brand' && user.role !== UserRole.SUPER_ADMIN) {
     return <div className="p-4">Brand access required.</div>;
   }
 


### PR DESCRIPTION
## Summary
- allow any role (string or enum) in `withRole`
- check super admin role consistently
- enable super admins to access vendor pages and APIs
- support super admin bypass for vendor orders API

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686914bffd5c832fbab4b4da02d66436