### PR TITLE
Refactor SVG icons into components

### DIFF
--- a/components/ActiveFilters.tsx
+++ b/components/ActiveFilters.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { ActiveFilter } from '@/types';
+import XMarkIcon from '@components/icons/XMarkIcon';
 
 interface ActiveFiltersProps {
   filters: ActiveFilter[];
@@ -17,15 +18,13 @@ const ActiveFilters: React.FC<ActiveFiltersProps> = ({ filters, clearAll }) => {
           className="inline-flex items-center gap-2 px-3 py-1.5 bg-primary/10 text-primary border border-primary/20 rounded-full text-sm font-medium hover:bg-primary/20 transition-all duration-200 group"
         >
           <span>{f.label}</span>
-          <button 
-            type="button" 
+          <button
+            type="button"
             onClick={() => f.clear()}
             className="ml-1 p-0.5 rounded-full hover:bg-primary/20 transition-colors duration-200 group-hover:scale-110"
             aria-label={`Remove ${f.label} filter`}
           >
-            <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
-            </svg>
+            <XMarkIcon className="w-3 h-3" fill="currentColor" />
           </button>
         </span>
       ))}
@@ -35,9 +34,7 @@ const ActiveFilters: React.FC<ActiveFiltersProps> = ({ filters, clearAll }) => {
           onClick={clearAll}
           className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-base-content/60 hover:text-base-content border border-base-300 rounded-full hover:bg-base-200 transition-all duration-200"
         >
-          <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
-          </svg>
+          <XMarkIcon className="w-3 h-3" fill="currentColor" />
           Clear All
         </button>
       )}

--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import ChevronLeftIcon from '@components/icons/ChevronLeftIcon';
+import ChevronRightIcon from '@components/icons/ChevronRightIcon';
 
 interface PaginationProps {
   currentPage: number;
@@ -63,9 +65,7 @@ const Pagination: React.FC<PaginationProps> = ({
         className="rounded-lg px-3 py-2 border border-primary bg-white text-primary hover:bg-primary/10 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
         aria-label="Previous page"
       >
-        <svg className="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-        </svg>
+        <ChevronLeftIcon className="w-4 h-4 text-primary" />
       </button>
 
       {/* Page Numbers */}
@@ -99,9 +99,7 @@ const Pagination: React.FC<PaginationProps> = ({
         className="rounded-lg px-3 py-2 border border-primary bg-white text-primary hover:bg-primary/10 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
         aria-label="Next page"
       >
-        <svg className="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-        </svg>
+        <ChevronRightIcon className="w-4 h-4 text-primary" />
       </button>
     </div>
   );

--- a/components/brand/BrandProductsPage.tsx
+++ b/components/brand/BrandProductsPage.tsx
@@ -15,30 +15,12 @@ import { ConfirmModal } from '@components/UI';
 import BrandProductSort, { BrandProductSortValue } from './BrandProductSort';
 import Pagination from '@components/Pagination';
 
-// Inline SVG icons
-const PlusIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-  </svg>
-);
+import PlusIcon from '@components/icons/PlusIcon';
+import SearchIcon from '@components/icons/SearchIcon';
+import FunnelIcon from '@components/icons/FunnelIcon';
+import XMarkIcon from '@components/icons/XMarkIcon';
 
-const MagnifyingGlassIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-  </svg>
-);
-
-const FunnelIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.207A1 1 0 013 6.5V4z" />
-  </svg>
-);
-
-const XMarkIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-  </svg>
-);
+// Inline SVG icons removed in favor of reusable components
 
 const SORT_VALUES: BrandProductSortValue[] = [
   'title_asc',

--- a/components/icons/ArrowLeftIcon.tsx
+++ b/components/icons/ArrowLeftIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const ArrowLeftIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+  </svg>
+);
+
+export default ArrowLeftIcon;

--- a/components/icons/BuildingIcon.tsx
+++ b/components/icons/BuildingIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const BuildingIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+  </svg>
+);
+
+export default BuildingIcon;

--- a/components/icons/ChartBarIcon.tsx
+++ b/components/icons/ChartBarIcon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const ChartBarIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+    />
+  </svg>
+);
+
+export default ChartBarIcon;

--- a/components/icons/ChatBubbleIcon.tsx
+++ b/components/icons/ChatBubbleIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const ChatBubbleIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+  </svg>
+);
+
+export default ChatBubbleIcon;

--- a/components/icons/CheckIcon.tsx
+++ b/components/icons/CheckIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const CheckIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+  </svg>
+);
+
+export default CheckIcon;

--- a/components/icons/CurrencyDollarIcon.tsx
+++ b/components/icons/CurrencyDollarIcon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const CurrencyDollarIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"
+    />
+  </svg>
+);
+
+export default CurrencyDollarIcon;

--- a/components/icons/FunnelIcon.tsx
+++ b/components/icons/FunnelIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const FunnelIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.207A1 1 0 013 6.5V4z" />
+  </svg>
+);
+
+export default FunnelIcon;

--- a/components/icons/HeartIcon.tsx
+++ b/components/icons/HeartIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const HeartIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+  </svg>
+);
+
+export default HeartIcon;

--- a/components/icons/PlusIcon.tsx
+++ b/components/icons/PlusIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const PlusIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+  </svg>
+);
+
+export default PlusIcon;

--- a/components/icons/ShoppingBagIcon.tsx
+++ b/components/icons/ShoppingBagIcon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const ShoppingBagIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"
+    />
+  </svg>
+);
+
+export default ShoppingBagIcon;

--- a/components/icons/StarIcon.tsx
+++ b/components/icons/StarIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const StarIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+  </svg>
+);
+
+export default StarIcon;

--- a/components/icons/TruckIcon.tsx
+++ b/components/icons/TruckIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const TruckIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 17a2 2 0 11-4 0 2 2 0 014 0zM21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+  </svg>
+);
+
+export default TruckIcon;

--- a/components/icons/XMarkIcon.tsx
+++ b/components/icons/XMarkIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { IconProps } from './IconProps';
+
+const XMarkIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className = '', ...rest }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={1.5}
+    className={className}
+    aria-hidden="true"
+    role="img"
+    {...rest}
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+  </svg>
+);
+
+export default XMarkIcon;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import SearchIcon from '@components/icons/SearchIcon';
 
 export default function Custom404() {
   const router = useRouter();
@@ -23,7 +24,7 @@ export default function Custom404() {
           <a className="mb-8 px-6 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-semibold shadow transition">Back to dashboard</a>
         </Link>
         <form onSubmit={handleSearch} className="w-full flex items-center bg-gray-200 dark:bg-gray-800 rounded-lg px-3 py-2 shadow-inner mb-8">
-          <svg className="w-5 h-5 text-gray-400 mr-2" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></svg>
+          <SearchIcon className="w-5 h-5 text-gray-400 mr-2" />
           <input
             type="text"
             className="flex-1 bg-transparent outline-none text-gray-700 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"

--- a/pages/brand/dashboard.tsx
+++ b/pages/brand/dashboard.tsx
@@ -14,50 +14,15 @@ import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
 import Link from 'next/link';
 
-// Inline SVG icons
-const ChartBarIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-  </svg>
-);
+import ChartBarIcon from '@components/icons/ChartBarIcon';
+import ShoppingBagIcon from '@components/icons/ShoppingBagIcon';
+import CurrencyDollarIcon from '@components/icons/CurrencyDollarIcon';
+import TruckIcon from '@components/icons/TruckIcon';
+import PlusIcon from '@components/icons/PlusIcon';
+import EyeIcon from '@components/icons/EyeIcon';
+import CogIcon from '@components/icons/CogIcon';
 
-const ShoppingBagIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
-  </svg>
-);
-
-const CurrencyDollarIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1" />
-  </svg>
-);
-
-const TruckIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17a2 2 0 11-4 0 2 2 0 014 0zM21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-  </svg>
-);
-
-const PlusIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-  </svg>
-);
-
-const EyeIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-  </svg>
-);
-
-const CogIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-  </svg>
-);
+// Inline SVG icons removed in favor of reusable components
 
 const BrandDashboard: React.FC = () => {
   const { user } = useContext(AppContext) as { user: User | null };

--- a/pages/brand/orders.tsx
+++ b/pages/brand/orders.tsx
@@ -17,31 +17,12 @@ import ChatWindow from '@components/Chat/ChatWindow';
 import { ChatContext } from '@contexts/ChatContext';
 import { NotificationContext } from '@contexts/NotificationContext';
 
-// Inline SVG icons
-const TruckIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17a2 2 0 11-4 0 2 2 0 014 0zM21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-  </svg>
-);
+import TruckIcon from '@components/icons/TruckIcon';
+import ChatBubbleIcon from '@components/icons/ChatBubbleIcon';
+import EyeIcon from '@components/icons/EyeIcon';
+import XMarkIcon from '@components/icons/XMarkIcon';
 
-const ChatBubbleIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-  </svg>
-);
-
-const EyeIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-  </svg>
-);
-
-const XMarkIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-  </svg>
-);
+// Inline SVG icons removed in favor of reusable components
 
 const BrandOrders: React.FC = () => {
   const { user } = useContext(AppContext)!;

--- a/pages/brand/products/new.tsx
+++ b/pages/brand/products/new.tsx
@@ -13,24 +13,11 @@ import { UserRole } from '@/types';
 import { getPageTitle } from '@lib/pageTitle';
 import PageContainer from '@components/Layout/PageContainer';
 
-// Inline SVG icons
-const ArrowLeftIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-  </svg>
-);
+import ArrowLeftIcon from '@components/icons/ArrowLeftIcon';
+import PlusIcon from '@components/icons/PlusIcon';
+import XMarkIcon from '@components/icons/XMarkIcon';
 
-const PlusIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-  </svg>
-);
-
-const XMarkIcon: React.FC<{ className?: string }> = ({ className = "w-5 h-5" }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-  </svg>
-);
+// Inline SVG icons removed in favor of reusable components
 
 const NewProductPage: React.FC = () => {
   const router = useRouter();

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -8,6 +8,8 @@ import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { AppContext } from '@contexts/AppContext';
 import ProductImageSlider from '@components/Product/ProductImageSlider';
 import RecommendedProducts from '@components/Product/RecommendedProducts';
+import HeartIcon from '@components/icons/HeartIcon';
+import StarIcon from '@components/icons/StarIcon';
 import {
   getProductBySlug,
   getReviewsForProduct,
@@ -194,9 +196,7 @@ export default function ProductDetail({
                   }`}
                   aria-label={isInWishlist ? 'Remove from wishlist' : 'Add to wishlist'}
                 >
-                  <svg className={`w-5 h-5 ${isInWishlist ? 'fill-current' : ''}`} viewBox="0 0 24 24">
-                    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-                  </svg>
+                  <HeartIcon className={`w-5 h-5 ${isInWishlist ? 'fill-current' : ''}`} />
                 </button>
               </div>
 
@@ -204,17 +204,12 @@ export default function ProductDetail({
                <div className="flex items-center space-x-2">
                  <div className="flex items-center">
                    {[1, 2, 3, 4, 5].map((star) => (
-                     <svg
+                     <StarIcon
                        key={star}
                        className={`w-5 h-5 ${
-                         star <= averageRating
-                           ? 'text-yellow-400 fill-current'
-                           : 'text-gray-300'
+                         star <= averageRating ? 'text-yellow-400 fill-current' : 'text-gray-300'
                        }`}
-                       viewBox="0 0 24 24"
-                     >
-                       <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-                     </svg>
+                     />
                    ))}
                  </div>
                  <span className="text-sm text-base-content/70">
@@ -390,17 +385,14 @@ export default function ProductDetail({
                     <div className="flex items-center space-x-2">
                                              <div className="flex items-center">
                          {[1, 2, 3, 4, 5].map((star) => (
-                           <svg
+                           <StarIcon
                              key={star}
                              className={`w-4 h-4 ${
                                star <= review.rating
                                  ? 'text-yellow-400 fill-current'
                                  : 'text-gray-300'
                              }`}
-                             viewBox="0 0 24 24"
-                           >
-                             <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-                           </svg>
+                           />
                          ))}
                        </div>
                       <span className="text-sm text-base-content/70">

--- a/pages/signup/brand.tsx
+++ b/pages/signup/brand.tsx
@@ -6,6 +6,7 @@ import { AppContext } from '@contexts/AppContext';
 import { signIn } from 'next-auth/react';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
+import BuildingIcon from '@components/icons/BuildingIcon';
 import GoogleIcon from '@components/icons/GoogleIcon';
 import FacebookIcon from '@components/icons/FacebookIcon';
 import {
@@ -102,9 +103,7 @@ export default function BrandSignup() {
       <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl p-8 sm:p-10 relative z-10">
         <div className="flex flex-col items-center mb-6">
           <div className="w-14 h-14 flex items-center justify-center rounded-full bg-purple-100 mb-3">
-            <svg className="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-            </svg>
+            <BuildingIcon className="w-8 h-8 text-purple-600" />
           </div>
           <h1 className="text-2xl font-bold text-gray-900 mb-1">Create Your Brand Account</h1>
           <p className="text-gray-500 text-center text-base">Sign up to start selling, manage your store, and grow your business.</p>

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,6 +1,10 @@
 import Link from 'next/link';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
+import UserIcon from '@components/icons/UserIcon';
+import BuildingIcon from '@components/icons/BuildingIcon';
+import CheckIcon from '@components/icons/CheckIcon';
+import ChevronRightIcon from '@components/icons/ChevronRightIcon';
 
 export default function Signup() {
   return (
@@ -36,9 +40,7 @@ export default function Signup() {
             >
               <div className="p-8">
                 <div className="flex items-center justify-center w-16 h-16 bg-blue-100 rounded-full mb-6 mx-auto">
-                  <svg className="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                  </svg>
+                  <UserIcon className="w-8 h-8 text-blue-600" />
                 </div>
                 <h3 className="text-2xl font-bold text-gray-900 mb-4 text-center">
                   Customer Account
@@ -48,30 +50,22 @@ export default function Signup() {
                 </p>
                 <div className="space-y-3 mb-6">
                   <div className="flex items-center text-sm text-gray-600">
-                    <svg className="w-4 h-4 text-green-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
+                    <CheckIcon className="w-4 h-4 text-green-500 mr-3" />
                     Browse and purchase products
                   </div>
                   <div className="flex items-center text-sm text-gray-600">
-                    <svg className="w-4 h-4 text-green-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
+                    <CheckIcon className="w-4 h-4 text-green-500 mr-3" />
                     Track orders and manage returns
                   </div>
                   <div className="flex items-center text-sm text-gray-600">
-                    <svg className="w-4 h-4 text-green-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
+                    <CheckIcon className="w-4 h-4 text-green-500 mr-3" />
                     Access exclusive customer deals
                   </div>
                 </div>
                 <div className="text-center">
                   <span className="inline-flex items-center px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors duration-200">
                     Get Started
-                    <svg className="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
+                    <ChevronRightIcon className="w-4 h-4 ml-2" />
                   </span>
                 </div>
               </div>
@@ -87,9 +81,7 @@ export default function Signup() {
             >
               <div className="p-8">
                 <div className="flex items-center justify-center w-16 h-16 bg-purple-100 rounded-full mb-6 mx-auto">
-                  <svg className="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-                  </svg>
+                  <BuildingIcon className="w-8 h-8 text-purple-600" />
                 </div>
                 <h3 className="text-2xl font-bold text-gray-900 mb-4 text-center">
                   Brand Account
@@ -99,30 +91,22 @@ export default function Signup() {
                 </p>
                 <div className="space-y-3 mb-6">
                   <div className="flex items-center text-sm text-gray-600">
-                    <svg className="w-4 h-4 text-green-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
+                    <CheckIcon className="w-4 h-4 text-green-500 mr-3" />
                     List and sell your products
                   </div>
                   <div className="flex items-center text-sm text-gray-600">
-                    <svg className="w-4 h-4 text-green-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
+                    <CheckIcon className="w-4 h-4 text-green-500 mr-3" />
                     Manage orders and inventory
                   </div>
                   <div className="flex items-center text-sm text-gray-600">
-                    <svg className="w-4 h-4 text-green-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
+                    <CheckIcon className="w-4 h-4 text-green-500 mr-3" />
                     Access analytics and insights
                   </div>
                 </div>
                 <div className="text-center">
                   <span className="inline-flex items-center px-4 py-2 bg-purple-600 text-white font-medium rounded-lg hover:bg-purple-700 transition-colors duration-200">
                     Start Selling
-                    <svg className="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
+                    <ChevronRightIcon className="w-4 h-4 ml-2" />
                   </span>
                 </div>
               </div>
@@ -140,9 +124,7 @@ export default function Signup() {
             className="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors duration-200"
           >
             Sign in to your account
-            <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
+            <ChevronRightIcon className="w-4 h-4 ml-1" />
           </Link>
         </div>
       </div>

--- a/pages/signup/user.tsx
+++ b/pages/signup/user.tsx
@@ -6,6 +6,7 @@ import { AppContext } from '@contexts/AppContext';
 import { signIn } from 'next-auth/react';
 import Head from 'next/head';
 import { getPageTitle } from '@lib/pageTitle';
+import UserIcon from '@components/icons/UserIcon';
 import GoogleIcon from '@components/icons/GoogleIcon';
 import FacebookIcon from '@components/icons/FacebookIcon';
 import {
@@ -102,9 +103,7 @@ export default function UserSignup() {
       <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl p-8 sm:p-10 relative z-10">
         <div className="flex flex-col items-center mb-6">
           <div className="w-14 h-14 flex items-center justify-center rounded-full bg-blue-100 mb-3">
-            <svg className="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-            </svg>
+            <UserIcon className="w-8 h-8 text-blue-600" />
           </div>
           <h1 className="text-2xl font-bold text-gray-900 mb-1">Create Your Account</h1>
           <p className="text-gray-500 text-center text-base">Sign up to shop, track orders, and enjoy exclusive benefits.</p>


### PR DESCRIPTION
## Summary
- create reusable icon components under `components/icons`
- replace inline icons in 404, signup pages, brand dashboard/orders, product pages, etc.
- update helpers like `Pagination` and `ActiveFilters` to use icon components

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871f5d3c6e4832f9b65e4aa3b28d2cc