### PR TITLE
Fix missing getReviewsForProduct

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -75,11 +75,15 @@ export function getReviewsForEntity(entityType: string, entityId: number): Revie
   return reviewsStore.get(key) || [];
 }
 
+export function getReviewsForProduct(productId: string): Review[] {
+  return getReviewsForEntity('PRODUCT', Number(productId));
+}
+
 export function getAverageRating(productId: string): {
   average: number;
   count: number;
 } {
-  const reviews = reviewsStore.get(productId) || [];
+  const reviews = getReviewsForProduct(productId);
   if (reviews.length === 0) return { average: 0, count: 0 };
   const sum = reviews.reduce((acc, r) => acc + r.rating, 0);
   return { average: sum / reviews.length, count: reviews.length };


### PR DESCRIPTION
## Summary
- add `getReviewsForProduct` helper to `lib/db.ts`
- compute average rating using new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687228edd5c0832fb1d36246a4d2d466