### PR TITLE
Improve filters UI and checkbox styling

### DIFF
--- a/components/ActiveFilters.tsx
+++ b/components/ActiveFilters.tsx
@@ -11,20 +11,20 @@ const ActiveFilters: React.FC<ActiveFiltersProps> = ({ filters, clearAll }) => {
   if (filters.length === 0) return null;
   
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-wrap items-center gap-2 max-w-full">
       {filters.map((f, i) => (
-        <span 
-          key={i} 
-          className="inline-flex items-center gap-2 px-3 py-1.5 bg-primary/10 text-primary border border-primary/20 rounded-full text-sm font-medium hover:bg-primary/20 transition-all duration-200 group"
+        <span
+          key={i}
+          className="inline-flex items-center px-3 py-1 bg-zinc-200 dark:bg-zinc-700 rounded-full text-sm text-zinc-800 dark:text-zinc-100"
         >
           <span>{f.label}</span>
           <button
             type="button"
             onClick={() => f.clear()}
-            className="ml-1 p-0.5 rounded-full hover:bg-primary/20 transition-colors duration-200 group-hover:scale-110"
+            className="ml-2 p-1 rounded-full hover:bg-red-600 hover:text-white transition-colors"
             aria-label={`Remove ${f.label} filter`}
           >
-            <XMarkIcon className="w-3 h-3" fill="currentColor" />
+            <XMarkIcon className="w-3 h-3" />
           </button>
         </span>
       ))}
@@ -32,9 +32,9 @@ const ActiveFilters: React.FC<ActiveFiltersProps> = ({ filters, clearAll }) => {
         <button
           type="button"
           onClick={clearAll}
-          className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-base-content/60 hover:text-base-content border border-base-300 rounded-full hover:bg-base-200 transition-all duration-200"
+          className="ml-2 inline-flex items-center gap-1 px-3 py-1 text-sm text-blue-600 dark:text-blue-400 rounded-full hover:bg-blue-50 dark:hover:bg-zinc-600 transition-colors"
         >
-          <XMarkIcon className="w-3 h-3" fill="currentColor" />
+          <XMarkIcon className="w-3 h-3" />
           Clear All
         </button>
       )}

--- a/components/Product/ProductGrid.tsx
+++ b/components/Product/ProductGrid.tsx
@@ -20,7 +20,7 @@ const ProductGrid: React.FC<ProductGridProps> = ({
 
   return (
     <div
-      className={`min-h-[400px] grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-6 py-6 justify-center ${className}`}
+      className={`min-h-[400px] grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-6 gap-y-6 py-6 justify-center ${className}`}
     >
       {products.length === 0
         ? Array.from({ length: 8 }).map((_, i) => (

--- a/components/form-fields/Checkbox.tsx
+++ b/components/form-fields/Checkbox.tsx
@@ -39,8 +39,8 @@ const Checkbox = <T extends FieldValues>(props: CheckboxProps<T>) => {
   const inputId = rest.id || name;
   const registration = register ? register(name, rules) : {};
   return (
-    <div className="mb-2 last:mb-0 w-full">
-      <div className="flex items-center">
+    <div className={`mb-2 last:mb-0 w-full ${disabled ? 'opacity-60' : ''}`}>
+      <label htmlFor={inputId} className="cursor-pointer flex items-center gap-2">
         <input
           type="checkbox"
           id={inputId}
@@ -50,16 +50,12 @@ const Checkbox = <T extends FieldValues>(props: CheckboxProps<T>) => {
           onBlur={onBlur}
           disabled={disabled}
           required={required}
-          className={`h-4 w-4 mr-2 text-primary border-gray-300 rounded focus:ring-primary dark:border-gray-600 ${className}`}
+          className={`h-4 w-4 rounded border-gray-300 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 dark:focus:ring-green-500 transition checked:bg-blue-600 checked:border-blue-600 dark:checked:bg-green-500 dark:checked:border-green-500 ${className}`}
           {...registration}
           {...rest}
         />
-        {label && (
-          <label htmlFor={inputId} className="text-sm text-base-content">
-            {label}
-          </label>
-        )}
-      </div>
+        {label && <span className="text-sm">{label}</span>}
+      </label>
       {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
     </div>
   );

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -304,7 +304,7 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
         </div>
         <div className="flex flex-col lg:flex-row gap-10 items-start">
           {/* Filters Sidebar */}
-          <aside className="lg:w-80 w-full">
+          <aside className="lg:w-80 w-full mb-6 lg:mb-0">
             <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl p-6 sticky border border-gray-100 dark:border-gray-700 transition-all duration-300">
               <div className="flex items-center justify-between mb-8">
                 <h2 className="text-2xl font-bold text-base-content">Filters</h2>
@@ -337,12 +337,12 @@ const ProductsPage: React.FC<ProductsProps> & { maxWidthClass?: string } = ({
             {/* Results Header */}
             <div className="bg-base-100 rounded-2xl shadow-lg p-6">
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                <div className="flex items-center space-x-4">
+                <div className="flex flex-wrap items-start sm:items-center gap-2 sm:space-x-4">
                   <h2 className="text-2xl font-bold text-base-content">
                     {items.length} Products
                   </h2>
                   {activeFilters.length > 0 && (
-                    <div className="flex items-center space-x-2">
+                    <div className="flex flex-wrap items-center gap-2">
                       <span className="text-sm text-base-content/60">Filtered by:</span>
                       <ActiveFilters filters={activeFilters} clearAll={clearAll} />
                     </div>


### PR DESCRIPTION
## Summary
- polish the active filters chips and spacing
- restyle checkboxes for better light/dark theme support
- add vertical gap to product grid items
- tweak layout spacing in products page

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727f08f000832f981da4710df3af83