### PR TITLE
Improve header search input

### DIFF
--- a/components/Layout/SearchBar.tsx
+++ b/components/Layout/SearchBar.tsx
@@ -2,7 +2,7 @@ import { getTrending, getSuggestions } from '@lib/api/search';
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
-import SearchIcon from '../icons/SearchIcon';
+import SearchInput from '../common/SearchInput';
 import type { TrendingResponse, SuggestionsResponse } from '@/types';
 
 interface SearchBarProps {
@@ -144,9 +144,7 @@ const SearchBar: FC<SearchBarProps> = ({
       ref={formRef}
       className={`relative flex-1 max-w-lg transition-all duration-300 focus-within:max-w-xl ${className}`}
     >
-      <input
-        aria-label="Search"
-        className="input input-bordered w-full h-10 text-sm pr-14 rounded-full shadow-sm transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary focus:shadow-lg"
+      <SearchInput
         value={query}
         onChange={(e) => {
           setQuery(e.target.value);
@@ -155,13 +153,14 @@ const SearchBar: FC<SearchBarProps> = ({
         onFocus={() => setShowSuggestions(true)}
         onBlur={() => setTimeout(() => setShowSuggestions(false), 100)}
         onKeyDown={handleKeyDown}
+        onSearch={handleSearch}
         placeholder={placeholder}
       />
       {query && (
         <button
           type="button"
           aria-label="Clear search"
-          className="absolute right-8 top-1/2 -translate-y-1/2 text-gray-500"
+          className="absolute right-10 top-1/2 -translate-y-1/2 text-gray-500"
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => {
             setQuery('');
@@ -172,10 +171,6 @@ const SearchBar: FC<SearchBarProps> = ({
           ×
         </button>
       )}
-      <SearchIcon
-        aria-hidden="true"
-        className="w-5 h-5 absolute right-3 top-1/2 -translate-y-1/2 text-gray-500"
-      />
       {showSuggestions && (
         <div className="absolute left-0 right-0 mt-1 bg-base-100 border border-base-200 shadow rounded z-50">
           {query && suggestions.length > 0 && (

--- a/components/common/SearchInput.tsx
+++ b/components/common/SearchInput.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import SearchIcon from '../icons/SearchIcon';
+
+interface SearchInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  onSearch?: (term: string) => void;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+const SearchInput: React.FC<SearchInputProps> = ({
+  placeholder = 'Search...',
+  onSearch,
+  icon,
+  className = '',
+  value,
+  onChange,
+  ...rest
+}) => {
+  const [internal, setInternal] = useState('');
+  const val = typeof value === 'string' ? value : internal;
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInternal(e.target.value);
+    onChange?.(e);
+  };
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onSearch?.(val);
+    }
+    rest.onKeyDown?.(e);
+  };
+  return (
+    <div className={`relative ${className}`}>
+      <input
+        {...rest}
+        type="text"
+        aria-label="Search"
+        value={val}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        className="w-full sm:w-64 md:w-80 bg-white dark:bg-zinc-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 border border-transparent px-4 py-2 pr-10 rounded-lg focus:ring-2 focus:ring-primary hover:shadow-sm transition-all duration-200"
+      />
+      <button
+        type="button"
+        onClick={() => onSearch?.(val)}
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-400"
+        aria-label="Submit search"
+      >
+        {icon || <SearchIcon className="w-5 h-5" aria-hidden="true" />}
+      </button>
+    </div>
+  );
+};
+
+export default SearchInput;


### PR DESCRIPTION
## Summary
- add new `SearchInput` component with accessible design and dark theme styles
- refactor `SearchBar` to use `SearchInput`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68720bc2c7dc832f9d13f2c48d94930a