### PR TITLE
Improve admin deletion UX

### DIFF
--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -4,6 +4,7 @@ import { Category, CategoryInput, ApiMessage, UserRole } from '@/types';
 import { fetchJson } from '@utils/fetchJson';
 import { TextInput } from '@components/form-fields';
 import { slugify } from '@lib/slugify';
+import { ConfirmModal } from '@components/UI';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
 
@@ -14,6 +15,8 @@ export default function Categories() {
   const [message, setMessage] = useState<string>('');
   const [editing, setEditing] = useState<string | null>(null);
   const [editName, setEditName] = useState<string>('');
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const load = useCallback(async () => {
     if (!user) return;
@@ -57,11 +60,19 @@ export default function Categories() {
     load();
   };
 
-  const remove = async (id: number) => {
-    await fetchJson<ApiMessage>(`/api/admin/categories?id=${id}`, {
+  const handleDelete = (id: number) => {
+    setDeleteId(id);
+  };
+
+  const confirmDelete = async () => {
+    if (deleteId === null) return;
+    setDeleting(true);
+    await fetchJson<ApiMessage>(`/api/admin/categories?id=${deleteId}`, {
       method: 'DELETE',
     });
+    setDeleting(false);
     setMessage('Category deleted');
+    setDeleteId(null);
     load();
   };
 
@@ -103,6 +114,16 @@ export default function Categories() {
           <CategoryItem key={c.id} cat={c} />
         ))}
       </ul>
+      <ConfirmModal
+        isOpen={deleteId !== null}
+        title="Are you sure?"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        loading={deleting}
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteId(null)}
+      />
     </div>
   );
 
@@ -148,7 +169,7 @@ export default function Categories() {
                 Edit
               </button>
               <button
-                onClick={() => remove(Number(cat.id))}
+                onClick={() => handleDelete(Number(cat.id))}
                 className="btn btn-sm"
               >
                 Delete

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -10,11 +10,17 @@ import {
 import { fetchJson } from '@utils/fetchJson';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
+import { ConfirmModal } from '@components/UI';
 
 export default function ManageUsers() {
   const { user } = useContext(AppContext)!;
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [message, setMessage] = useState<string>('');
+  const [deleteUser, setDeleteUser] = useState<{
+    id: number;
+    email: string;
+  } | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const fetchUsers = useCallback(async () => {
     if (!user) return;
@@ -48,12 +54,19 @@ export default function ManageUsers() {
     fetchUsers();
   };
 
-  const remove = async (id: number, email: string) => {
-    if (!confirm(`Delete user ${email}?`)) return;
-    await fetchJson<ApiMessage>(`/api/admin/users/${id}`, {
+  const handleDelete = (id: number, email: string) => {
+    setDeleteUser({ id, email });
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteUser) return;
+    setDeleting(true);
+    await fetchJson<ApiMessage>(`/api/admin/users/${deleteUser.id}`, {
       method: 'DELETE',
     });
+    setDeleting(false);
     setMessage('User deleted');
+    setDeleteUser(null);
     fetchUsers();
   };
 
@@ -85,7 +98,11 @@ export default function ManageUsers() {
             >
               <option value="user">user</option>
               <option value="brand">brand</option>
-              <option value={UserRole.SUPER_ADMIN.toLowerCase().replace('_', '-')}>{UserRole.SUPER_ADMIN.toLowerCase().replace('_', '-')}</option>
+              <option
+                value={UserRole.SUPER_ADMIN.toLowerCase().replace('_', '-')}
+              >
+                {UserRole.SUPER_ADMIN.toLowerCase().replace('_', '-')}
+              </option>
             </select>
             <label className="label cursor-pointer gap-1">
               <span className="label-text">Disabled</span>
@@ -98,7 +115,7 @@ export default function ManageUsers() {
               />
             </label>
             <button
-              onClick={() => remove(u.id, u.email)}
+              onClick={() => handleDelete(u.id, u.email)}
               className="btn btn-sm"
               disabled={u.role === 'SUPER_ADMIN'}
             >
@@ -107,6 +124,16 @@ export default function ManageUsers() {
           </li>
         ))}
       </ul>
+      <ConfirmModal
+        isOpen={!!deleteUser}
+        title="Are you sure?"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        loading={deleting}
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteUser(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add confirmation modal for deleting users in admin dashboard
- add confirmation modal for category deletions in admin dashboard

## Testing
- `npx prettier --write pages/admin/users.tsx pages/admin/categories.tsx`
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_68691aa76ae4832f98d47a367604ab49