### PR TITLE
Implement search and brand activation

### DIFF
--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -22,9 +22,7 @@ const Header: FC<HeaderProps> = ({
     app?.user?.role ||
     (session?.user as { role?: string } | undefined)?.role ||
     ''
-  )
-    .toString()
-    .toUpperCase();
+  ).toString();
   if (role === UserRole.BRAND) {
     return (
       <BrandHeader

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -8,15 +8,15 @@ const reviewsStore = new Map<string, Review[]>();
 export const getDb = () => prisma;
 
 export async function getProductByUuid(uuid: string) {
-  return prisma.product.findUnique({
-    where: { uuid },
+  return prisma.product.findFirst({
+    where: { uuid, vendor: { active: true } },
     include: { variants: true, vendor: true, category: true },
   });
 }
 
 export async function getProductBySlug(slug: string) {
-  return prisma.product.findUnique({
-    where: { slug },
+  return prisma.product.findFirst({
+    where: { slug, vendor: { active: true } },
     include: { category: true, vendor: true, variants: true },
   });
 }

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -144,7 +144,7 @@ async function loadProductsData(): Promise<Product[]> {
   const db = getDb();
   try {
     const rows: ProductWithRelations[] = await db.product.findMany({
-      where: { status: 'approved' },
+      where: { status: 'approved', vendor: { active: true } },
       include: { category: true, vendor: true, variants: true },
     });
 
@@ -383,7 +383,7 @@ export async function getProductsByCategorySlug(
 ): Promise<Product[]> {
   const db = getDb();
   const rows: ProductWithRelations[] = await db.product.findMany({
-    where: { status: 'approved', category: { slug } },
+    where: { status: 'approved', category: { slug }, vendor: { active: true } },
     include: { category: true, vendor: true, variants: true },
   });
   return rows.map(mapDbRowToProduct);
@@ -396,7 +396,7 @@ export async function getProductsByCategorySlugPaginated(
 ): Promise<Product[]> {
   const db = getDb();
   const rows: ProductWithRelations[] = await db.product.findMany({
-    where: { status: 'approved', category: { slug } },
+    where: { status: 'approved', category: { slug }, vendor: { active: true } },
     include: { category: true, vendor: true, variants: true },
     take: limit,
     skip: offset,
@@ -411,7 +411,7 @@ export async function getApprovedProductsPaginated(
 ): Promise<Product[]> {
   const db = getDb();
   const rows: ProductWithRelations[] = await db.product.findMany({
-    where: { status: 'approved' },
+    where: { status: 'approved', vendor: { active: true } },
     include: { category: true, vendor: true, variants: true },
     take: limit,
     skip: offset,
@@ -425,7 +425,7 @@ export async function getProductsByVendorBrandName(
 ): Promise<Product[]> {
   const db = getDb();
   const rows: ProductWithRelations[] = await db.product.findMany({
-    where: { status: 'approved', vendor: { brandName } },
+    where: { status: 'approved', vendor: { brandName, active: true } },
     include: { category: true, vendor: true, variants: true },
     orderBy: { id: 'asc' },
   });
@@ -452,7 +452,7 @@ export async function getProductsPaginated(
   options: PaginatedOptions
 ): Promise<PaginatedResult> {
   const db = getDb();
-  const where: Prisma.ProductWhereInput = { status: 'approved' };
+  const where: Prisma.ProductWhereInput = { status: 'approved', vendor: { active: true } };
   if (options.categorySlugs && options.categorySlugs.length > 0) {
     where.category = {
       slug: { in: options.categorySlugs },

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -50,6 +50,7 @@ export async function addUser({
       stripeAccountId,
       role: role as Role,
       disabled: false,
+      active: true,
       verificationToken,
     },
   });
@@ -63,8 +64,19 @@ export function findUserById(id: number | string) {
   return prisma.user.findUnique({ where: { id: Number(id) } });
 }
 
-export function getAllUsers() {
+export function getAllUsers(search = '') {
+  const where = search
+    ? {
+        OR: [
+          { firstName: { contains: search, mode: 'insensitive' } },
+          { lastName: { contains: search, mode: 'insensitive' } },
+          { email: { contains: search, mode: 'insensitive' } },
+          { role: search.toUpperCase() as Role },
+        ],
+      }
+    : undefined;
   return prisma.user.findMany({
+    where,
     select: {
       id: true,
       email: true,
@@ -84,6 +96,10 @@ export function updateUserRole(email: string, role: Role) {
 
 export function setUserDisabled(email: string, disabled: boolean) {
   return prisma.user.update({ where: { email }, data: { disabled } });
+}
+
+export function setBrandActive(id: number, active: boolean) {
+  return prisma.user.update({ where: { id }, data: { active } });
 }
 
 export function deleteUser(email: string) {
@@ -153,18 +169,22 @@ export function updateUserProfile(email: string, data: Prisma.UserUpdateInput) {
 
 export function findVendorByName(brandName: string) {
   return prisma.user.findFirst({
-    where: { role: 'BRAND', brandName },
-    select: { id: true, brandName: true, email: true },
+    where: { role: 'BRAND', brandName, active: true },
+    select: { id: true, brandName: true, email: true, active: true },
   });
 }
 
-export function getVendors(search = '', limit = 20, offset = 0) {
+export function getVendors(search = '', limit = 20, offset = 0, includeInactive = false) {
   return prisma.user.findMany({
     where: {
       role: 'BRAND',
-      brandName: { contains: search, mode: 'insensitive' },
+      OR: [
+        { brandName: { contains: search, mode: 'insensitive' } },
+        { email: { contains: search, mode: 'insensitive' } },
+      ],
+      ...(includeInactive ? {} : { active: true }),
     },
-    select: { id: true, brandName: true, email: true },
+    select: { id: true, brandName: true, email: true, active: true },
     orderBy: { brandName: 'asc' },
     take: limit,
     skip: offset,

--- a/pages/admin/brands.tsx
+++ b/pages/admin/brands.tsx
@@ -1,6 +1,6 @@
 import { useContext, useCallback, useEffect, useState } from 'react';
 import { AppContext } from '@contexts/AppContext';
-import type { Vendor, UserRole } from '@/types';
+import type { Vendor, UserRole, ApiMessage } from '@/types';
 import { fetchJson } from '@utils/fetchJson';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
@@ -8,12 +8,24 @@ import { getPageTitle } from '@lib/pageTitle';
 export default function ManageBrands() {
   const { user } = useContext(AppContext)!;
   const [brands, setBrands] = useState<Vendor[]>([]);
+  const [search, setSearch] = useState('');
 
   const load = useCallback(async () => {
     if (!user) return;
-    const data = await fetchJson<{ vendors: Vendor[] }>('/api/vendors');
-    setBrands(data.vendors);
-  }, [user]);
+    const params = new URLSearchParams();
+    if (search) params.set('search', search);
+    const data = await fetchJson<Vendor[]>(`/api/admin/brands?${params.toString()}`);
+    setBrands(data);
+  }, [user, search]);
+
+  const toggleActive = async (id: number, active: boolean) => {
+    await fetchJson<ApiMessage>('/api/admin/brands', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, active }),
+    });
+    load();
+  };
 
   useEffect(() => {
     load();
@@ -29,11 +41,27 @@ export default function ManageBrands() {
         <title>{getPageTitle('Manage Brands')}</title>
       </Head>
       <h1 className="text-2xl font-bold mb-4">Brands</h1>
+      <input
+        type="text"
+        placeholder="Search"
+        className="input input-bordered mb-4"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
       <ul className="space-y-2">
         {brands.map((b) => (
-          <li key={b.id} className="flex justify-between border-b pb-1">
+          <li key={b.id} className="flex items-center justify-between border-b pb-1">
             <span>{b.brandName || '(no name)'}</span>
             <span className="text-sm text-gray-500">{b.email}</span>
+            <label className="label cursor-pointer gap-1">
+              <span className="label-text">Active</span>
+              <input
+                type="checkbox"
+                className="checkbox"
+                checked={b.active ?? true}
+                onChange={(e) => toggleActive(Number(b.id), e.target.checked)}
+              />
+            </label>
           </li>
         ))}
       </ul>

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -15,19 +15,22 @@ export default function ManageUsers() {
   const { user } = useContext(AppContext)!;
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [message, setMessage] = useState<string>('');
+  const [search, setSearch] = useState('');
 
   const fetchUsers = useCallback(async () => {
     if (!user) return;
-    const data = await fetchJson<AdminUser[]>('/api/admin/users');
+    const params = new URLSearchParams();
+    if (search) params.set('search', search);
+    const data = await fetchJson<AdminUser[]>(`/api/admin/users?${params.toString()}`);
     setUsers(data);
-  }, [user]);
+  }, [user, search]);
 
   useEffect(() => {
     fetchUsers();
   }, [fetchUsers]);
 
   const changeRole = async (email: string, role: string) => {
-    const payload: UserRoleUpdateRequest = { email, role: role.toUpperCase() };
+    const payload: UserRoleUpdateRequest = { email, role };
     await fetchJson<ApiMessage>('/api/admin/users', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -67,6 +70,13 @@ export default function ManageUsers() {
         <title>{getPageTitle('Manage Users')}</title>
       </Head>
       <h1 className="text-2xl font-bold mb-4">Manage Users</h1>
+      <input
+        type="text"
+        placeholder="Search"
+        className="input input-bordered mb-4"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
       {message && <div className="mb-4 text-green-600">{message}</div>}
       <ul className="space-y-2">
         {users.map((u) => (

--- a/pages/api/admin/brands.ts
+++ b/pages/api/admin/brands.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getVendors } from '@lib/users';
+import { getVendors, setBrandActive } from '@lib/users';
 import { withRole } from '@lib/withRole';
 import { handleApiError } from '@utils/handleApiError';
 import type { Vendor, ApiMessage } from '@/types';
@@ -10,12 +10,26 @@ async function handler(
   res: NextApiResponse<Vendor[] | ApiMessage>
 ): Promise<void> {
   try {
-    if (req.method !== 'GET') {
-      res.status(405).json({ message: METHOD_NOT_ALLOWED });
+    if (req.method === 'GET') {
+      const search = String(req.query.search || '');
+      const page = parseInt(String(req.query.page || '1'), 10);
+      const limit = parseInt(String(req.query.limit || '20'), 10);
+      const offset = (page - 1) * limit;
+      const vendors = await getVendors(search, limit, offset, true);
+      res.status(200).json(vendors);
       return;
     }
-    const vendors = await getVendors();
-    res.status(200).json(vendors);
+    if (req.method === 'PATCH') {
+      const { id, active } = req.body as { id?: number; active?: boolean };
+      if (!id || typeof active !== 'boolean') {
+        res.status(400).json({ message: 'id and active required' });
+        return;
+      }
+      await setBrandActive(id, active);
+      res.status(200).json({ message: 'updated' });
+      return;
+    }
+    res.status(405).json({ message: METHOD_NOT_ALLOWED });
   } catch (error) {
     handleApiError(res, error, 'Failed to load brands');
   }

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -30,7 +30,8 @@ async function handler(
 ): Promise<void> {
   try {
     if (req.method === 'GET') {
-      const users: AdminUser[] = await getAllUsers();
+      const search = getQueryParam(req.query.search) || '';
+      const users: AdminUser[] = await getAllUsers(search);
       res.status(200).json(users);
       return;
     }
@@ -42,7 +43,7 @@ async function handler(
       if (target?.role === 'SUPER_ADMIN') {
         return res.status(403).json({ message: 'cannot modify super admin' });
       }
-      await updateUserRole(email, role as Role);
+      await updateUserRole(email, role.toUpperCase() as Role);
       res.status(200).json({ message: 'role updated' });
       return;
     }

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -108,18 +108,28 @@ export default async function handler(
       .collections('products')
       .documents()
       .search(searchParams);
-    const hits =
+    let hits =
       result.hits?.map((h: any) => ({
         ...h.document,
         highlights: h.highlights,
       })) || [];
+    const brandNames = Array.from(new Set(hits.map((h: any) => h.brand))).filter(Boolean);
+    let activeSet = new Set<string>();
+    if (brandNames.length > 0) {
+      const activeRows = await db.user.findMany({
+        where: { role: 'BRAND', brandName: { in: brandNames }, active: true },
+        select: { brandName: true },
+      });
+      activeSet = new Set(activeRows.map((r) => r.brandName || ''));
+    }
+    hits = hits.filter((h: any) => activeSet.has(h.brand));
     const totalPages = Math.ceil(result.found / searchParams.per_page);
     const brands: string[] = [];
     const categories: string[] = [];
     if (Array.isArray(result.facet_counts)) {
       for (const facet of result.facet_counts as FacetCount[]) {
         if (facet.field_name === 'brand') {
-          brands.push(...facet.counts.map((c) => c.value));
+          brands.push(...facet.counts.map((c) => c.value).filter((b) => activeSet.has(b)));
         }
         if (facet.field_name === 'category') {
           categories.push(...facet.counts.map((c) => c.value));
@@ -153,7 +163,7 @@ export default async function handler(
     }
     return res.status(200).json({
       results: hits,
-      total: result.found,
+      total: hits.length,
       page: searchParams.page,
       totalPages,
       brands,

--- a/pages/api/vendors.ts
+++ b/pages/api/vendors.ts
@@ -20,7 +20,7 @@ export default async function handler(
     const pageNum = parseInt(String(page || '1'), 10);
     const limitNum = parseInt(String(limit || '20'), 10);
     const offset = (pageNum - 1) * limitNum;
-    const vendors = await getVendors(String(search), limitNum, offset);
+    const vendors = await getVendors(String(search), limitNum, offset, false);
     return res.status(200).json({ vendors });
   } catch (error) {
     return handleApiError(res, error, 'Failed to load vendors');

--- a/pages/orders/[orderId].tsx
+++ b/pages/orders/[orderId].tsx
@@ -20,7 +20,7 @@ export default function OrderDetail() {
   useEffect(() => {
     if (!orderId) return;
     const endpoint =
-      user?.role?.toUpperCase() === UserRole.USER
+      user?.role === UserRole.USER
         ? `/api/user/orders/${orderId}`
         : `/api/orders/${orderId}`;
     setLoading(true);

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -62,7 +62,7 @@ export const UserProfile: React.FC = () => {
   };
 
   if (!user) return <div className="p-4">Please log in.</div>;
-  if (user.role?.toUpperCase() !== UserRole.USER)
+  if (user.role !== UserRole.USER)
     return <div className="p-4">User access required.</div>;
 
   return (

--- a/prisma/migrations/20250705120000_add-brand-active/migration.sql
+++ b/prisma/migrations/20250705120000_add-brand-active/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "active" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,7 @@ model User {
   role                Role      @default(USER)
   verified            Boolean   @default(false)
   disabled            Boolean   @default(false)
+  active              Boolean   @default(true)
   verificationToken   String?
   resetToken          String?
   resetExpires        DateTime?

--- a/types/user.ts
+++ b/types/user.ts
@@ -30,6 +30,7 @@ export interface User {
   resetExpires?: Date;
   verified?: boolean;
   disabled?: boolean;
+  active?: boolean;
   createdAt?: Date;
   updatedAt?: Date;
 }

--- a/types/vendor.ts
+++ b/types/vendor.ts
@@ -15,6 +15,7 @@ export interface Vendor {
   taxId?: string;
   paymentMethods?: BrandPaymentMethod[];
   status?: string;
+  active?: boolean;
   createdAt?: Date;
   updatedAt?: Date;
 }


### PR DESCRIPTION
## Summary
- add `active` field to brands in DB
- implement search on admin users and brands pages
- allow super admins to toggle brand active status
- filter inactive brands from search results and product queries
- store roles consistently in uppercase

## Testing
- `npm run lint`
- `npm run type-check` *(fails: cannot find Prisma types)*

------
https://chatgpt.com/codex/tasks/task_e_68691a57d5e4832f8825df7f429acc8a