### PR TITLE
Update admin hero component

### DIFF
--- a/components/UI/PageHero.tsx
+++ b/components/UI/PageHero.tsx
@@ -7,21 +7,17 @@ interface PageHeroProps {
 }
 
 const PageHero: React.FC<PageHeroProps> = ({ heading, description, className = '' }) => (
-  <section
-    className={`relative overflow-hidden bg-gradient-to-r from-green-600 via-blue-600 to-green-800 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 py-12 md:py-16 w-full transition-colors duration-300 ${className}`}
-  >
-    <div className="absolute inset-0 bg-black/10 dark:bg-black/40 pointer-events-none transition-colors duration-300" />
-    <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h1 className="text-3xl md:text-5xl font-extrabold text-white dark:text-primary mb-4 drop-shadow-lg transition-colors duration-300">
-        {heading}
-      </h1>
-      {description && (
-        <p className="text-lg md:text-xl text-green-100 dark:text-gray-200 max-w-2xl mx-auto transition-colors duration-300">
-          {description}
-        </p>
-      )}
+  <div className={`relative overflow-hidden bg-gradient-to-r from-green-600 via-blue-600 to-green-800 ${className}`}>
+    <div className="absolute inset-0 bg-black/10" />
+    <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <div className="text-center">
+        <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">{heading}</h1>
+        {description && (
+          <p className="text-xl text-green-100 max-w-2xl mx-auto">{description}</p>
+        )}
+      </div>
     </div>
-  </section>
+  </div>
 );
 
 export default PageHero; 

--- a/pages/admin/approvals.tsx
+++ b/pages/admin/approvals.tsx
@@ -4,6 +4,7 @@ import { PendingProduct, ApiMessage, UserRole, USER_ROLES } from '@/types';
 import { fetchJson } from '@utils/fetchJson';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
+import PageHero from '@components/UI/PageHero';
 
 export default function Approvals() {
   const { user } = useContext(AppContext)!;
@@ -38,13 +39,14 @@ export default function Approvals() {
     return <div className="p-4">Admin access required.</div>;
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8">
+    <>
       <Head>
         <title>{getPageTitle('Vendor Approvals')}</title>
       </Head>
-      <h1 className="text-2xl font-bold mb-4">Vendor Product Approvals</h1>
-      {message && <div className="mb-4 text-green-600">{message}</div>}
-      <ul className="space-y-2">
+      <PageHero heading="Vendor Product Approvals" />
+      {message && <div className="mb-4 text-green-600 px-4 sm:px-6 lg:px-8">{message}</div>}
+      <div className="w-full px-4 sm:px-6 lg:px-8">
+        <ul className="space-y-2">
         {pending.map((p) => (
           <li key={p.id} className="flex justify-between items-center">
             <span>{p.title}</span>
@@ -65,7 +67,8 @@ export default function Approvals() {
           </li>
         ))}
         {pending.length === 0 && <li>No pending products.</li>}
-      </ul>
-    </div>
+        </ul>
+      </div>
+    </>
   );
 }

--- a/pages/admin/brands.tsx
+++ b/pages/admin/brands.tsx
@@ -185,15 +185,10 @@ export default function ManageBrands() {
         <title>{getPageTitle('Manage Brands')}</title>
       </Head>
       {/* Hero Section */}
-      <div className="relative overflow-hidden bg-gradient-to-r from-green-600 via-blue-600 to-green-800">
-        <div className="absolute inset-0 bg-black/10"></div>
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="text-center">
-            <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">Brand Management</h1>
-            <p className="text-xl text-green-100 max-w-2xl mx-auto">Manage all brands and vendor accounts across the platform. View, edit, and maintain brand information.</p>
-          </div>
-        </div>
-      </div>
+      <PageHero
+        heading="Brand Management"
+        description="Manage all brands and vendor accounts across the platform. View, edit, and maintain brand information."
+      />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="bg-white dark:bg-gray-950 rounded-xl shadow-lg p-6 mb-8 border border-gray-200 dark:border-gray-800 transition-colors duration-300">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/pages/admin/coupons.tsx
+++ b/pages/admin/coupons.tsx
@@ -5,6 +5,7 @@ import { AppContext } from '@contexts/AppContext';
 import { TextInput } from '@components/form-fields';
 import { Coupon, UserRole, USER_ROLES } from '@/types';
 import { getPageTitle } from '@lib/pageTitle';
+import PageHero from '@components/UI/PageHero';
 
 export default function AdminCoupons() {
   const { user } = useContext(AppContext)!;
@@ -58,13 +59,14 @@ export default function AdminCoupons() {
     return <div className="p-4">Admin access required.</div>;
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8">
+    <>
       <Head>
         <title>{getPageTitle('Manage Coupons')}</title>
       </Head>
-      <h1 className="text-2xl font-bold mb-4">Coupons</h1>
-      {message && <div className="mb-2 text-green-600">{message}</div>}
-      <form onSubmit={submit} className="space-y-2 max-w-md">
+      <PageHero heading="Coupons" />
+      <div className="w-full px-4 sm:px-6 lg:px-8">
+        {message && <div className="mb-2 text-green-600">{message}</div>}
+        <form onSubmit={submit} className="space-y-2 max-w-md">
         <TextInput
           name="code"
           value={form.code}
@@ -194,5 +196,6 @@ export default function AdminCoupons() {
         </tbody>
       </table>
     </div>
+    </>
   );
 }

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -97,15 +97,10 @@ export default function AdminOrders() {
       <Head>
         <title>{getPageTitle('Orders')}</title>
       </Head>
-      <div className="relative overflow-hidden bg-gradient-to-r from-green-600 via-blue-600 to-green-800">
-        <div className="absolute inset-0 bg-black/10"></div>
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="text-center">
-            <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">Order Management</h1>
-            <p className="text-xl text-green-100 max-w-2xl mx-auto">Manage all orders across the platform. View, track, and maintain order information.</p>
-          </div>
-        </div>
-      </div>
+      <PageHero
+        heading="Order Management"
+        description="Manage all orders across the platform. View, track, and maintain order information."
+      />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="bg-white dark:bg-gray-950 rounded-xl shadow-lg p-6 mb-8 border border-gray-200 dark:border-gray-800 transition-colors duration-300">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/pages/admin/policies.tsx
+++ b/pages/admin/policies.tsx
@@ -5,6 +5,7 @@ import { AppContext } from '@contexts/AppContext';
 import { fetchJson } from '@utils/fetchJson';
 import { getPageTitle } from '@lib/pageTitle';
 import { USER_ROLES } from '@/types';
+import PageHero from '@components/UI/PageHero';
 
 const TYPES = [
   { value: 'terms', label: 'Terms & Conditions' },
@@ -38,13 +39,14 @@ export default function ManagePolicies() {
   };
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8 space-y-4">
+    <>
       <Head>
         <title>{getPageTitle('Manage Policies')}</title>
       </Head>
-      <h1 className="text-2xl font-bold mb-4">Manage Policies</h1>
-      {message && <div className="text-green-600">{message}</div>}
-      <div className="form-control w-full max-w-xs">
+      <PageHero heading="Manage Policies" />
+      <div className="w-full px-4 sm:px-6 lg:px-8 space-y-4">
+        {message && <div className="text-green-600">{message}</div>}
+        <div className="form-control w-full max-w-xs">
         <label className="label">
           <span className="label-text">Policy Type</span>
         </label>
@@ -75,5 +77,6 @@ export default function ManagePolicies() {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/pages/admin/products.tsx
+++ b/pages/admin/products.tsx
@@ -282,15 +282,10 @@ export default function AdminProducts() {
         <title>{getPageTitle('Admin Products')}</title>
       </Head>
       {/* Hero Section */}
-      <div className="relative overflow-hidden bg-gradient-to-r from-green-600 via-blue-600 to-green-800">
-        <div className="absolute inset-0 bg-black/10"></div>
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="text-center">
-            <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">Product Management</h1>
-            <p className="text-xl text-green-100 max-w-2xl mx-auto">Manage all products across the platform. View, edit, and maintain product information.</p>
-          </div>
-        </div>
-      </div>
+      <PageHero
+        heading="Product Management"
+        description="Manage all products across the platform. View, edit, and maintain product information."
+      />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="bg-white dark:bg-gray-950 rounded-xl shadow-lg p-6 mb-8 border border-gray-200 dark:border-gray-800 transition-colors duration-300">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/pages/admin/search-analytics.tsx
+++ b/pages/admin/search-analytics.tsx
@@ -5,6 +5,7 @@ import { SearchAnalyticsResponse, UserRole, USER_ROLES } from '@/types';
 import { fetchJson } from '@utils/fetchJson';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
+import PageHero from '@components/UI/PageHero';
 
 export default function SearchAnalytics() {
   const { user } = useContext(AppContext)!;
@@ -23,16 +24,17 @@ export default function SearchAnalytics() {
   if (!data) return <div className="p-4">Loading...</div>;
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8">
+    <>
       <Head>
         <title>{getPageTitle('Search Analytics')}</title>
       </Head>
-      <h1 className="text-2xl font-bold mb-4">Search Analytics</h1>
-      <div className="mb-4 space-x-2">
-        <Link href="/admin/analytics" className="btn btn-sm">
-          Back
-        </Link>
-      </div>
+      <PageHero heading="Search Analytics" />
+      <div className="w-full px-4 sm:px-6 lg:px-8">
+        <div className="mb-4 space-x-2">
+          <Link href="/admin/analytics" className="btn btn-sm">
+            Back
+          </Link>
+        </div>
       <h2 className="text-xl font-semibold mt-4 mb-2">Top Searches</h2>
       <ul className="list-disc list-inside">
         {data.topSearches.map((s) => (
@@ -52,5 +54,6 @@ export default function SearchAnalytics() {
         {data.failedSearches.length === 0 && <li>None.</li>}
       </ul>
     </div>
+    </>
   );
 }

--- a/pages/admin/support.tsx
+++ b/pages/admin/support.tsx
@@ -4,6 +4,7 @@ import { AppContext } from '@contexts/AppContext';
 import { fetchJson } from '@utils/fetchJson';
 import { getPageTitle } from '@lib/pageTitle';
 import { SupportTicket, UserRole, USER_ROLES } from '@/types';
+import PageHero from '@components/UI/PageHero';
 
 export default function SupportTickets() {
   const { user } = useContext(AppContext)!;
@@ -21,12 +22,13 @@ export default function SupportTickets() {
     return <div className="p-4">Admin access required.</div>;
 
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8">
+    <>
       <Head>
         <title>{getPageTitle('Support Tickets')}</title>
       </Head>
-      <h1 className="text-2xl font-bold mb-4">Support Tickets</h1>
-      <div className="form-control max-w-xs">
+      <PageHero heading="Support Tickets" />
+      <div className="w-full px-4 sm:px-6 lg:px-8">
+        <div className="form-control max-w-xs">
         <label className="label">
           <span className="label-text">Status</span>
         </label>
@@ -53,5 +55,6 @@ export default function SupportTickets() {
         {tickets.length === 0 && <li>No tickets</li>}
       </ul>
     </div>
+    </>
   );
 }

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -166,15 +166,10 @@ export default function ManageUsers() {
         <title>{getPageTitle('Manage Users')}</title>
       </Head>
       {/* Hero Section */}
-      <div className="relative overflow-hidden bg-gradient-to-r from-green-600 via-blue-600 to-green-800">
-        <div className="absolute inset-0 bg-black/10"></div>
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="text-center">
-            <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">User Management</h1>
-            <p className="text-xl text-green-100 max-w-2xl mx-auto">Manage all users across the platform. View, edit roles, and maintain user accounts.</p>
-          </div>
-        </div>
-      </div>
+      <PageHero
+        heading="User Management"
+        description="Manage all users across the platform. View, edit roles, and maintain user accounts."
+      />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="bg-white dark:bg-gray-950 rounded-xl shadow-lg p-6 mb-8 border border-gray-200 dark:border-gray-800 transition-colors duration-300">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">


### PR DESCRIPTION
## Summary
- refactor `PageHero` to new design markup
- use `PageHero` across all admin pages instead of inline markup

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715624dff0832f90e516b8dc13a46b