### PR TITLE
Add missing API tests

### DIFF
--- a/__tests__/check-email.api.test.ts
+++ b/__tests__/check-email.api.test.ts
@@ -1,0 +1,59 @@
+import handler from '@pages/api/check-email';
+import { findUser } from '@lib/users';
+import { handleApiError } from '@utils/handleApiError';
+import { EMAIL_REQUIRED } from '@/constants/messages';
+
+jest.mock('@lib/users', () => ({
+  findUser: jest.fn(),
+}));
+
+jest.mock('@utils/handleApiError', () => ({
+  handleApiError: jest.fn(),
+}));
+
+function mockRes() {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  return { status, json } as any;
+}
+
+describe('check-email API', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('requires email query param', async () => {
+    const req = { method: 'GET', query: {} } as any;
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.status.mock.results[0].value.json).toHaveBeenCalledWith({ message: EMAIL_REQUIRED });
+  });
+
+  test('reports existing email', async () => {
+    (findUser as jest.Mock).mockResolvedValue({ id: 1 });
+    const req = { method: 'GET', query: { email: 'test@example.com' } } as any;
+    const res = mockRes();
+    await handler(req, res);
+    expect(findUser).toHaveBeenCalledWith('test@example.com');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.status.mock.results[0].value.json).toHaveBeenCalledWith({ exists: true });
+  });
+
+  test('reports missing email', async () => {
+    (findUser as jest.Mock).mockResolvedValue(null);
+    const req = { method: 'GET', query: { email: 'none@example.com' } } as any;
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.status.mock.results[0].value.json).toHaveBeenCalledWith({ exists: false });
+  });
+
+  test('handles errors', async () => {
+    (findUser as jest.Mock).mockRejectedValue(new Error('fail'));
+    const req = { method: 'GET', query: { email: 'x@test.com' } } as any;
+    const res = mockRes();
+    await handler(req, res);
+    expect(handleApiError).toHaveBeenCalled();
+  });
+});

--- a/__tests__/tags.api.test.ts
+++ b/__tests__/tags.api.test.ts
@@ -1,0 +1,48 @@
+import handler from '@pages/api/tags';
+import { getDistinctTags } from '@lib/products';
+import { handleApiError } from '@utils/handleApiError';
+
+jest.mock('@lib/products', () => ({
+  getDistinctTags: jest.fn(),
+}));
+
+jest.mock('@utils/handleApiError', () => ({
+  handleApiError: jest.fn(),
+}));
+
+function mockRes() {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  return { status, json } as any;
+}
+
+describe('tags API', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns tags list', async () => {
+    (getDistinctTags as jest.Mock).mockResolvedValue(['a', 'b']);
+    const req = { method: 'GET', query: { search: 'a' } } as any;
+    const res = mockRes();
+    await handler(req, res);
+    expect(getDistinctTags).toHaveBeenCalledWith('a');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.status.mock.results[0].value.json).toHaveBeenCalledWith({ tags: ['a', 'b'] });
+  });
+
+  test('rejects non-GET', async () => {
+    const req = { method: 'POST' } as any;
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  test('handles errors', async () => {
+    (getDistinctTags as jest.Mock).mockRejectedValue(new Error('fail'));
+    const req = { method: 'GET', query: {} } as any;
+    const res = mockRes();
+    await handler(req, res);
+    expect(handleApiError).toHaveBeenCalled();
+  });
+});

--- a/__tests__/trending.api.test.ts
+++ b/__tests__/trending.api.test.ts
@@ -1,0 +1,27 @@
+import handler from '@pages/api/trending';
+
+function mockRes() {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  return { status, json } as any;
+}
+
+describe('trending API', () => {
+  test('returns trending keywords', () => {
+    const req = { method: 'GET' } as any;
+    const res = mockRes();
+    handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.status.mock.results[0].value.json).toHaveBeenCalledWith({
+      keywords: expect.any(Array),
+    });
+  });
+
+  test('rejects wrong method', () => {
+    const req = { method: 'POST' } as any;
+    const res = mockRes();
+    handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.status.mock.results[0].value.json).toHaveBeenCalledWith({ keywords: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `/api/check-email`
- add tests for `/api/trending`
- add tests for `/api/tags`

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6871fb7484a8832f853d9f23842aaf69